### PR TITLE
Overflow text on batch tagging checklist

### DIFF
--- a/public/css/lrr.css
+++ b/public/css/lrr.css
@@ -261,9 +261,16 @@ a:hover > .page-number {
     overflow: auto;
     list-style: none outside none;
     text-align: left;
-    margin-left: -20px;
+    margin-left: -30px;
     margin-right: 5px;
     font-size: 9pt;
+}
+
+.checklist > li {
+    text-align: left;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
 }
 
 .isnew {


### PR DESCRIPTION
Have archive title overflow be hidden and apply ellipsis.

Additionally increase margin-left on checklist from -20 to -30 to fill more space with archive title.