### PR TITLE
Update vagrant instructions and fix nightly vagrantfile

### DIFF
--- a/tools/Documentation/README.md
+++ b/tools/Documentation/README.md
@@ -12,3 +12,4 @@ Just getting started? Check out how to install the software:
 
 Or how to use your freshly installed instance:
 
+{% page-ref page="basic-operations/first-steps.md" %}

--- a/tools/Documentation/basic-operations/first-steps.md
+++ b/tools/Documentation/basic-operations/first-steps.md
@@ -23,7 +23,7 @@ When logged in as Admin in LRR, you have access to the full functionalities of t
 There are three basic levels of security you can enable:
 
 | Security Level | Reading Archives | Public API | Editing Metadata | Change Settings |
-| :--- | :--- | :--- | :--- | :--- |
+| :---: | :---: | :---: | :---: | :---: |
 | Password Disabled | ✅ | ✅ | ✅ | ✅ |
 | Password Enabled \(default\) | ✅ | ✅ | ❌ | ❌ |
 | No-Fun Mode | ❌ | ❌ | ❌ | ❌ |

--- a/tools/Documentation/installing-lanraragi/vagrant.md
+++ b/tools/Documentation/installing-lanraragi/vagrant.md
@@ -18,7 +18,7 @@ You can use the available Vagrantfile with [Vagrant](https://www.vagrantup.com/d
 This method requires [VirtualBox](https://www.virtualbox.org/) to be installed on your machine! I recommend version [6.0.4](https://download.virtualbox.org/virtualbox/6.0.4/).
 {% endhint %}
 
-Download [the Vagrantfile setup](https://github.com/Difegue/LANraragi/raw/master/tools/VagrantSetup) and put it in your future LANraragi folder, and enter the following commands in a terminal pointed to that folder:
+Download the vagrantfile that's relevant to the version of LANraragi that you wan't to install. For the main builds grab [this Vagrantfile setup](https://github.com/Difegue/LANraragi/tree/dev/tools/VagrantSetup) if you grab the nightly be sure to remove `_nightly` from the end of the filename. Once you've done that, put it in your future LANraragi folder, and open a terminal in that folder and enter the following commands:
 
 ```text
 vagrant plugin install vagrant-vbguest

--- a/tools/Documentation/installing-lanraragi/vagrant.md
+++ b/tools/Documentation/installing-lanraragi/vagrant.md
@@ -18,7 +18,7 @@ You can use the available Vagrantfile with [Vagrant](https://www.vagrantup.com/d
 This method requires [VirtualBox](https://www.virtualbox.org/) to be installed on your machine! I recommend version [6.0.4](https://download.virtualbox.org/virtualbox/6.0.4/).
 {% endhint %}
 
-Download the vagrantfile that's relevant to the version of LANraragi that you wan't to install. For the main builds grab [this Vagrantfile setup](https://github.com/Difegue/LANraragi/tree/dev/tools/VagrantSetup) if you grab the nightly be sure to remove `_nightly` from the end of the filename. Once you've done that, put it in your future LANraragi folder, and open a terminal in that folder and enter the following commands:
+Download [the Vagrantfile](https://github.com/Difegue/LANraragi/tree/dev/tools/VagrantSetup) that's relevant to the version of LANraragi that you wan't to install then move it to your future LANraragi folder. If you grabbed the nightly vagrantfile be sure to remove `_nightly` from the end of the filename. Once you've done that, open a terminal in that folder and enter the following commands:
 
 ```text
 vagrant plugin install vagrant-vbguest

--- a/tools/Documentation/installing-lanraragi/vagrant.md
+++ b/tools/Documentation/installing-lanraragi/vagrant.md
@@ -18,7 +18,7 @@ You can use the available Vagrantfile with [Vagrant](https://www.vagrantup.com/d
 This method requires [VirtualBox](https://www.virtualbox.org/) to be installed on your machine!
 {% endhint %}
 
-Download the [Vagrantfile](https://github.com/Difegue/LANraragi/tree/dev/tools/VagrantSetup) that's relevant to the version of LANraragi that you wan't to install then move it to your future LANraragi folder. If you downloaded the nightly vagrantfile be sure to remove `_nightly` from the end of the filename. Once you've done that, open a terminal in that folder and enter the following commands:
+Download the [Vagrantfile](https://github.com/Difegue/LANraragi/tree/dev/tools/VagrantSetup) that's relevant to the version of LANraragi that you want to install, then move it to your future LANraragi folder. If you downloaded the nightly Vagrantfile, be sure to remove `_nightly` from the end of the filename. Once you've done that, open a terminal in that folder and enter the following commands:
 
 ```text
 vagrant plugin install vagrant-vbguest

--- a/tools/Documentation/installing-lanraragi/vagrant.md
+++ b/tools/Documentation/installing-lanraragi/vagrant.md
@@ -40,10 +40,6 @@ vagrant provision
 
 Keep in mind that the Vagrant setup, just like Docker, will always use the latest release.
 
-{% hint style="info" %}
-You can switch to nightlies by downloading the Vagrantfile available [here](https://github.com/Difegue/LANraragi/raw/master/tools/VagrantSetup_nightly) and replacing your vanilla Vagrantfile with it.
-{% endhint %}
-
 ### Updating
 
 From the directory where the Vagrantfile is located:

--- a/tools/Documentation/installing-lanraragi/vagrant.md
+++ b/tools/Documentation/installing-lanraragi/vagrant.md
@@ -15,10 +15,10 @@ Vagrant installs are **deprecated** as of 0.6.0. They'll work, but come with eno
 You can use the available Vagrantfile with [Vagrant](https://www.vagrantup.com/downloads.html) to deploy a virtual machine on your computer with LANraragi preinstalled.
 
 {% hint style="info" %}
-This method requires [VirtualBox](https://www.virtualbox.org/) to be installed on your machine! I recommend version [6.0.4](https://download.virtualbox.org/virtualbox/6.0.4/).
+This method requires [VirtualBox](https://www.virtualbox.org/) to be installed on your machine!
 {% endhint %}
 
-Download [the Vagrantfile](https://github.com/Difegue/LANraragi/tree/dev/tools/VagrantSetup) that's relevant to the version of LANraragi that you wan't to install then move it to your future LANraragi folder. If you grabbed the nightly vagrantfile be sure to remove `_nightly` from the end of the filename. Once you've done that, open a terminal in that folder and enter the following commands:
+Download the [Vagrantfile](https://github.com/Difegue/LANraragi/tree/dev/tools/VagrantSetup) that's relevant to the version of LANraragi that you wan't to install then move it to your future LANraragi folder. If you downloaded the nightly vagrantfile be sure to remove `_nightly` from the end of the filename. Once you've done that, open a terminal in that folder and enter the following commands:
 
 ```text
 vagrant plugin install vagrant-vbguest

--- a/tools/VagrantSetup/Vagrantfile_nightly
+++ b/tools/VagrantSetup/Vagrantfile_nightly
@@ -14,7 +14,7 @@ Vagrant.configure(2) do |config|
     inline: "docker stop lanraragi || true && docker rm lanraragi || true"
   config.vm.provision "docker" do |d|
     d.pull_images "difegue/lanraragi:nightly"
-    d.run "difegue/lanraragi:nightly",
+    d.run "difegue/lanraragi:nightly:nightly",
       args: "--name=lanraragi -e LRR_UID=1000 -p 3000:3000 --restart=always --mount type=bind,source=/vagrant,target=/home/koyomi/lanraragi/content "
   end
   config.vm.post_up_message = "LANraragi Vagrant Machine Started, App should be available at http://localhost:3000."

--- a/tools/VagrantSetup/Vagrantfile_nightly
+++ b/tools/VagrantSetup/Vagrantfile_nightly
@@ -13,7 +13,7 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell",
     inline: "docker stop lanraragi || true && docker rm lanraragi || true"
   config.vm.provision "docker" do |d|
-    d.pull_images "difegue/lanraragi:nightly"
+    d.pull_images "difegue/lanraragi"
     d.run "difegue/lanraragi:nightly:nightly",
       args: "--name=lanraragi -e LRR_UID=1000 -p 3000:3000 --restart=always --mount type=bind,source=/vagrant,target=/home/koyomi/lanraragi/content "
   end

--- a/tools/VagrantSetup/Vagrantfile_nightly
+++ b/tools/VagrantSetup/Vagrantfile_nightly
@@ -14,7 +14,7 @@ Vagrant.configure(2) do |config|
     inline: "docker stop lanraragi || true && docker rm lanraragi || true"
   config.vm.provision "docker" do |d|
     d.pull_images "difegue/lanraragi"
-    d.run "difegue/lanraragi:nightly:nightly",
+    d.run "difegue/lanraragi:nightly",
       args: "--name=lanraragi -e LRR_UID=1000 -p 3000:3000 --restart=always --mount type=bind,source=/vagrant,target=/home/koyomi/lanraragi/content "
   end
   config.vm.post_up_message = "LANraragi Vagrant Machine Started, App should be available at http://localhost:3000."


### PR DESCRIPTION
Added link to dev branch for the vagrant file instead which includes a separate nightly vagrant file and edited the documentation to reflect that vbox 6.0.4 is no longer necessary.