### PR TITLE
Improve tag black-list

### DIFF
--- a/lib/LANraragi/Model/Config.pm
+++ b/lib/LANraragi/Model/Config.pm
@@ -101,7 +101,7 @@ sub get_password {
 
 sub get_tagblacklist {
     return &get_redis_conf( "blacklist",
-"already uploaded, forbidden content, translated, russian, chinese, portuguese, french, spanish, italian, vietnamese, german, indonesian"
+"already uploaded, forbidden content, incomplete, ongoing, complete, various, digital, decensored, translated, russian, chinese, portuguese, french, spanish, italian, vietnamese, german, indonesian"
     );
 }
 

--- a/lib/LANraragi/Model/Config.pm
+++ b/lib/LANraragi/Model/Config.pm
@@ -101,7 +101,7 @@ sub get_password {
 
 sub get_tagblacklist {
     return &get_redis_conf( "blacklist",
-"already uploaded, forbidden content, incomplete, ongoing, complete, various, digital, decensored, translated, russian, chinese, portuguese, french, spanish, italian, vietnamese, german, indonesian"
+"already uploaded, forbidden content, incomplete, ongoing, complete, various, digital, translated, russian, chinese, portuguese, french, spanish, italian, vietnamese, german, indonesian"
     );
 }
 


### PR DESCRIPTION
Adds the following to the black-list to help stop LRR's file-tagger from adding invalid tags.
`incomplete`, `ongoing`, `complete`, `various`, `digital`, `decensored`
`decensored` should probably be automatically changed to `uncensored` but I'm not sure how to do that.