### PR TITLE
(#274-4.10) Fix tiny batch tagging checkboxes

### DIFF
--- a/public/css/lrr.css
+++ b/public/css/lrr.css
@@ -307,6 +307,10 @@ a:hover > .page-number {
   width: 60%;
 }
 
+.tag-options .stdinput {
+  width: auto !important;
+}
+
 .if a {
   margin-right: 10px;
 }


### PR DESCRIPTION
I set the `width` of the checkboxes below "override plugin global arguments" to `auto` to use the default size and stay consistent with every other checkbox. This will be override the 21px by 21px big checkboxes set by some LANraragi themes, which only apply to the E-Hentai plugin on this page.