### PR TITLE
Allow non-unique id to LRR_UID/GID

### DIFF
--- a/tools/build/docker/s6/cont-init.d/01-lrr-setup
+++ b/tools/build/docker/s6/cont-init.d/01-lrr-setup
@@ -7,8 +7,8 @@ echo "Starting LANraragi with UID/GID : $USER_ID/$GROUP_ID"
 
 #Update the koyomi user, using the specified uid/gid.
 #This solves permission problems on the content folder if the Docker user sets the same uid as the owner of the folder.
-usermod -u $USER_ID koyomi
-groupmod -g $GROUP_ID koyomi
+usermod -o -u $USER_ID koyomi
+groupmod -o -g $GROUP_ID koyomi
 
 #Ensure LRR folder is writable
 chown koyomi /home/koyomi/lanraragi


### PR DESCRIPTION
This is necessary when you want to
- run as root (LRR_UID/GID=0)
- run as the same uid as the host when using a rootless container