### PR TITLE
Detect SSL and use WSS instead of WS for WebSocket

### DIFF
--- a/public/js/batch.js
+++ b/public/js/batch.js
@@ -66,7 +66,9 @@ function startBatch() {
 
     console.log(command);
 
-    var batchSocket = new WebSocket("ws://" + window.location.host + "/batch/socket");
+    var wsProto = "ws://";
+    if (location.protocol == 'https:') wsProto = "wss://";
+    var batchSocket = new WebSocket(wsProto + window.location.host + "/batch/socket");
 
     batchSocket.onopen = function (event) {
         batchSocket.send(JSON.stringify(command));


### PR DESCRIPTION
Browsers block insecure WebSocket requests when connection was established over SSL.

Documentation should also be updated for Nginx example configuration to reflect that /batch/socket needs additional Upgrade header when doing proxy from WSS to insecure WS on backend (when SSL is not enabled in LRR): https://www.nginx.com/blog/websocket-nginx/