### PR TITLE
More robust version check

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -87,17 +87,37 @@ function switch_index_view() {
 
 }
 
-function checkVersion(currentVersion) {
+function checkVersion(currentVersionConf) {
 	//Check the github API to see if an update was released. If so, flash another friendly notification inviting the user to check it out
 	var githubAPI = "https://api.github.com/repos/difegue/lanraragi/releases/latest";
 	var latestVersion;
 
 	$.getJSON(githubAPI).done(function (data) {
-		latestVersion = data.tag_name;
-		if (latestVersion != "v." + currentVersion) {
+		var expr = /(\d+)/g;
+		var latestVersionArr = Array.from(data.tag_name.match(expr));
+		var latestVersion = '';
+		var currentVersionArr = Array.from(currentVersionConf.match(expr));
+		var currentVersion = '';
+
+		latestVersionArr.forEach(function(element, index) {
+			if(index+1 < latestVersionArr.length) {
+				latestVersion = latestVersion + '' + element;
+			} else {
+				latestVersion = latestVersion + '.' + element;
+			}
+		});
+		currentVersionArr.forEach(function(element, index) {
+			if(index+1 < currentVersionArr.length) {
+				currentVersion = currentVersion + '' + element;
+			} else {
+				currentVersion = currentVersion + '.' + element;
+			}
+		});
+
+		if (latestVersion > currentVersion) {
 
 			$.toast({
-				heading: 'A new version of LANraragi (' + latestVersion + ') is available !',
+				heading: 'A new version of LANraragi (' + data.tag_name + ') is available !',
 				text: '<a href="' + data.html_url + '">Click here to check it out.</a>',
 				hideAfter: false,
 				position: 'top-left',


### PR DESCRIPTION
Actually checks if current version on GitHub has higher release number than currently running one instead of simple != check.