### PR TITLE
more aggressively check archives for batch tagging

### DIFF
--- a/lib/LANraragi/Controller/Batch.pm
+++ b/lib/LANraragi/Controller/Batch.pm
@@ -39,7 +39,7 @@ sub index {
                 LANraragi::Utils::Generic::remove_newlines($t);
                 
                 # the following are the only namespaces that LANraragi::Utils::Database::parse_name adds
-                $nondefaulttags += 1 unless $t ~= /(artist|parody|language|event|group):.*/
+                $nondefaulttags += 1 unless $t =~ /(artist|parody|language|event|group):.*/
             }
             
             #If the archive has no tags, or the tags namespaces are only from


### PR DESCRIPTION
check archives if the only tags they have are in the namespaces that LANraragi::Utils::Database::parse_name adds (artist, parody, language, event, group)
closes #94 