### PR TITLE
Do not use sudo when installing with perlbrew.

### DIFF
--- a/tools/Documentation/installing-lanraragi/source.md
+++ b/tools/Documentation/installing-lanraragi/source.md
@@ -39,6 +39,8 @@ git clone -b master http://github.com/Difegue/LANraragi /home/koyomi/lanraragi
 cd /home/koyomi/lanraragi && sudo npm run lanraragi-installer install-full
 ```
 
+Note: Do not use `sudo` in the above command if you are using `perlbrew`.
+
 Once this is done, you can get started by running `npm start` and opening [http://localhost:3000](http://localhost:3000).
 
 To change the default port or add SSL support, see this page:


### PR DESCRIPTION
A new PR from [pullrequest.club](https://pullrequest.club): Mention in the docs that when installing with `perlbrew` from source code, you should not run the `lanraragi-installer` with `sudo` as `sudo` will  modify the environment variables such that the installer will switch to the vendor `perl` (system `perl`) instead.