### PR TITLE
(#274-4.1) Add code to handle plugin types

### DIFF
--- a/lib/LANraragi/Controller/Plugins.pm
+++ b/lib/LANraragi/Controller/Plugins.pm
@@ -155,16 +155,15 @@ sub process_upload {
         if ($filetext =~ /package LANraragi::Plugin::(Login|Metadata|Scripts)::/) {
             $plugintype = $1;
         } else {
-            $logger->error("Could not find a valid plugin package type in the plugin "
-              . "\"$filename\"!");
+            my $errormess= "Could not find a valid plugin package type in the plugin \"$filename\"!";
+            $logger->error($errormess);
 
             $self->render(
                 json => {
                     operation => "upload_plugin",
                     name      => $file->filename,
                     success   => 0,
-                    error     => "Could not find a valid plugin package type in the "
-                      . "plugin \"$filename\"!"
+                    error     => $errormess
                 }
             );
 


### PR DESCRIPTION
Now the "upload plugin" functionality should work again. The coding style in `Plugins.pm` is inconsistent but I tried to stay consistent.