### PR TITLE
DateAdded plugin

### DIFF
--- a/lib/LANraragi/Plugin/DateAdded.pm
+++ b/lib/LANraragi/Plugin/DateAdded.pm
@@ -18,9 +18,9 @@ sub plugin_info {
         namespace => "DateAddedPlugin",
         author => "Utazukin",
         version  => "0.1",
-        description => "Adds the date the archive was added as a tag.",
-        oneshot_arg => "Use file modified time.",
-		global_args => ["Use file modified time"]
+        description => "Adds the unix time stamp of the date the archive was added as a tag under the \"date_added\" namespace.",
+        oneshot_arg => "Use file modified time (yes/true), or use current time (no/false). Leaving blank uses the global setting",
+        global_args => ["Use file modified time.\n\"Yes\" or \"True\" means use the modified time.  Anything else means use the current time"]
     );
 
 }
@@ -39,7 +39,11 @@ sub get_tags {
 
     $logger->debug("Processing file: " . $file);
     my $newtags = "";
-    if ($oneshotarg ne "no" && $oneshotarg ne "false" && ($args[0] eq "yes" || $args[0] eq "true" || $oneshotarg eq "yes" || $oneshotarg eq "true")) {
+    my $global_use_file_time = $args[0] =~ /^(yes|true)$/i;
+    my $oneshot_use_file_time = $oneshotarg =~ /^(yes|true)$/i;
+    my $oneshot_use_current_time = $oneshotarg =~ /^(no|false)$/i;
+
+    if ($oneshot_use_file_time || ($global_use_file_time && !$oneshot_use_current_time)) {
 		$logger->info("Using file date");
 		$newtags = "date_added:" . (stat($file))[9]; #9 is the unix time stamp for date modified.
     } else {

--- a/lib/LANraragi/Plugin/DateAdded.pm
+++ b/lib/LANraragi/Plugin/DateAdded.pm
@@ -1,0 +1,53 @@
+package LANraragi::Plugin::DateAdded;
+
+use strict;
+use warnings;
+
+#Plugins can freely use all Perl packages already installed on the system 
+#Try however to restrain yourself to the ones already installed for LRR (see tools/cpanfile) to avoid extra installations by the end-user.
+use Mojo::UserAgent;
+
+use LANraragi::Model::Plugins;
+
+#Meta-information about your plugin.
+sub plugin_info {
+
+    return (
+        #Standard metadata
+        name  => "Date Added",
+        namespace => "DateAddedPlugin",
+        author => "Utazukin",
+        version  => "0.1",
+        description => "Adds the date the archive was added as a tag.",
+        oneshot_arg => "Use file modified time.",
+		global_args => ["Use file modified time"]
+    );
+
+}
+
+#Mandatory function to be implemented by your plugin
+sub get_tags {
+
+    #LRR gives your plugin the recorded title for the file, the filesystem path to the file, and the custom arguments if available.
+    shift;
+    my ($title, $tags, $thumbhash, $file, $oneshotarg, @args) = @_;
+
+    #Use the logger to output status - they'll be passed to a specialized logfile and written to STDOUT.
+    my $logger = LANraragi::Utils::Generic::get_logger("Date Added Plugin","plugins");
+
+    #Work your magic here - You can create subroutines below to organize the code better
+
+    $logger->debug("Processing file: " . $file);
+    my $newtags = "";
+    if ($oneshotarg ne "no" && $oneshotarg ne "false" && ($args[0] eq "yes" || $args[0] eq "true" || $oneshotarg eq "yes" || $oneshotarg eq "true")) {
+		$logger->info("Using file date");
+		$newtags = "date_added:" . (stat($file))[9]; #9 is the unix time stamp for date modified.
+    } else {
+		$logger->info("Using current date");
+		$newtags = "date_added:" . time();
+    }
+    return ( tags => $newtags );
+}
+
+1;
+

--- a/lib/LANraragi/Plugin/DateAdded.pm
+++ b/lib/LANraragi/Plugin/DateAdded.pm
@@ -19,8 +19,9 @@ sub plugin_info {
         author => "Utazukin",
         version  => "0.1",
         description => "Adds the unix time stamp of the date the archive was added as a tag under the \"date_added\" namespace.",
-        oneshot_arg => "Use file modified time (yes/true), or use current time (no/false). Leaving blank uses the global setting",
-        global_args => ["Use file modified time.\n\"Yes\" or \"True\" means use the modified time.  Anything else means use the current time"]
+        oneshot_arg => "Use file modified time (yes/true), or use current time (no/false). Leaving blank uses the global setting (default: current time)",
+        global_args => ["Use file modified time instead of current time.<br/>".
+                        "\"Yes\" or \"True\" means use the modified time.  Anything else means use the current time"]
     );
 
 }


### PR DESCRIPTION
This is a simple plugin that adds a tag with a unix timestamp in the "date_added" namespace.  There is one option to choose between the current system time and the date modified time of the archive file.  This is mostly useful for clients to use to implement things like sorting by date, which I've already added to Ichaival.