### PR TITLE
Hide overflow tags

### DIFF
--- a/public/themes/ex.css
+++ b/public/themes/ex.css
@@ -26,9 +26,11 @@ div.gt {
     padding: 1px 4px;
     position: relative;
     white-space: nowrap;
-    width: default;
     cursor: pointer;
     line-height: 17px;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 div.gt:hover {

--- a/public/themes/g.css
+++ b/public/themes/g.css
@@ -61,8 +61,10 @@ div.gt {
     padding: 1px 4px;
     position: relative;
     white-space: nowrap;
-    width: default;
     cursor: pointer;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 div.gt:hover {

--- a/public/themes/modern.css
+++ b/public/themes/modern.css
@@ -94,9 +94,11 @@ div.gt {
   padding: 1px 4px 4px 4px;
   position: relative;
   white-space: nowrap;
-  width: default;
   cursor: pointer;
   line-height: 17px;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 div.gt:hover {

--- a/public/themes/modern_clear.css
+++ b/public/themes/modern_clear.css
@@ -73,10 +73,12 @@ div.gt {
     padding: 1px 4px;
     position: relative;
     white-space: nowrap;
-    width: default;
     color: #E1E7E9;
     cursor: pointer;
     line-height: 17px;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 div.gt:hover {

--- a/public/themes/modern_red.css
+++ b/public/themes/modern_red.css
@@ -84,9 +84,11 @@ div.gt {
   padding: 1px 4px;
   position: relative;
   white-space: nowrap;
-  width: default;
   color: #EFEAEA;
   cursor: pointer;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 div.gt:hover {


### PR DESCRIPTION
Long tags in the tooltip are not displayed nicely.
This PR adds `text-overflow` to the tag tooltip so it looks nicer (I think)
![20-12-11_225001](https://user-images.githubusercontent.com/28638872/101915913-98bfa200-3c09-11eb-9f98-1fbedfbb8849.jpg)
