### PR TITLE
Don't search for expunged galleries on EHentai

### DIFF
--- a/lib/LANraragi/Plugin/EHentai.pm
+++ b/lib/LANraragi/Plugin/EHentai.pm
@@ -179,7 +179,7 @@ sub lookup_gallery {
         #search with image SHA hash
         $URL = $domain
           . "?advsearch=1&f_sname=on&f_stags=on&f_sdt2=on&f_sh=on&f_spf=&f_spt=&f_sfu=on&f_sft=on&f_sfl=on&f_shash=". $thumbhash
-          . "&fs_covers=1&fs_similar=1&fs_exp=1&f_search=";
+          . "&fs_covers=1&fs_similar=1&f_search=";
 
         #Add the language override, if it's defined.
         if ( $defaultlanguage ne "" ) {


### PR DESCRIPTION
Don't search for expunged galleries on EHentai - this proves to be too error-prone, producing too many matches against expunged galleries when non-expunged version exists (due to 'already uploaded').