### PR TITLE
Missed f_sh term for advanced search when removing expunged search from EHentai

### DIFF
--- a/lib/LANraragi/Plugin/EHentai.pm
+++ b/lib/LANraragi/Plugin/EHentai.pm
@@ -178,7 +178,7 @@ sub lookup_gallery {
 
         #search with image SHA hash
         $URL = $domain
-          . "?advsearch=1&f_sname=on&f_stags=on&f_sdt2=on&f_sh=on&f_spf=&f_spt=&f_sfu=on&f_sft=on&f_sfl=on&f_shash=". $thumbhash
+          . "?advsearch=1&f_sname=on&f_stags=on&f_sdt2=on&f_spf=&f_spt=&f_sfu=on&f_sft=on&f_sfl=on&f_shash=". $thumbhash
           . "&fs_covers=1&fs_similar=1&f_search=";
 
         #Add the language override, if it's defined.
@@ -198,7 +198,7 @@ sub lookup_gallery {
     #Regular text search
     $URL =
         $domain
-      . "?advsearch=1&f_sname=on&f_stags=on&f_sdt2=on&f_sh=on&f_spf=&f_spt=&f_sfu=on&f_sft=on&f_sfl=on"
+      . "?advsearch=1&f_sname=on&f_stags=on&f_sdt2=on&f_spf=&f_spt=&f_sfu=on&f_sft=on&f_sfl=on"
       . "&f_search=" . uri_escape_utf8(qw(").$title.qw("));
 
     #Add the language override, if it's defined.


### PR DESCRIPTION
f_exp is for file search and f_sh is for advanced search. Either of them work for file (thumb hash) search so previous PR was ineffective.