### PR TITLE
Perform search on button click, not on keyup

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -188,11 +188,6 @@ function loadTagSuggestions() {
 				}
 			});
 
-			// Perform a search when a tag is selected
-			Awesomplete.$('#srch').addEventListener("awesomplete-selectcomplete", function() {
-				performSearch();
-			});
-
 		}).fail(function (data) {
 			$.toast({
 				showHideTransition: 'slide',

--- a/public/js/index_datatables.js
+++ b/public/js/index_datatables.js
@@ -63,6 +63,14 @@ function initIndex(pagesize) {
 	$('#subsrch').click(function () {
 		performSearch();
 	});
+	$('#subsrch').keyup(function (e) {
+		if(e.defaultPrevented) {
+			return;
+		} else if(e.key == "Enter") {
+			performSearch();
+		}
+		e.preventDefault();
+	});
 
 	$('#clrsrch').click(function () {
 		//clear all favtags

--- a/public/js/index_datatables.js
+++ b/public/js/index_datatables.js
@@ -60,7 +60,7 @@ function initIndex(pagesize) {
 	});
 
 	//add datatable search event to the local searchbox and clear search to the clear filter button
-	$('#srch').keyup(function () {
+	$('#subsrch').click(function () {
 		performSearch();
 	});
 

--- a/public/themes/ex.css
+++ b/public/themes/ex.css
@@ -110,7 +110,7 @@ tr.gtr0{background:#4f535b}
 tr.gtr1{background:#363940}
 
 /* input */
-.stdbtn{font-size:8pt;color:#f1f1f1;background:#34353b;border:2px solid #000000;height:21px;margin:4px 1px 0px 1px;padding:0px 4px 1px 4px; min-width: 100px; cursor: pointer;}
+.stdbtn{font-size:8pt;color:#f1f1f1;background:#34353b;border:2px solid #000000;height:21px;margin:4px 1px 0px 1px;padding:0px 4px 1px 4px; min-width: 150px; cursor: pointer;}
 .stdbtn:hover{color:#f1f1f1;background:#43464e;border:2px solid #000000}
 .stdbtn:focus{color:#f1f1f1;background:#43464e}
 
@@ -118,6 +118,8 @@ tr.gtr1{background:#363940}
 .stdinput:hover{color:#f1f1f1;background:#43464e}
 .stdinput:focus{color:#f1f1f1;background:#43464e}
 .stdinput:disabled{color:#f1f1f1;background:#34353b}
+
+.searchbtn{min-width: 100px !important;}
 
 /* gallery row */
 td.itd{text-align:left;padding:3px 4px;border-right:1px solid #40454b}

--- a/public/themes/ex.css
+++ b/public/themes/ex.css
@@ -110,7 +110,7 @@ tr.gtr0{background:#4f535b}
 tr.gtr1{background:#363940}
 
 /* input */
-.stdbtn{font-size:8pt;color:#f1f1f1;background:#34353b;border:2px solid #000000;height:21px;margin:4px 1px 0px 1px;padding:0px 4px 1px 4px; min-width: 150px; cursor: pointer;}
+.stdbtn{font-size:8pt;color:#f1f1f1;background:#34353b;border:2px solid #000000;height:21px;margin:4px 1px 0px 1px;padding:0px 4px 1px 4px; min-width: 100px; cursor: pointer;}
 .stdbtn:hover{color:#f1f1f1;background:#43464e;border:2px solid #000000}
 .stdbtn:focus{color:#f1f1f1;background:#43464e}
 

--- a/public/themes/g.css
+++ b/public/themes/g.css
@@ -163,7 +163,7 @@ tr.gtr1 {
     height: 21px;
     margin: 4px 1px 0;
     padding: 0 4px 1px;
-    min-width: 150px;
+    min-width: 100px;
     cursor: pointer;
 }
 .stdbtn:hover {

--- a/public/themes/g.css
+++ b/public/themes/g.css
@@ -163,7 +163,7 @@ tr.gtr1 {
     height: 21px;
     margin: 4px 1px 0;
     padding: 0 4px 1px;
-    min-width: 100px;
+    min-width: 150px;
     cursor: pointer;
 }
 .stdbtn:hover {
@@ -192,6 +192,9 @@ tr.gtr1 {
 .stdinput:focus {
     background: none repeat scroll 0 0 #F2EFDF;
     color: #9B4E03;
+}
+.searchbtn {
+    min-width: 100px !important;
 }
 td.itd {
     border-right: 1px solid #D9D7CC;

--- a/public/themes/modern.css
+++ b/public/themes/modern.css
@@ -173,7 +173,7 @@ tr.gtr1{background:#363940}
     margin: 1px;
     outline: 0 none;
     padding: 0 4px 1px;
-    min-width: 100px;
+    min-width: 150px;
     cursor: pointer;
 }
 .stdbtn:hover{background-color: #43464E}
@@ -189,6 +189,9 @@ tr.gtr1{background:#363940}
     max-width: 450px;
 
     width: 80%;
+}
+.searchbtn {
+    min-width: 100px !important;
 }
 
 /* gallery row */

--- a/public/themes/modern.css
+++ b/public/themes/modern.css
@@ -173,7 +173,7 @@ tr.gtr1{background:#363940}
     margin: 1px;
     outline: 0 none;
     padding: 0 4px 1px;
-    min-width: 150px;
+    min-width: 100px;
     cursor: pointer;
 }
 .stdbtn:hover{background-color: #43464E}

--- a/public/themes/modern_clear.css
+++ b/public/themes/modern_clear.css
@@ -199,7 +199,7 @@ tr.gtr1{background:#34495E}
     margin: 1px;
     outline: 0 none;
     padding: 0 4px 1px;
-    min-width: 150px;
+    min-width: 100px;
     cursor: pointer;
 }
 

--- a/public/themes/modern_clear.css
+++ b/public/themes/modern_clear.css
@@ -199,7 +199,7 @@ tr.gtr1{background:#34495E}
     margin: 1px;
     outline: 0 none;
     padding: 0 4px 1px;
-    min-width: 100px;
+    min-width: 150px;
     cursor: pointer;
 }
 
@@ -224,6 +224,10 @@ tr.gtr1{background:#34495E}
     padding: 2px 3px;
     max-width: 450px;
     width:80%;
+}
+
+.searchbtn {
+    min-width: 100px !important;
 }
 
 /* gallery row */

--- a/public/themes/modern_red.css
+++ b/public/themes/modern_red.css
@@ -215,7 +215,7 @@ tr.gtr1 {
     font-size: 9pt;
     height: 28px;
     margin: 1px;
-    min-width: 150px;
+    min-width: 100px;
     outline: 0 none;
     padding: 0 4px 1px;
 }

--- a/public/themes/modern_red.css
+++ b/public/themes/modern_red.css
@@ -215,7 +215,7 @@ tr.gtr1 {
     font-size: 9pt;
     height: 28px;
     margin: 1px;
-    min-width: 100px;
+    min-width: 150px;
     outline: 0 none;
     padding: 0 4px 1px;
 }
@@ -233,6 +233,9 @@ tr.gtr1 {
     max-width: 450px;
     padding: 2px 3px;
     width: 80%;
+}
+.searchbtn {
+    min-width: 100px !important;
 }
 td.itd {
     border-right: 2px dotted #414135;

--- a/templates/index.html.tt2
+++ b/templates/index.html.tt2
@@ -82,8 +82,8 @@
 
 				<input type='text' id='srch' class='search stdinput' size='90' style='width:100%' 
 					placeholder='Search Title, Artist, Series, Language or Tags' />
-        <input id='subsrch' class='stdbtn' type='button' value='Apply Filter' />
-				<input id='clrsrch' class='stdbtn' type='button' value='Clear Filter' />
+        <input id='subsrch' class='searchbtn stdbtn' type='button' value='Apply Filter' />
+				<input id='clrsrch' class='searchbtn stdbtn' type='button' value='Clear Filter' />
 			</div>
 
 			<p id='cssbutton' style='display:inline'>

--- a/templates/index.html.tt2
+++ b/templates/index.html.tt2
@@ -82,6 +82,7 @@
 
 				<input type='text' id='srch' class='search stdinput' size='90' style='width:100%' 
 					placeholder='Search Title, Artist, Series, Language or Tags' />
+        <input id='subsrch' class='stdbtn' type='button' value='Apply Filter' />
 				<input id='clrsrch' class='stdbtn' type='button' value='Clear Filter' />
 			</div>
 


### PR DESCRIPTION
Adds 'Apply Filter' button, similar to EH that performs search. This stops search from being executed on every key press in search bar and also disables automatic search when new value is selected from Awesomplete (for now at least, since it doesn't properly handle "" for tags with whitespaces yet). Additionally this decreases min-width on .stdbtn to 100px as 150px buttons are too big with search bar.