### PR TITLE
Only change file permissions for the owner in Docker init

### DIFF
--- a/tools/build/docker/s6/cont-init.d/01-lrr-setup
+++ b/tools/build/docker/s6/cont-init.d/01-lrr-setup
@@ -12,7 +12,7 @@ groupmod -g $GROUP_ID koyomi
 
 #Ensure LRR folder is writable
 chown koyomi /home/koyomi/lanraragi
-chmod 744 /home/koyomi/lanraragi
+chmod u+rwx /home/koyomi/lanraragi
 
 #Crash with an error if content folder doesn't exist
 if [ ! -d "/home/koyomi/lanraragi/content" ]; then
@@ -26,17 +26,17 @@ chmod -R 777 /home/koyomi/lanraragi/database
 
 #Ensure thumbnail folder is writable
 chown -R koyomi /home/koyomi/lanraragi/content/thumb
-chmod -R 744 /home/koyomi/lanraragi/content/thumb
+chmod -R u+rwx /home/koyomi/lanraragi/content/thumb
 
 #Ensure log folder is writable
 mkdir /home/koyomi/lanraragi/log
 chown -R koyomi /home/koyomi/lanraragi/log
-chmod 744 /home/koyomi/lanraragi/log
+chmod u+rwx /home/koyomi/lanraragi/log
 
 #Ensure temp folder is writable
 mkdir /home/koyomi/lanraragi/public/temp
 chown -R koyomi /home/koyomi/lanraragi/public/temp
-chmod 744 /home/koyomi/lanraragi/public/temp
+chmod u+rwx /home/koyomi/lanraragi/public/temp
 
 #Remove hypnotoad, minion and shinobu pid files
 rm /home/koyomi/lanraragi/script/hypnotoad.pid

--- a/tools/build/docker/s6/cont-init.d/01-lrr-setup
+++ b/tools/build/docker/s6/cont-init.d/01-lrr-setup
@@ -26,7 +26,8 @@ chmod -R 777 /home/koyomi/lanraragi/database
 
 #Ensure thumbnail folder is writable
 chown -R koyomi /home/koyomi/lanraragi/content/thumb
-chmod -R u+rwx /home/koyomi/lanraragi/content/thumb
+find /home/koyomi/lanraragi/content/thumb -type f -exec chmod u+rw  {} \;
+find /home/koyomi/lanraragi/content/thumb -type d -exec chmod u+rwx {} \;
 
 #Ensure log folder is writable
 mkdir /home/koyomi/lanraragi/log


### PR DESCRIPTION
LRR keeps removing perms from my group on its bind mount and it's p'in me the f o. We only chown a user, so don't try and force permissions for stuff we're not interested in.