### PR TITLE
Properly handle stacking favorites filter and search bar term

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -59,10 +59,13 @@ function favTagSearch() {
 
 	//Perform search in datatables field with our own regexes enabled and smart search off
 	if (searchQuery !== ")") {
-		arcTable.search(searchQuery, true, false).draw();
+		arcTable.column('.tags.itd').search(searchQuery, true, false);
+		arcTable.search($('#srch').val().replace(",", ""), false, true);
+		arcTable.draw();
 	} else {
-		//clear
-		arcTable.search("", false, true).draw();
+		// no fav filters
+		arcTable.column('.tags.itd').search("", false, true);
+		arcTable.search($('#srch').val().replace(",", ""), false, true).draw();
 	}
 
 }
@@ -187,7 +190,7 @@ function loadTagSuggestions() {
 
 			// Perform a search when a tag is selected
 			Awesomplete.$('#srch').addEventListener("awesomplete-selectcomplete", function() {
-				arcTable.search($('#srch').val().replace(",", "")).draw();
+				favTagSearch();
 			});
 
 		}).fail(function (data) {

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -19,7 +19,7 @@ function toggleFav(button) {
 		button.classList.remove("toggled");
 
 	//Trigger search
-	favTagSearch();
+	performSearch();
 }
 
 function toggleInbox(button) {
@@ -40,9 +40,9 @@ function toggleInbox(button) {
 	$('#clrsrch').click();
 }
 
-// Triggered when a favTag checkbox is modified, 
 // looks at all checked favTags and builds an OR regex to jam in DataTables
-function favTagSearch() {
+// and then ANDs result with standard smart DataTables search
+function performSearch() {
 
 	favTags = $(".favtag");
 	searchQuery = "("
@@ -190,7 +190,7 @@ function loadTagSuggestions() {
 
 			// Perform a search when a tag is selected
 			Awesomplete.$('#srch').addEventListener("awesomplete-selectcomplete", function() {
-				favTagSearch();
+				performSearch();
 			});
 
 		}).fail(function (data) {

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -187,7 +187,7 @@ function loadTagSuggestions() {
 
 			// Perform a search when a tag is selected
 			Awesomplete.$('#srch').addEventListener("awesomplete-selectcomplete", function() {
-				arcTable.search($('#srch').val()).draw();
+				arcTable.search($('#srch').val().replace(",", "")).draw();
 			});
 
 		}).fail(function (data) {

--- a/public/js/index_datatables.js
+++ b/public/js/index_datatables.js
@@ -56,7 +56,7 @@ function initIndex(pagesize, dataSet) {
 
 	//add datatable search event to the local searchbox and clear search to the clear filter button
 	$('#srch').keyup(function () {
-		favTagSearch();
+		performSearch();
 	});
 
 	$('#clrsrch').click(function () {
@@ -67,7 +67,7 @@ function initIndex(pagesize, dataSet) {
 		}
 		$('#srch').val('');
 
-		favTagSearch();
+		performSearch();
 	});
 
 	//clear searchbar cache

--- a/public/js/index_datatables.js
+++ b/public/js/index_datatables.js
@@ -56,7 +56,7 @@ function initIndex(pagesize, dataSet) {
 
 	//add datatable search event to the local searchbox and clear search to the clear filter button
 	$('#srch').keyup(function () {
-		arcTable.search($(this).val()).draw();
+		arcTable.search($(this).val().replace(",", "")).draw();
 	});
 
 	$('#clrsrch').click(function () {

--- a/public/js/index_datatables.js
+++ b/public/js/index_datatables.js
@@ -56,7 +56,7 @@ function initIndex(pagesize, dataSet) {
 
 	//add datatable search event to the local searchbox and clear search to the clear filter button
 	$('#srch').keyup(function () {
-		arcTable.search($(this).val().replace(",", "")).draw();
+		favTagSearch();
 	});
 
 	$('#clrsrch').click(function () {
@@ -65,9 +65,9 @@ function initIndex(pagesize, dataSet) {
 			$(".favtag")[i].checked = false;
 			$(".favtag-btn")[i].classList.remove("toggled");
 		}
-
-		arcTable.search('').draw();
 		$('#srch').val('');
+
+		favTagSearch();
 	});
 
 	//clear searchbar cache


### PR DESCRIPTION
Autocomplete adds and requires tags to be comma separated however in case where haystack is "female:sole female, already uploaded" and needle (search term) is "already uploaded, " it will fail (the same haystack will work fine with needle "female:sole female,"). As such, add simple ```.replace(",","")``` to search bar event listener to silently ignore comma when passing needle to datatables.

---

Properly handle stacking favorites filter and search bar term. This is done by moving search logic completely to ```favTagSearch``` and using it to stack two search terms in datatables by first applying regex search on favorites OR on tags column, and then applying smart search filter on table itself. This allows us to take benefit of the fact that .search() is subtractive in datatables.