### PR TITLE
fix s6 uid/gid dropping

### DIFF
--- a/tools/build/docker/s6/cont-init.d/01-lrr-setup
+++ b/tools/build/docker/s6/cont-init.d/01-lrr-setup
@@ -42,8 +42,6 @@ chmod 744 /home/koyomi/lanraragi/public/temp
 rm /home/koyomi/lanraragi/script/hypnotoad.pid
 rm /home/koyomi/lanraragi/.shinobu-pid
 
-export HOME=/home/koyomi
-
 # https://redis.io/topics/faq#background-saving-fails-with-a-fork-error-under-linux-even-if-i-have-a-lot-of-free-ram
 OVERCOMMIT=$(cat /proc/sys/vm/overcommit_memory)
 if [ $OVERCOMMIT -eq 0 ]

--- a/tools/build/docker/s6/services.d/lanraragi/run
+++ b/tools/build/docker/s6/services.d/lanraragi/run
@@ -1,4 +1,4 @@
 #!/bin/sh
 cd /home/koyomi/lanraragi/
 export HOME=/home/koyomi
-s6-setuidgid $(id -u koyomi):$(id -g koyomi) perl /home/koyomi/lanraragi/script/launcher.pl -f /home/koyomi/lanraragi/script/lanraragi
+s6-setuidgid koyomi perl /home/koyomi/lanraragi/script/launcher.pl -f /home/koyomi/lanraragi/script/lanraragi

--- a/tools/build/docker/s6/services.d/lanraragi/run
+++ b/tools/build/docker/s6/services.d/lanraragi/run
@@ -1,4 +1,4 @@
-#!/usr/bin/execlineb -P
-s6-envuidgid -B koyomi:koyomi
+#!/bin/sh
 cd /home/koyomi/lanraragi/
-perl /home/koyomi/lanraragi/script/launcher.pl -f /home/koyomi/lanraragi/script/lanraragi
+export HOME=/home/koyomi
+s6-setuidgid $(id -u koyomi):$(id -g koyomi) perl /home/koyomi/lanraragi/script/launcher.pl -f /home/koyomi/lanraragi/script/lanraragi

--- a/tools/build/docker/s6/services.d/redis/run
+++ b/tools/build/docker/s6/services.d/redis/run
@@ -1,2 +1,2 @@
 #!/bin/sh
-s6-setuidgid $(id -u koyomi):$(id -g koyomi) /usr/bin/redis-server /home/koyomi/lanraragi/tools/build/docker/redis.conf
+s6-setuidgid koyomi /usr/bin/redis-server /home/koyomi/lanraragi/tools/build/docker/redis.conf

--- a/tools/build/docker/s6/services.d/redis/run
+++ b/tools/build/docker/s6/services.d/redis/run
@@ -1,3 +1,2 @@
-#!/usr/bin/execlineb -P
-s6-envuidgid -B koyomi:koyomi
-/usr/bin/redis-server /home/koyomi/lanraragi/tools/build/docker/redis.conf
+#!/bin/sh
+s6-setuidgid $(id -u koyomi):$(id -g koyomi) /usr/bin/redis-server /home/koyomi/lanraragi/tools/build/docker/redis.conf


### PR DESCRIPTION
We're using `#!/bin/sh` now because we need shell features like `export` and command substitution. For some reason, s6-envuidgid can take a colon separated user/group pair, but [s6-setuidgid can't](https://skarnet.org/software/s6/s6-setuidgid.html) (though it can take colon separated uid/gids, or just the username, for some reason). An alternative might be to use the LRR_UID/GID envvars directly, but I think it's better to continue using the koyomi mapping after it's been set once in `cont-init.d`.