### PR TITLE
Refactor reader.js

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,16 +12,22 @@
         "sourceType": "module"
     },
     "rules": {
+        "func-names": ["error", "never"],
         "indent": ["error", 4],
         "quotes": ["error", "double"],
-        "func-names": ["error", "never"],
+        "no-alert": "off",
+        "no-else-return": "off",
         "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
+        "no-multi-assign": ["error", { "ignoreNonDeclaration": true }],
         "no-unused-expressions": [
             "error",
             {
                 "allowShortCircuit": true,
                 "allowTernary": true
             }
-        ]
+        ],
+        "one-var": "off",
+        "one-var-declaration-per-line": ["error", "initializations"],
+        "prefer-destructuring": ["error", {"object": true, "array": false}]
     }
 }

--- a/public/css/lrr.css
+++ b/public/css/lrr.css
@@ -505,3 +505,8 @@ li {
     margin-top: 0 !important;
   }
 }
+
+.page_dropdown a {
+   padding-right: 10px;
+   text-decoration: none;
+}

--- a/public/css/lrr.css
+++ b/public/css/lrr.css
@@ -188,6 +188,7 @@ p#nb {
   left: 5%;
   width: 90% !important;
   overflow-y: scroll;
+  max-height: 90vh;
 }
 
 .small-overlay {
@@ -217,9 +218,10 @@ p#nb {
   left: 30%;
   z-index: -1;
   padding: 5px;
+  color: lightskyblue;
 }
 
-a:hover > .page-number {
+.quick-thumbnail:hover > .page-number {
   z-index: 300;
   background-color: #000000;
 }
@@ -506,9 +508,15 @@ li {
   }
 }
 
+.page_dropdown {
+  position: absolute;
+  right: 20px;
+  z-index: 20;
+}
+
 .page_dropdown a {
-   padding-right: 10px;
-   text-decoration: none;
+  padding-right: 10px;
+  text-decoration: none;
 }
 
 .pagecount {
@@ -517,4 +525,44 @@ li {
 
 .page-link {
   cursor: pointer;
+}
+
+#archivePagesOverlay {
+  height: 90vh;
+}
+
+#settingsOverlay {
+  height: unset;
+}
+
+/* Infinite Scrolling Reader */
+
+body.infinite-scroll .sn,
+body.infinite-scroll .file-info,
+body.infinite-scroll #toggle-manga-mode,
+body.infinite-scroll #toggle-double-mode {
+  display: none;
+}
+
+body.infinite-scroll #i2 .page_dropdown {
+  position: fixed;
+  top: 20px;
+}
+
+body.infinite-scroll #i4 {
+  display: none;
+}
+
+body.infinite-scroll #display {
+  display: flex;
+  flex-direction: column;
+}
+
+body.infinite-scroll #display img {
+  margin: 5px auto;
+  cursor: pointer;
+}
+
+body.infinite-scroll .sb {
+  margin-top: 10px;
 }

--- a/public/css/lrr.css
+++ b/public/css/lrr.css
@@ -135,11 +135,6 @@ p#nb {
   min-width: 30% !important;
 }
 
-/* Reader page */ 
-div.sni {
-  max-width: 1200px;
-}
-
 /* Reader overlays. */
 .loading-overlay,
 .page-overlay,

--- a/public/css/lrr.css
+++ b/public/css/lrr.css
@@ -510,3 +510,11 @@ li {
    padding-right: 10px;
    text-decoration: none;
 }
+
+.pagecount {
+  vertical-align: unset !important;
+}
+
+.page-link {
+  cursor: pointer;
+}

--- a/public/css/lrr.css
+++ b/public/css/lrr.css
@@ -539,6 +539,7 @@ li {
 
 body.infinite-scroll .sn,
 body.infinite-scroll .file-info,
+body.infinite-scroll .reading-direction,
 body.infinite-scroll #toggle-manga-mode,
 body.infinite-scroll #toggle-double-mode {
   display: none;

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -16,7 +16,7 @@ Reader.initializeAll = function () {
 
     $(document).on("click.toggle_fit_mode", "#fit-mode input", Reader.toggleFitMode);
     $(document).on("click.toggle_double_mode", "#toggle-double-mode input", Reader.toggleDoublePageMode);
-    $(document).on("click.toggle_manga_mode", "#toggle-manga-mode input", Reader.toggleMangaMode);
+    $(document).on("click.toggle_manga_mode", "#toggle-manga-mode input, .reading-direction", Reader.toggleMangaMode);
     $(document).on("click.toggle_header", "#toggle-header input", Reader.toggleHeader);
     $(document).on("click.toggle_progress", "#toggle-progress input", Reader.toggleProgressTracking);
     $(document).on("click.toggle_infinite_scroll", "#toggle-infinite-scroll input", Reader.toggleInfiniteScroll);
@@ -102,7 +102,12 @@ Reader.initializeSettings = function () {
     }
 
     Reader.mangaMode = localStorage.mangaMode === "true" || localStorage.righttoleft === "true" || false;
-    Reader.mangaMode ? $("#manga-mode").addClass("toggled") : $("#normal-mode").addClass("toggled");
+    if (Reader.mangaMode) {
+        $("#manga-mode").addClass("toggled");
+        $(".reading-direction").toggleClass("fa-arrow-left fa-arrow-right");
+    } else {
+        $("#normal-mode").addClass("toggled");
+    }
 
     Reader.doublePageMode = localStorage.doublePageMode === "true" || localStorage.doublepage === "true" || false;
     Reader.doublePageMode ? $("#double-page").addClass("toggled") : $("#single-page").addClass("toggled");
@@ -425,6 +430,7 @@ Reader.toggleMangaMode = function () {
     if (Reader.infiniteScroll) { return false; }
     Reader.mangaMode = localStorage.mangaMode = !Reader.mangaMode;
     $("#toggle-manga-mode input").toggleClass("toggled");
+    $(".reading-direction").toggleClass("fa-arrow-left fa-arrow-right");
     if (!Reader.showingSinglePage) { Reader.goToPage(Reader.currentPage); }
 
     return false;

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -1,408 +1,408 @@
-//functions to navigate in reader with the keyboard.
-//also handles the thumbnail archive explorer.
+// functions to navigate in reader with the keyboard.
+// also handles the thumbnail archive explorer.
 
 function moveSomething(e) {
     if (e.target.tagName === "INPUT") {
         return;
     }
-	switch (e.keyCode) {
-		case 8:   // backspace
-			returnToIndex();
-			break;
-		case 37:  // left arrow
-		case 65:  // a
-			advancePage(-1);
-			break;
-		case 39:  // right arrow
-		case 68:  // d
-			advancePage(1);
-			break;
-		case 32:  // spacebar
-			if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight) {
-(localStorage.readorder === 'true') ? advancePage(-1) : advancePage(1);			
-			}
-			break;
-		case 81:  // q
-			openOverlay();
-			break;
-	}
+    switch (e.keyCode) {
+    case 8: // backspace
+        returnToIndex();
+        break;
+    case 37: // left arrow
+    case 65: // a
+        advancePage(-1);
+        break;
+    case 39: // right arrow
+    case 68: // d
+        advancePage(1);
+        break;
+    case 32: // spacebar
+        if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight) {
+            (localStorage.readorder === "true") ? advancePage(-1) : advancePage(1);
+        }
+        break;
+    case 81: // q
+        openOverlay();
+        break;
+    }
 }
 
 document.addEventListener("keyup", moveSomething, false);
 
 function toastHelpReader() {
-	$.toast().reset('all');
+    $.toast().reset("all");
 
-	$.toast({
-		heading: 'Navigation Help',
-		text: `
-			You can navigate between pages using:
-			<ul>
-				<li>The arrow icons</li>
-				<li>The a/d keys</li>
-				<li>Your keyboard arrows (and the spacebar)</li>
-				<li>Touching the left/right side of the image.</li>
-			</ul>
-			<br>To return to the archive index, touch the arrow pointing down or use Backspace.
-			<br>Pressing the q key will bring up the thumbnail index and archive options.
-		`,
-		hideAfter: false,
-		position: 'top-left',
-		icon: 'info'
-	});
+    $.toast({
+        heading: "Navigation Help",
+        text: `
+            You can navigate between pages using:
+            <ul>
+                <li>The arrow icons</li>
+                <li>The a/d keys</li>
+                <li>Your keyboard arrows (and the spacebar)</li>
+                <li>Touching the left/right side of the image.</li>
+            </ul>
+            <br>To return to the archive index, touch the arrow pointing down or use Backspace.
+            <br>Pressing the q key will bring up the thumbnail index and archive options.
+        `,
+        hideAfter: false,
+        position: "top-left",
+        icon: "info"
+    });
 }
 
 function updateMetadata() {
 
-	//remove overlay
-	loaded = true;
-	$("#i3").removeClass("loading");
+    // remove overlay
+    loaded = true;
+    $("#i3").removeClass("loading");
 
-	filename = $("#img").get(0).src.replace(/^.*[\\\/]/, '');
-	w = $("#img").get(0).naturalWidth;
-	h = $("#img").get(0).naturalHeight;
-	size = "UNKNOWN"
+    filename = $("#img").get(0).src.replace(/^.*[\\\/]/, "");
+    w = $("#img").get(0).naturalWidth;
+    h = $("#img").get(0).naturalHeight;
+    size = "UNKNOWN"
 
-	if (showingSinglePage) {
+    if (showingSinglePage) {
 
-		//HEAD request to get filesize
-		xhr = $.ajax({
-			url: pages.pages[currentPage],
-			type: 'HEAD',
-			success: function () {
-				size = parseInt(xhr.getResponseHeader('Content-Length') / 1024, 10);
-			}
-		}).done(function (data) {
+        // HEAD request to get filesize
+        xhr = $.ajax({
+            url: pages.pages[currentPage],
+            type: "HEAD",
+            success: function () {
+                size = parseInt(xhr.getResponseHeader("Content-Length") / 1024, 10);
+            }
+        }).done(function (data) {
 
-			metadataString = filename + " :: " + w + " x " + h + " :: " + size + " KB";
+            metadataString = filename + " :: " + w + " x " + h + " :: " + size + " KB";
 
-			$('.file-info').each(function () {
-				$(this).html(metadataString);
-			});
+            $(".file-info").each(function () {
+                $(this).html(metadataString);
+            });
 
-			updateImageMap();
-		});
+            updateImageMap();
+        });
 
-	} else {
+    } else {
 
-		metadataString = "Double-Page View :: " + w + " x " + h;
+        metadataString = "Double-Page View :: " + w + " x " + h;
 
-		$('.file-info').each(function () {
-			$(this).html(metadataString);
-		});
+        $(".file-info").each(function () {
+            $(this).html(metadataString);
+        });
 
-		updateImageMap();
+        updateImageMap();
 
-	}
+    }
 
 }
 
 function updateImageMap() {
 
-	//update imagemap with the w/h parameters we obtained
-	mapWidth = $("#img").get(0).width / 2;
-	mapHeight = $("#img").get(0).height;
-	$("#leftmap").attr("coords", "0,0," + mapWidth + "," + mapHeight);
-	$("#rightmap").attr("coords", (mapWidth + 1) + ",0," + $("#img").get(0).width + "," + mapHeight);
+    // update imagemap with the w/h parameters we obtained
+    mapWidth = $("#img").get(0).width / 2;
+    mapHeight = $("#img").get(0).height;
+    $("#leftmap").attr("coords", "0,0," + mapWidth + "," + mapHeight);
+    $("#rightmap").attr("coords", (mapWidth + 1) + ",0," + $("#img").get(0).width + "," + mapHeight);
 }
 
 function goToPage(page) {
 
-	previousPage = currentPage;
+    previousPage = currentPage;
 
-	// Clear out style overrides
-	$("#img").attr("style", "");
-	$(".sni").attr("style", "");
+    // Clear out style overrides
+    $("#img").attr("style", "");
+    $(".sni").attr("style", "");
 
-	if (page < 0)
-		currentPage = 0;
-	else if (page >= pageNumber)
-		currentPage = pageNumber - 1;
-	else currentPage = page;
+    if (page < 0)
+        currentPage = 0;
+    else if (page >= pageNumber)
+        currentPage = pageNumber - 1;
+    else currentPage = page;
 
-	if (localStorage.containerwidth !== "" && !isNaN(localStorage.containerwidth)) {
-		$(".sni").attr("style", `max-width: ${localStorage.containerwidth}px`);
-	}
+    if (localStorage.containerwidth !== "" && !isNaN(localStorage.containerwidth)) {
+        $(".sni").attr("style", `max-width: ${localStorage.containerwidth}px`);
+    }
 
-	//if double-page view is enabled(and the current page isn't the first or the last)
-	if (localStorage.doublepage === 'true' && currentPage > 0 && currentPage < pageNumber - 1) {
-		//composite an image and use that as the source
-		img1 = loadImage(pages.pages[currentPage], canvasCallback);
-		img2 = loadImage(pages.pages[currentPage + 1], canvasCallback);
+    // if double-page view is enabled(and the current page isn"t the first or the last)
+    if (localStorage.doublepage === "true" && currentPage > 0 && currentPage < pageNumber - 1) {
+        // composite an image and use that as the source
+        img1 = loadImage(pages.pages[currentPage], canvasCallback);
+        img2 = loadImage(pages.pages[currentPage + 1], canvasCallback);
 
-		//We can also override the 1200px maxwidth since we usually have twice the pages
-		if (localStorage.containerwidth === "" || isNaN(localStorage.containerwidth))
-			$(".sni").attr("style", "max-width: 90%");
+        // We can also override the 1200px maxwidth since we usually have twice the pages
+        if (localStorage.containerwidth === "" || isNaN(localStorage.containerwidth))
+            $(".sni").attr("style", "max-width: 90%");
 
-		// Preload next two images
-		loadImage(pages.pages[currentPage + 2], null);
-		loadImage(pages.pages[currentPage + 3], null);
-	}
-	else {
-		// In single view, just use the source URLs as is
-		$("#img").attr("src", pages.pages[currentPage]);
-		showingSinglePage = true;
+        // Preload next two images
+        loadImage(pages.pages[currentPage + 2], null);
+        loadImage(pages.pages[currentPage + 3], null);
+    }
+    else {
+        // In single view, just use the source URLs as is
+        $("#img").attr("src", pages.pages[currentPage]);
+        showingSinglePage = true;
 
-		// Preload next image
-		loadImage(pages.pages[currentPage + 1], null);
-	}
+        // Preload next image
+        loadImage(pages.pages[currentPage + 1], null);
+    }
 
-	//Fit to screen simply forces image height at 90vh (90% of viewport height)
-	if (localStorage.scaletoview === 'true')
-		$("#img").attr("style", "max-height: 90vh;");
+    // Fit to screen simply forces image height at 90vh (90% of viewport height)
+    if (localStorage.scaletoview === "true")
+        $("#img").attr("style", "max-height: 90vh;");
 
-	//hide/show toplevel nav depending on the pref
-	if (localStorage.hidetop === 'true') {
-		$("#i2").attr("style", "display:none");
-		$("div.sni h1").attr("style", "display:none");
+    // hide/show toplevel nav depending on the pref
+    if (localStorage.hidetop === "true") {
+        $("#i2").attr("style", "display:none");
+        $("div.sni h1").attr("style", "display:none");
 
-		//Since the topnav is gone, we can afford to make the image a bit bigger.
-		if (localStorage.scaletoview === 'true')
-			$("#img").attr("style", "max-height: 98vh;");
-	}
-	else {
-		$("#i2").attr("style", "");
-		$("div.sni h1").attr("style", "");
-	}
+        // Since the topnav is gone, we can afford to make the image a bit bigger.
+        if (localStorage.scaletoview === "true")
+            $("#img").attr("style", "max-height: 98vh;");
+    }
+    else {
+        $("#i2").attr("style", "");
+        $("div.sni h1").attr("style", "");
+    }
 
-	// Force full width discards fit to screen and just forces img width to 100%
-	if (localStorage.forcefullwidth === 'true') {
-		$("#img").attr("style", "width: 100%;");
-		$(".sni").attr("style", "max-width: 98%");
-	}
+    // Force full width discards fit to screen and just forces img width to 100%
+    if (localStorage.forcefullwidth === "true") {
+        $("#img").attr("style", "width: 100%;");
+        $(".sni").attr("style", "max-width: 98%");
+    }
 
-	//update numbers
-	$('.current-page').each(function () {
-		$(this).html(parseInt(currentPage) + 1);
-	});
+    // update numbers
+    $(".current-page").each(function () {
+        $(this).html(parseInt(currentPage) + 1);
+    });
 
-	$('.max-page').each(function () {
-		$(this).html(pageNumber);
-	});
+    $(".max-page").each(function () {
+        $(this).html(pageNumber);
+    });
 
-	loaded = false;
+    loaded = false;
 
-	//display overlay if it takes too long to load a page
-	setTimeout(function () {
-		if (!loaded)
-			$("#i3").addClass("loading");
-	}, 500);
+    // display overlay if it takes too long to load a page
+    setTimeout(function () {
+        if (!loaded)
+            $("#i3").addClass("loading");
+    }, 500);
 
-	//update full image link
-	$("#imgLink").attr("href", pages.pages[currentPage]);
+    // update full image link
+    $("#imgLink").attr("href", pages.pages[currentPage]);
 
-	// Send an API request to update progress on the server
-	genericAPICall(`api/archives/${id}/progress/${currentPage + 1}`, "PUT", null, "Error updating reading progress!", null);
+    // Send an API request to update progress on the server
+    genericAPICall(`api/archives/${id}/progress/${currentPage + 1}`, "PUT", null, "Error updating reading progress!", null);
 
-	//scroll to top
-	window.scrollTo(0, 0);
+    // scroll to top
+    window.scrollTo(0, 0);
 
-	// Update url to contain all search parameters, and push it to the history 
-	if (isComingFromPopstate) // But don't fire this if we're coming from popstate 
-		isComingFromPopstate = false;
-	else {
-		window.history.pushState(null, null, `?id=${id}&p=${page + 1}`);
-	}
+    // Update url to contain all search parameters, and push it to the history
+    if (isComingFromPopstate) // But don"t fire this if we"re coming from popstate
+        isComingFromPopstate = false;
+    else {
+        window.history.pushState(null, null, `?id=${id}&p=${page + 1}`);
+    }
 }
 
 function initArchivePageOverlay() {
 
-	$("#tagContainer").append(buildTagsDiv(tags));
+    $("#tagContainer").append(buildTagsDiv(tags));
 
-	//For each link in the pages array, craft a div and jam it in the overlay.
-	for (index = 0; index < pages.pages.length; ++index) {
+    // For each link in the pages array, craft a div and jam it in the overlay.
+    for (index = 0; index < pages.pages.length; ++index) {
 
-		thumb_css = (localStorage.cropthumbs === 'true') ? "id3" : "id3 nocrop";
-		thumbnail = `<div class='${thumb_css}' style='display: inline-block; cursor: pointer'>` +
-			`<a onclick='goToPage(${index}); closeOverlay()'>` +
-			`<span class='page-number'>Page ${(index + 1)}</span>` +
-			`<img src='${pages.pages[index]}' /></a></div>`;
+        thumb_css = (localStorage.cropthumbs === "true") ? "id3" : "id3 nocrop";
+        thumbnail = `<div class="${thumb_css}" style="display: inline-block; cursor: pointer">` +
+            `<a onclick="goToPage(${index}); closeOverlay()">` +
+            `<span class="page-number">Page ${(index + 1)}</span>` +
+            `<img src="${pages.pages[index]}" /></a></div>`;
 
-		$("#archivePagesOverlay").append(thumbnail);
-	}
-	$("#archivePagesOverlay").attr("loaded", "true");
+        $("#archivePagesOverlay").append(thumbnail);
+    }
+    $("#archivePagesOverlay").attr("loaded", "true");
 }
 
 function applySettings() {
 
-	$(".favtag-btn").removeClass("toggled");
-	$("#containersetting").hide();
+    $(".favtag-btn").removeClass("toggled");
+    $("#containersetting").hide();
 
-	if (!isNaN(localStorage.containerwidth))
-		$("#containerwidth").val(localStorage.containerwidth);
+    if (!isNaN(localStorage.containerwidth))
+        $("#containerwidth").val(localStorage.containerwidth);
 
-	if (localStorage.readorder === 'true')
-		$("#mangaread").addClass("toggled");
-	else
-		$("#normalread").addClass("toggled");
+    if (localStorage.readorder === "true")
+        $("#mangaread").addClass("toggled");
+    else
+        $("#normalread").addClass("toggled");
 
-	if (localStorage.doublepage === 'true')
-		$("#doublepage").addClass("toggled");
-	else
-		$("#singlepage").addClass("toggled");
+    if (localStorage.doublepage === "true")
+        $("#doublepage").addClass("toggled");
+    else
+        $("#singlepage").addClass("toggled");
 
-	if (localStorage.forcefullwidth === 'true')
-		$("#fitwidth").addClass("toggled");
-	else if (localStorage.scaletoview === 'true')
-		$("#fitheight").addClass("toggled");
-	else {
-		$("#fitcontainer").addClass("toggled");
-		$("#containersetting").show();
-	}
+    if (localStorage.forcefullwidth === "true")
+        $("#fitwidth").addClass("toggled");
+    else if (localStorage.scaletoview === "true")
+        $("#fitheight").addClass("toggled");
+    else {
+        $("#fitcontainer").addClass("toggled");
+        $("#containersetting").show();
+    }
 
-	if (localStorage.hidetop === 'true')
-		$("#hidetop").addClass("toggled");
-	else
-		$("#showtop").addClass("toggled");
+    if (localStorage.hidetop === "true")
+        $("#hidetop").addClass("toggled");
+    else
+        $("#showtop").addClass("toggled");
 
-	if (localStorage.nobookmark === 'true')
-		$("#nobookmark").addClass("toggled");
-	else
-		$("#dobookmark").addClass("toggled");
+    if (localStorage.nobookmark === "true")
+        $("#nobookmark").addClass("toggled");
+    else
+        $("#dobookmark").addClass("toggled");
 
-	// Reset reader
-	goToPage(currentPage);
+    // Reset reader
+    goToPage(currentPage);
 }
 
 function setDisplayMode(fittowidth, fittoheight) {
-	localStorage.forcefullwidth = fittowidth;
-	localStorage.scaletoview = fittoheight;
-	applySettings();
+    localStorage.forcefullwidth = fittowidth;
+    localStorage.scaletoview = fittoheight;
+    applySettings();
 }
 
 function setDoublePage(doublepage) {
-	localStorage.doublepage = doublepage;
-	applySettings();
+    localStorage.doublepage = doublepage;
+    applySettings();
 }
 
 function setRTL(righttoleft) {
-	localStorage.readorder = righttoleft;
-	applySettings();
+    localStorage.readorder = righttoleft;
+    applySettings();
 }
 
 function setHideHeader(hideheader) {
-	localStorage.hidetop = hideheader;
-	applySettings();
+    localStorage.hidetop = hideheader;
+    applySettings();
 }
 
 function setTracking(disablebookmark) {
-	localStorage.nobookmark = disablebookmark;
-	applySettings();
+    localStorage.nobookmark = disablebookmark;
+    applySettings();
 }
 
 function applyContainerWidth() {
-	input = $("#containerwidth").val().trim();
+    input = $("#containerwidth").val().trim();
 
-	if (!isNaN(input))
-		localStorage.containerwidth = input;
-	else
-		localStorage.removeItem("containerwidth");
+    if (!isNaN(input))
+        localStorage.containerwidth = input;
+    else
+        localStorage.removeItem("containerwidth");
 
-	applySettings();
+    applySettings();
 }
 
 function openOverlay() {
-	if ($("#archivePagesOverlay").attr("loaded") === "false")
-		initArchivePageOverlay();
+    if ($("#archivePagesOverlay").attr("loaded") === "false")
+        initArchivePageOverlay();
 
-	$('#overlay-shade').fadeTo(150, 0.6, function () {
-		$('#archivePagesOverlay').css('display', 'block');
-	});
+    $("#overlay-shade").fadeTo(150, 0.6, function () {
+        $("#archivePagesOverlay").css("display", "block");
+    });
 }
 
 function confirmThumbnailReset(id) {
 
-	if (confirm("Are you sure you want to regenerate the thumbnail for this archive?")) {
+    if (confirm("Are you sure you want to regenerate the thumbnail for this archive?")) {
 
-		$.get("./reader?id=" + id + "&reload_thumbnail=1").done(function () {
-			$.toast({
-				showHideTransition: 'slide',
-				position: 'top-left',
-				loader: false,
-				heading: 'Thumbnail Regenerated.',
-				icon: 'success'
-			});
-		});
-	}
+        $.get("./reader?id=" + id + "&reload_thumbnail=1").done(function () {
+            $.toast({
+                showHideTransition: "slide",
+                position: "top-left",
+                loader: false,
+                heading: "Thumbnail Regenerated.",
+                icon: "success"
+            });
+        });
+    }
 }
 
 function canvasCallback() {
-	imagesLoaded += 1;
+    imagesLoaded += 1;
 
-	if (imagesLoaded == 2) {
+    if (imagesLoaded == 2) {
 
-		//If w > h on one of the images(widespread), set canvasdata to the first image only
-		if (img1.naturalWidth > img1.naturalHeight || img2.naturalWidth > img2.naturalHeight) {
+        // If w > h on one of the images(widespread), set canvasdata to the first image only
+        if (img1.naturalWidth > img1.naturalHeight || img2.naturalWidth > img2.naturalHeight) {
 
-			//Depending on whether we were going forward or backward, display img1 or img2
-			if (previousPage > currentPage)
-				$("#img").attr("src", img2.src);
-			else
-				$("#img").attr("src", img1.src);
+            // Depending on whether we were going forward or backward, display img1 or img2
+            if (previousPage > currentPage)
+                $("#img").attr("src", img2.src);
+            else
+                $("#img").attr("src", img1.src);
 
-			showingSinglePage = true;
-			imagesLoaded = 0;
-			return;
-		}
+            showingSinglePage = true;
+            imagesLoaded = 0;
+            return;
+        }
 
-		//Double page confirmed
-		showingSinglePage = false;
+        // Double page confirmed
+        showingSinglePage = false;
 
-		//Create an adequately-sized canvas
-		var canvas = $("#dpcanvas")[0];
-		canvas.width = img1.naturalWidth + img2.naturalWidth;
-		canvas.height = Math.max(img1.naturalHeight, img2.naturalHeight);
+        // Create an adequately-sized canvas
+        var canvas = $("#dpcanvas")[0];
+        canvas.width = img1.naturalWidth + img2.naturalWidth;
+        canvas.height = Math.max(img1.naturalHeight, img2.naturalHeight);
 
-		//Draw both images on it
-		ctx = canvas.getContext("2d");
-		if (localStorage.readorder === 'true') {
-			ctx.drawImage(img2, 0, 0);
-			ctx.drawImage(img1, img2.naturalWidth + 1, 0);
-		} else {
-			ctx.drawImage(img1, 0, 0);
-			ctx.drawImage(img2, img1.naturalWidth + 1, 0);
-		}
+        // Draw both images on it
+        ctx = canvas.getContext("2d");
+        if (localStorage.readorder === "true") {
+            ctx.drawImage(img2, 0, 0);
+            ctx.drawImage(img1, img2.naturalWidth + 1, 0);
+        } else {
+            ctx.drawImage(img1, 0, 0);
+            ctx.drawImage(img2, img1.naturalWidth + 1, 0);
+        }
 
-		imagesLoaded = 0;
-		$("#img").attr("src", canvas.toDataURL('image/jpeg'));
+        imagesLoaded = 0;
+        $("#img").attr("src", canvas.toDataURL("image/jpeg"));
 
-	}
+    }
 }
 
 function loadImage(src, onload) {
-	var img = new Image();
+    var img = new Image();
 
-	img.onload = onload;
-	img.src = src;
+    img.onload = onload;
+    img.src = src;
 
-	return img;
+    return img;
 }
 
 // Go forward or backward in pages. Pass -1 for left, +1 for right.
 function advancePage(pageModifier) {
-	if (localStorage.doublepage === 'true' && showingSinglePage == false)
-		pageModifier = pageModifier * 2;
+    if (localStorage.doublepage === "true" && showingSinglePage == false)
+        pageModifier = pageModifier * 2;
 
-	if (localStorage.readorder === 'true')
-		pageModifier = -pageModifier;
+    if (localStorage.readorder === "true")
+        pageModifier = -pageModifier;
 
-	goToPage(currentPage + pageModifier);
+    goToPage(currentPage + pageModifier);
 }
 
 function goFirst() {
-	if (localStorage.readorder === 'true')
-		goToPage(pageNumber - 1);
-	else
-		goToPage(0);
+    if (localStorage.readorder === "true")
+        goToPage(pageNumber - 1);
+    else
+        goToPage(0);
 }
 
 function goLast() {
-	if (localStorage.readorder === 'true')
-		goToPage(0);
-	else
-		goToPage(pageNumber - 1);
+    if (localStorage.readorder === "true")
+        goToPage(0);
+    else
+        goToPage(pageNumber - 1);
 }
 
 function returnToIndex() {
-	document.location.href = "/";
+    document.location.href = "/";
 }

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -12,6 +12,7 @@ Reader.initializeAll = function () {
 
     // bind events to DOM
     $(window).on("resize", Reader.updateImageMap);
+    $(document).on("load.style", "body", set_style_from_storage);
     $(document).on("keyup", Reader.handleShortcuts);
 
     $(document).on("click.toggle_fit_mode", "#fit-mode input", Reader.toggleFitMode);
@@ -24,10 +25,16 @@ Reader.initializeAll = function () {
     $(document).on("click.pagination_change_pages", ".page-link", Reader.handlePaginator);
     $(document).on("click.imagemap_change_pages", "#Map area", Reader.handlePaginator);
 
+    $(document).on("click.close_overlay", "#overlay-shade", closeOverlay);
     $(document).on("click.toggle_archive_overlay", "#toggle-archive-overlay", Reader.toggleArchiveOverlay);
     $(document).on("click.toggle_settings_overlay", "#toggle-settings-overlay", Reader.toggleSettingsOverlay);
     $(document).on("click.toggle_help", "#toggle-help", Reader.toggleHelp);
     $(document).on("click.regenerate_thumbnail", "#regenerate-thumbnail", Reader.regenerateThumbnail);
+    $(document).on("click.regenerate_archive_cache", "#regenerate-cache", () => {
+        window.location.href = `./reader?id=${Reader.id}&force_reload=1`;
+    });
+    $(document).on("click.edit_metadata", "#edit-archive", () => openInNewTab(`./edit?id=${Reader.id}`));
+    $(document).on("click.add_category", "#add-category", () => addArchiveToCategory(Reader.id, $("#category").val()));
 
     // check and display warnings for unsupported filetypes
     Reader.checkFiletypeSupport();
@@ -119,7 +126,9 @@ Reader.handleShortcuts = function (e) {
         break;
     case 32: // spacebar
         if ($(".page-overlay").is(":visible")) { break; }
-        if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight) {
+        if (e.originalEvent.getModifierState("Shift") && (window.scrollY) === 0) {
+            (Reader.mangaMode) ? Reader.changePage(1) : Reader.changePage(-1);
+        } else if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight) {
             (Reader.mangaMode) ? Reader.changePage(-1) : Reader.changePage(1);
         }
         // spacebar is always forward regardless of reading direction, so it needs to be flipped

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -200,6 +200,9 @@ Reader.handleShortcuts = function (e) {
     case 81: // q
         Reader.toggleArchiveOverlay();
         break;
+    case 82: // r
+        document.location.href = "/random";
+        break;
     default:
         break;
     }
@@ -253,9 +256,10 @@ Reader.toggleHelp = function () {
             <br>Other keyboard shortcuts:
             <ul>
                 <li>M: toggle manga mode (right-to-left reading)</li>
-                <li>P: toggle double page mode</li>
                 <li>O: show advanced reader options.</li>
+                <li>P: toggle double page mode</li>
                 <li>Q: bring up the thumbnail index and archive options.</li>
+                <li>R: open a random archive.</li>
             </ul>
             <br>To return to the archive index, touch the arrow pointing down or use Backspace.
         </div>

--- a/templates/reader.html.tt2
+++ b/templates/reader.html.tt2
@@ -214,6 +214,7 @@
 <!-- -->
 [% BLOCK pagesel %]
 <div class="page_dropdown">
+    <a class="fa fa-arrow-right fa-2x reading-direction" href="#" title="Reading Direction"></a>
     <a class="fa fa-th fa-2x" id="toggle-archive-overlay" href="#" title="Archive Overview"></a>
     <a class="fa fa-cog fa-2x" id="toggle-settings-overlay" href="#" title="Reader Settings"></a>
     <a class="fa fa-info-circle fa-2x" id="toggle-help" href="#" title="Help"></a>

--- a/templates/reader.html.tt2
+++ b/templates/reader.html.tt2
@@ -75,36 +75,10 @@
     <script>
 
         let isComingFromPopstate = false;
-        const pages = [% imgpaths %];
-        const id = "[%id%]";
-        let filename = "[% filename %]";
-        const tags = "[% tags %]";
-
-        if ((filename.endsWith(".rar") || filename.endsWith(".cbr")) && !localStorage.rarWarningShown) {
-            localStorage.rarWarningShown = true;
-            $.toast({
-                showHideTransition: 'slide',
-                position: 'top-left',
-                loader: false,
-                heading: "This archive seems to be in RAR format!",
-                text: 'RAR archives might not work properly in LANraragi depending on how they were made. If you encounter errors while reading, consider converting your archive to zip.',
-                hideAfter: false,
-                icon: 'warning'
-            });
-        }
-
-        if (filename.endsWith(".epub") && !localStorage.epubWarningShown) {
-            localStorage.epubWarningShown = true;
-            $.toast({
-                showHideTransition: 'slide',
-                position: 'top-left',
-                loader: false,
-                heading: "EPUB support in LANraragi is minimal",
-                text: 'EPUB books will only show images in the Web Reader. If you want text support, consider pairing LANraragi with an <a href= "https://sugoi.gitbook.io/lanraragi/advanced-usage/external-readers#generic-opds-readers">OPDS reader.</a> ',
-                hideAfter: false,
-                icon: 'warning'
-            });
-        }
+        Reader.pages = [% imgpaths %].pages;
+        Reader.id = "[%id%]";
+        Reader.filename = "[% filename %]";
+        Reader.tags = "[% tags %]";
 
         // Go straight to page number if there's an existing progress value
         if (localStorage.nobookmark === 'true')
@@ -112,17 +86,12 @@
         else
             currentPage = parseInt([% progress %] - 1 || 0);
 
-        pageNumber = [% pagecount %];
-
         //canvas variables
-        previousPage = -1;
-        imagesLoaded = 0;
         img1 = "";
         img2 = "";
-        showingSinglePage = false;
 
         //if we made it to the last page in a previous read, reset the page number
-        if (currentPage === pageNumber - 1)
+        if (currentPage === Reader.maxPage)
             currentPage = 0;
 
         var params = new URLSearchParams(window.location.search);
@@ -131,24 +100,6 @@
             goToPage(params.get("p") - 1);
         else
             goToPage(currentPage);
-
-        // Remove new flag with an API call
-        clearNew(id);
-
-        //image map update on window resize
-        $(window).resize(function () {
-            updateImageMap();
-        });
-
-        // Add a listen event to window.popstate to update the page accordingly if the user goes back using browser history
-        window.onpopstate = () => {
-            var params = new URLSearchParams(window.location.search);
-            if (params.has("p")) {
-                isComingFromPopstate = true;
-                goToPage(params.get("p") - 1);
-            }
-        }
-
     </script>
 
     <div id="overlay-shade" onclick="closeOverlay();"></div>
@@ -280,7 +231,7 @@
 
     <div class="pagecount">
         <span class="current-page"></span> /
-        <span class="max-page"></span>
+        <span class="max-page">[% pagecount %]</span>
     </div>
 
     <a id="right" onclick="advancePage(1)" style="cursor:pointer;">

--- a/templates/reader.html.tt2
+++ b/templates/reader.html.tt2
@@ -24,12 +24,12 @@
 
 </head>
 
-<body onload="set_style_from_storage(); applySettings();">
+<body onload="set_style_from_storage();">
 
     <div id="i1" class="sni">
-        <h1>[% arcname %]</h1>
-
         <div id="i2">
+            <h1 id="archive-title">[% arcname %]</h1>
+
             [% INCLUDE pagesel %] [% INCLUDE arrows %] [% INCLUDE fileinfo %]
         </div>
 
@@ -79,27 +79,9 @@
         Reader.id = "[%id%]";
         Reader.filename = "[% filename %]";
         Reader.tags = "[% tags %]";
-
-        // Go straight to page number if there's an existing progress value
-        if (localStorage.nobookmark === 'true')
-            currentPage = 0;
-        else
-            currentPage = parseInt([% progress %] - 1 || 0);
-
-        //canvas variables
+        Reader.progress = [% progress %] - 1;
         img1 = "";
         img2 = "";
-
-        //if we made it to the last page in a previous read, reset the page number
-        if (currentPage === Reader.maxPage)
-            currentPage = 0;
-
-        var params = new URLSearchParams(window.location.search);
-
-        if (params.has("p"))
-            goToPage(params.get("p") - 1);
-        else
-            goToPage(currentPage);
     </script>
 
     <div id="overlay-shade" onclick="closeOverlay();"></div>
@@ -172,48 +154,44 @@
 
 <h1 class="ih config-panel">Those options save automatically -- Click around and find out!</h1>
 
-<div style="margin:auto; font-size:8pt;">
+<div id="fit-mode" style="margin:auto; font-size:8pt;">
     <h2 class="config-panel"> Fit display to </h2>
-    <input id="fitcontainer" class="favtag-btn config-btn" type="button" value="Container"
-        onclick="setDisplayMode(false,false)">
-    <input id="fitwidth" class="favtag-btn config-btn" type="button" value="Width" onclick="setDisplayMode(true,false)">
-    <input id="fitheight" class="favtag-btn config-btn" type="button" value="Height"
-        onclick="setDisplayMode(false,true)">
+    <input id="fit-container" class="favtag-btn config-btn" type="button" value="Container">
+    <input id="fit-width" class="favtag-btn config-btn" type="button" value="Width">
+    <input id="fit-height" class="favtag-btn config-btn" type="button" value="Height">
 </div>
 
-<div style="margin:auto; font-size:8pt;" id="containersetting">
-    <h2 class="config-panel"> Container Width (in pixels)</h2>
-    <input id="containerwidth" class="stdinput" style="display:inline" onsubmit="applyContainerWidth()"
-        placeholder="The default value is 1200px, or 90% in Double Page Mode.">
-    <input class="favtag-btn config-btn" type="button" style="display:inline" value="Apply"
-        onclick="applyContainerWidth()">
+<div id="container-width" style="margin:auto; font-size:8pt;">
+    <h2 class="config-panel"> Container Width (in pixels or percentage)</h2>
+    <input id="container-width-input" class="stdinput" style="display:inline" placeholder="The default value is 1200px, or 90% in Double Page Mode.">
+    <input id="container-width-apply" class="favtag-btn config-btn" type="button" style="display:inline;" value="Apply">
 </div>
 
-<div style="margin:auto; font-size:8pt;">
+<div id="toggle-double-mode" style="margin:auto; font-size:8pt;">
     <h2 class="config-panel"> Page Rendering </h2>
-    <input id="singlepage" class="favtag-btn config-btn" type="button" value="Single" onclick="setDoublePage(false)">
-    <input id="doublepage" class="favtag-btn config-btn" type="button" value="Double" onclick="setDoublePage(true)">
+    <input id="single-page" class="favtag-btn config-btn" type="button" value="Single">
+    <input id="double-page" class="favtag-btn config-btn" type="button" value="Double">
 </div>
 
-<div style="margin:auto; font-size:8pt;">
-    <h2 class="config-panel"> Direction </h2>
+<div id="toggle-manga-mode" style="margin:auto; font-size:8pt;">
+    <h2 class="config-panel"> Reading Direction </h2>
     <span class="config-panel"></span>
-    <input id="normalread" class="favtag-btn config-btn" type="button" value="Left to Right" onclick="setRTL(false)">
-    <input id="mangaread" class="favtag-btn config-btn" type="button" value="Right to Left" onclick="setRTL(true)">
+    <input id="normal-mode" class="favtag-btn config-btn" type="button" value="Left to Right">
+    <input id="manga-mode" class="favtag-btn config-btn" type="button" value="Right to Left">
 </div>
 
-<div style="margin:auto; font-size:8pt;">
+<div id="toggle-header" style="margin:auto; font-size:8pt;">
     <h2 class="config-panel"> Header </h2>
-    <input id="showtop" class="favtag-btn config-btn" type="button" value="Visible" onclick="setHideHeader(false)">
-    <input id="hidetop" class="favtag-btn config-btn" type="button" value="Hidden" onclick="setHideHeader(true)">
+    <input id="show-header" class="favtag-btn config-btn" type="button" value="Visible">
+    <input id="hide-header" class="favtag-btn config-btn" type="button" value="Hidden">
 </div>
 
-<div style="margin:auto; font-size:8pt;">
+<div id="toggle-progress" style="margin:auto; font-size:8pt;">
     <h2 class="config-panel"> Progression Tracking </h2>
     <span class="config-panel">Disabling tracking will restart reading from page one every time you reopen the reader.
     </span>
-    <input id="dobookmark" class="favtag-btn config-btn" type="button" value="Enabled" onclick="setTracking(false)">
-    <input id="nobookmark" class="favtag-btn config-btn" type="button" value="Disabled" onclick="setTracking(true)">
+    <input id="track-progress" class="favtag-btn config-btn" type="button" value="Enabled">
+    <input id="untrack-progress" class="favtag-btn config-btn" type="button" value="Disabled">
 </div>
 
 [% END %]

--- a/templates/reader.html.tt2
+++ b/templates/reader.html.tt2
@@ -187,6 +187,14 @@
     <input id="untrack-progress" class="favtag-btn config-btn" type="button" value="Disabled">
 </div>
 
+<div id="toggle-infinite-scroll" style="margin:auto; font-size:8pt;">
+    <h2 class="config-panel"> Infinite Scrolling </h2>
+    <span class="config-panel">Display all images in a vertical view in the same page.
+    </span>
+    <input id="infinite-scroll-on" class="favtag-btn config-btn" type="button" value="Enabled">
+    <input id="infinite-scroll-off" class="favtag-btn config-btn" type="button" value="Disabled">
+</div>
+
 [% END %]
 <!-- -->
 [% BLOCK arrows %]
@@ -205,7 +213,7 @@
 [% END %]
 <!-- -->
 [% BLOCK pagesel %]
-<div style="position: absolute; right: 20px; z-index:20" class="page_dropdown">
+<div class="page_dropdown">
     <a class="fa fa-th fa-2x" id="toggle-archive-overlay" href="#" title="Archive Overview"></a>
     <a class="fa fa-cog fa-2x" id="toggle-settings-overlay" href="#" title="Reader Settings"></a>
     <a class="fa fa-info-circle fa-2x" id="toggle-help" href="#" title="Help"></a>

--- a/templates/reader.html.tt2
+++ b/templates/reader.html.tt2
@@ -41,11 +41,11 @@
             </div>
 
             <a id="display">
-                <img id="img" class="reader-image" onload="updateMetadata()" onerror="this.src='./img/noThumb.png'"
+                <img id="img" class="reader-image" onload="Reader.updateMetadata()" onerror="this.src='./img/noThumb.png'"
                     src="[% imgpath %]" usemap="#Map" />
                 <map name="Map" id="Map">
-                    <area id="leftmap" style="cursor:pointer;" onclick="advancePage(-1)" shape="rect" />
-                    <area id="rightmap" style="cursor:pointer;" onclick="advancePage(1)" shape="rect" />
+                    <area id="leftmap" style="cursor:pointer;" shape="rect" value="left"/>
+                    <area id="rightmap" style="cursor:pointer;" shape="rect" value="right" />
                 </map>
             </a>
 
@@ -194,28 +194,17 @@
 [% END %]
 <!-- -->
 [% BLOCK arrows %]
-<div class="sn">
-
-    <a onclick="goFirst()" style="cursor:pointer;">
-        <i class="fa fa-angle-double-left" style="font-size: 1.5em;"></i>
-    </a>
-
-    <a id="left" onclick="advancePage(-1)" style="cursor:pointer;">
-        <i class="fa fa-angle-left" style="font-size: 1.5em;"></i>
-    </a>
+<div class="sn paginator">
+    <a class="fa fa-angle-double-left page-link" style="font-size: 1.5em;" value="outer-left"></a>
+    <a class="fa fa-angle-left page-link" style="font-size: 1.5em;" value="left"></a>
 
     <div class="pagecount">
         <span class="current-page"></span> /
         <span class="max-page">[% pagecount %]</span>
     </div>
 
-    <a id="right" onclick="advancePage(1)" style="cursor:pointer;">
-        <i class="fa fa-angle-right" style="font-size: 1.5em;"></i>
-    </a>
-
-    <a onclick="goLast()" style="cursor:pointer;">
-        <i class="fa fa-angle-double-right" style="font-size: 1.5em;"></i>
-    </a>
+    <a class="fa fa-angle-right page-link" style="font-size: 1.5em;" value="right"></a>
+    <a class="fa fa-angle-double-right page-link" style="font-size: 1.5em;" value="outer-right"></a>
 </div>
 [% END %]
 <!-- -->

--- a/templates/reader.html.tt2
+++ b/templates/reader.html.tt2
@@ -99,8 +99,7 @@
 
                     <h2>Admin Options</h2>
 
-                    <input class="stdbtn" type='button' onclick="confirmThumbnailReset('[% id %]')"
-                        value="Regenerate Archive Thumbnail" />
+                    <input class="stdbtn" type='button' id="regenerate-thumbnail" value="Regenerate Archive Thumbnail" />
                     <br>
                     <input class='stdbtn' type='button'
                         onclick="window.location.href = './reader?id=[% id %]&force_reload=1'"
@@ -224,19 +223,9 @@
 <!-- -->
 [% BLOCK pagesel %]
 <div style="position: absolute; right: 20px; z-index:20" class="page_dropdown">
-
-    <a href="#" onclick="openOverlay();" title="Archive Overview">
-        <i class="fa fa-th fa-2x" style="padding-right: 10px;"></i>
-    </a>
-
-    <a href="#" onclick="openSettings();" title="Reader Settings">
-        <i class="fa fa-cog fa-2x" style="padding-right: 10px;"></i>
-    </a>
-
-    <a href="#" onclick="toastHelpReader()" title="Help">
-        <i class="fa fa-info-circle fa-2x" style="padding-right: 10px;"></i>
-    </a>
-
+    <a class="fa fa-th fa-2x" id="toggle-archive-overlay" href="#" title="Archive Overview"></a>
+    <a class="fa fa-cog fa-2x" id="toggle-settings-overlay" href="#" title="Reader Settings"></a>
+    <a class="fa fa-info-circle fa-2x" id="toggle-help" href="#" title="Help"></a>
 </div>
 [% END %]
 <!-- -->

--- a/templates/reader.html.tt2
+++ b/templates/reader.html.tt2
@@ -1,211 +1,211 @@
 <!DOCTYPE html>
 
 <head>
-	<title>[% arcname %]</title>
+    <title>[% arcname %]</title>
 
-	<meta name="viewport" content="width=device-width" />
-	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
-	<link type="image/png" rel="icon" href="favicon.ico" />
-	<link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version %]" />
-	<link rel="stylesheet" type="text/css" href="/css/config.css?[% version %]" />
+    <link type="image/png" rel="icon" href="favicon.ico" />
+    <link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version %]" />
+    <link rel="stylesheet" type="text/css" href="/css/config.css?[% version %]" />
 
-	<link rel="stylesheet" type="text/css" href="./css/vendor/fontawesome-all.min.css" />
-	<link rel="stylesheet" type="text/css" href="./css/vendor/jquery.toast.min.css" />
-	[% csshead %]
+    <link rel="stylesheet" type="text/css" href="./css/vendor/fontawesome-all.min.css" />
+    <link rel="stylesheet" type="text/css" href="./css/vendor/jquery.toast.min.css" />
+    [% csshead %]
 
-	<script src="./js/vendor/jquery.min.js" type="text/JAVASCRIPT"></script>
-	<script src="./js/vendor/jquery.toast.min.js" type="text/JAVASCRIPT"></script>
+    <script src="./js/vendor/jquery.min.js" type="text/javascript"></script>
+    <script src="./js/vendor/jquery.toast.min.js" type="text/javascript"></script>
 
-	<script src="./js/theme.js?[% version %]" type="text/JAVASCRIPT"></script>
-	<script src="./js/common.js?[% version %]" type="text/JAVASCRIPT"></script>
-	<script src="./js/reader.js?[% version %]" type="text/JAVASCRIPT"></script>
-	<script src="./js/ajax.js?[% version %]" type="text/JAVASCRIPT"></script>
+    <script src="./js/theme.js?[% version %]" type="text/javascript"></script>
+    <script src="./js/common.js?[% version %]" type="text/javascript"></script>
+    <script src="./js/reader.js?[% version %]" type="text/javascript"></script>
+    <script src="./js/ajax.js?[% version %]" type="text/javascript"></script>
 
 </head>
 
 <body onload="set_style_from_storage(); applySettings();">
 
-	<div id="i1" class="sni">
-		<h1>[% arcname %]</h1>
+    <div id="i1" class="sni">
+        <h1>[% arcname %]</h1>
 
-		<div id="i2">
-			[% INCLUDE pagesel %] [% INCLUDE arrows %] [% INCLUDE fileinfo %]
-		</div>
+        <div id="i2">
+            [% INCLUDE pagesel %] [% INCLUDE arrows %] [% INCLUDE fileinfo %]
+        </div>
 
-		<div id="i3">
-			<div class="loading-overlay">
-				<p class="loading-spinner">
-					<i id="spinner" class="fa fa-cog fa-spin"></i>
-				</p>
-			</div>
+        <div id="i3">
+            <div class="loading-overlay">
+                <p class="loading-spinner">
+                    <i id="spinner" class="fa fa-cog fa-spin"></i>
+                </p>
+            </div>
 
-			<a id="display">
-				<img id="img" class="reader-image" onload="updateMetadata()" onerror="this.src='./img/noThumb.png'"
-					src="[% imgpath %]" usemap="#Map" />
-				<map name="Map" id="Map">
-					<area id="leftmap" style="cursor:pointer;" onclick="advancePage(-1)" shape="rect" />
-					<area id="rightmap" style="cursor:pointer;" onclick="advancePage(1)" shape="rect" />
-				</map>
-			</a>
+            <a id="display">
+                <img id="img" class="reader-image" onload="updateMetadata()" onerror="this.src='./img/noThumb.png'"
+                    src="[% imgpath %]" usemap="#Map" />
+                <map name="Map" id="Map">
+                    <area id="leftmap" style="cursor:pointer;" onclick="advancePage(-1)" shape="rect" />
+                    <area id="rightmap" style="cursor:pointer;" onclick="advancePage(1)" shape="rect" />
+                </map>
+            </a>
 
-		</div>
+        </div>
 
-		<div id="i4">
-			[% INCLUDE fileinfo %] [% INCLUDE pagesel %] [% INCLUDE arrows %]
-		</div>
+        <div id="i4">
+            [% INCLUDE fileinfo %] [% INCLUDE pagesel %] [% INCLUDE arrows %]
+        </div>
 
-		<div id="i5">
-			<div class="sb">
-				<a href="./" title="Done reading? Go back to Archive Index">
-					<i class="fa fa-angle-down fa-3x"></i>
-				</a>
-			</div>
-		</div>
+        <div id="i5">
+            <div class="sb">
+                <a href="./" title="Done reading? Go back to Archive Index">
+                    <i class="fa fa-angle-down fa-3x"></i>
+                </a>
+            </div>
+        </div>
 
-		<div id="i7" class="if">
-			<i class="fa fa-caret-right fa-lg"></i>
-			<a id="imgLink" style="cursor:pointer;">View full-size image</a>
-			<i class="fa fa-caret-right fa-lg"></i>
-			<a href="./random">Switch to another random archive</a>
-		</div>
+        <div id="i7" class="if">
+            <i class="fa fa-caret-right fa-lg"></i>
+            <a id="imgLink" style="cursor:pointer;">View full-size image</a>
+            <i class="fa fa-caret-right fa-lg"></i>
+            <a href="./random">Switch to another random archive</a>
+        </div>
 
-	</div>
+    </div>
 
-	<script>
+    <script>
 
-		let isComingFromPopstate = false;
-		const pages = [% imgpaths %];
-		const id = "[%id%]";
-		let filename = "[% filename %]";
-		const tags = "[% tags %]";
+        let isComingFromPopstate = false;
+        const pages = [% imgpaths %];
+        const id = "[%id%]";
+        let filename = "[% filename %]";
+        const tags = "[% tags %]";
 
-		if ((filename.endsWith(".rar") || filename.endsWith(".cbr")) && !localStorage.rarWarningShown) {
-			localStorage.rarWarningShown = true;
-			$.toast({
-				showHideTransition: 'slide',
-				position: 'top-left',
-				loader: false,
-				heading: "This archive seems to be in RAR format!",
-				text: 'RAR archives might not work properly in LANraragi depending on how they were made. If you encounter errors while reading, consider converting your archive to zip.',
-				hideAfter: false,
-				icon: 'warning'
-			});
-		}
+        if ((filename.endsWith(".rar") || filename.endsWith(".cbr")) && !localStorage.rarWarningShown) {
+            localStorage.rarWarningShown = true;
+            $.toast({
+                showHideTransition: 'slide',
+                position: 'top-left',
+                loader: false,
+                heading: "This archive seems to be in RAR format!",
+                text: 'RAR archives might not work properly in LANraragi depending on how they were made. If you encounter errors while reading, consider converting your archive to zip.',
+                hideAfter: false,
+                icon: 'warning'
+            });
+        }
 
-		if (filename.endsWith(".epub") && !localStorage.epubWarningShown) {
-			localStorage.epubWarningShown = true;
-			$.toast({
-				showHideTransition: 'slide',
-				position: 'top-left',
-				loader: false,
-				heading: "EPUB support in LANraragi is minimal",
-				text: 'EPUB books will only show images in the Web Reader. If you want text support, consider pairing LANraragi with an <a href= "https://sugoi.gitbook.io/lanraragi/advanced-usage/external-readers#generic-opds-readers">OPDS reader.</a> ',
-				hideAfter: false,
-				icon: 'warning'
-			});
-		}
+        if (filename.endsWith(".epub") && !localStorage.epubWarningShown) {
+            localStorage.epubWarningShown = true;
+            $.toast({
+                showHideTransition: 'slide',
+                position: 'top-left',
+                loader: false,
+                heading: "EPUB support in LANraragi is minimal",
+                text: 'EPUB books will only show images in the Web Reader. If you want text support, consider pairing LANraragi with an <a href= "https://sugoi.gitbook.io/lanraragi/advanced-usage/external-readers#generic-opds-readers">OPDS reader.</a> ',
+                hideAfter: false,
+                icon: 'warning'
+            });
+        }
 
-		// Go straight to page number if there's an existing progress value
-		if (localStorage.nobookmark === 'true')
-			currentPage = 0;
-		else
-			currentPage = parseInt([% progress %] - 1 || 0);
+        // Go straight to page number if there's an existing progress value
+        if (localStorage.nobookmark === 'true')
+            currentPage = 0;
+        else
+            currentPage = parseInt([% progress %] - 1 || 0);
 
-		pageNumber = [% pagecount %];
+        pageNumber = [% pagecount %];
 
-		//canvas variables
-		previousPage = -1;
-		imagesLoaded = 0;
-		img1 = "";
-		img2 = "";
-		showingSinglePage = false;
+        //canvas variables
+        previousPage = -1;
+        imagesLoaded = 0;
+        img1 = "";
+        img2 = "";
+        showingSinglePage = false;
 
-		//if we made it to the last page in a previous read, reset the page number
-		if (currentPage === pageNumber - 1)
-			currentPage = 0;
+        //if we made it to the last page in a previous read, reset the page number
+        if (currentPage === pageNumber - 1)
+            currentPage = 0;
 
-		var params = new URLSearchParams(window.location.search);
+        var params = new URLSearchParams(window.location.search);
 
-		if (params.has("p"))
-			goToPage(params.get("p") - 1);
-		else
-			goToPage(currentPage);
+        if (params.has("p"))
+            goToPage(params.get("p") - 1);
+        else
+            goToPage(currentPage);
 
-		// Remove new flag with an API call
-		clearNew(id);
+        // Remove new flag with an API call
+        clearNew(id);
 
-		//image map update on window resize
-		$(window).resize(function () {
-			updateImageMap();
-		});
+        //image map update on window resize
+        $(window).resize(function () {
+            updateImageMap();
+        });
 
-		// Add a listen event to window.popstate to update the page accordingly if the user goes back using browser history
-		window.onpopstate = () => {
-			var params = new URLSearchParams(window.location.search);
-			if (params.has("p")) {
-				isComingFromPopstate = true;
-				goToPage(params.get("p") - 1);
-			}
-		}
+        // Add a listen event to window.popstate to update the page accordingly if the user goes back using browser history
+        window.onpopstate = () => {
+            var params = new URLSearchParams(window.location.search);
+            if (params.has("p")) {
+                isComingFromPopstate = true;
+                goToPage(params.get("p") - 1);
+            }
+        }
 
-	</script>
+    </script>
 
-	<div id="overlay-shade" onclick="closeOverlay();"></div>
-	<div id="archivePagesOverlay" class="id1 base-overlay page-overlay" style="display:none" loaded="false">
-		<h2 class="ih" style="text-align:center">Archive Overview</h2>
-		<div id="tagContainer" class="caption caption-tags caption-reader">
-			<br>
-			<div style="margin-bottom:16px;">
-				<div class="id3 nocrop reader-thumbnail">
-					<img src="./api/archives/[% id %]/thumbnail" />
-				</div>
+    <div id="overlay-shade" onclick="closeOverlay();"></div>
+    <div id="archivePagesOverlay" class="id1 base-overlay page-overlay" style="display:none" loaded="false">
+        <h2 class="ih" style="text-align:center">Archive Overview</h2>
+        <div id="tagContainer" class="caption caption-tags caption-reader">
+            <br>
+            <div style="margin-bottom:16px;">
+                <div class="id3 nocrop reader-thumbnail">
+                    <img src="./api/archives/[% id %]/thumbnail" />
+                </div>
 
-				[% IF userlogged %]
-				<div style="display:inline-block; vertical-align: middle;">
+                [% IF userlogged %]
+                <div style="display:inline-block; vertical-align: middle;">
 
-					<h2>Admin Options</h2>
+                    <h2>Admin Options</h2>
 
-					<input class="stdbtn" type='button' onclick="confirmThumbnailReset('[% id %]')"
-						value="Regenerate Archive Thumbnail" />
-					<br>
-					<input class='stdbtn' type='button'
-						onclick="window.location.href = './reader?id=[% id %]&force_reload=1'"
-						value='Clean Archive Cache' />
-					<br>
-					<input class='stdbtn' type='button' onclick="openInNewTab('./edit?id=[% id %]')"
-						value='Edit Archive Metadata' />
+                    <input class="stdbtn" type='button' onclick="confirmThumbnailReset('[% id %]')"
+                        value="Regenerate Archive Thumbnail" />
+                    <br>
+                    <input class='stdbtn' type='button'
+                        onclick="window.location.href = './reader?id=[% id %]&force_reload=1'"
+                        value='Clean Archive Cache' />
+                    <br>
+                    <input class='stdbtn' type='button' onclick="openInNewTab('./edit?id=[% id %]')"
+                        value='Edit Archive Metadata' />
 
-					<h2>Add this archive to a Category</h2>
+                    <h2>Add this archive to a Category</h2>
 
-					<select id="category" class="favtag-btn" style="width:200px; margin-right: 8px">
-						<option selected value=""> -- No Category -- </option>
-						[% FOREACH categories %]
-						<option value="[% id %]">[% name %]</option>
-						[% END %]
-					</select>
-					<br>
-					<input value="Add Archive" onclick="addArchiveToCategory('[% id %]', $('#category').val())"
-						class="stdbtn" id="goback" type="button">
-				</div>
-				[% END %]
-			</div>
+                    <select id="category" class="favtag-btn" style="width:200px; margin-right: 8px">
+                        <option selected value=""> -- No Category -- </option>
+                        [% FOREACH categories %]
+                        <option value="[% id %]">[% name %]</option>
+                        [% END %]
+                    </select>
+                    <br>
+                    <input value="Add Archive" onclick="addArchiveToCategory('[% id %]', $('#category').val())"
+                        class="stdbtn" id="goback" type="button">
+                </div>
+                [% END %]
+            </div>
 
-		</div>
+        </div>
 
-		<br><br>
+        <br><br>
 
-		<h2 class="ih" style="text-align:center">Pages</h2>
-	</div>
-	</div>
-	</div>
-	<div id="settingsOverlay" class="id1 base-overlay small-overlay" style="display:none">
-		[% INCLUDE config %]
-	</div>
+        <h2 class="ih" style="text-align:center">Pages</h2>
+    </div>
+    </div>
+    </div>
+    <div id="settingsOverlay" class="id1 base-overlay small-overlay" style="display:none">
+        [% INCLUDE config %]
+    </div>
 
-	<canvas id="dpcanvas" style="display:none" width="100" height="100"></canvas>
+    <canvas id="dpcanvas" style="display:none" width="100" height="100"></canvas>
 
-	[% INCLUDE footer %]
+    [% INCLUDE footer %]
 </body>
 
 </html>
@@ -222,47 +222,47 @@
 <h1 class="ih config-panel">Those options save automatically -- Click around and find out!</h1>
 
 <div style="margin:auto; font-size:8pt;">
-	<h2 class="config-panel"> Fit display to </h2>
-	<input id="fitcontainer" class="favtag-btn config-btn" type="button" value="Container"
-		onclick="setDisplayMode(false,false)">
-	<input id="fitwidth" class="favtag-btn config-btn" type="button" value="Width" onclick="setDisplayMode(true,false)">
-	<input id="fitheight" class="favtag-btn config-btn" type="button" value="Height"
-		onclick="setDisplayMode(false,true)">
+    <h2 class="config-panel"> Fit display to </h2>
+    <input id="fitcontainer" class="favtag-btn config-btn" type="button" value="Container"
+        onclick="setDisplayMode(false,false)">
+    <input id="fitwidth" class="favtag-btn config-btn" type="button" value="Width" onclick="setDisplayMode(true,false)">
+    <input id="fitheight" class="favtag-btn config-btn" type="button" value="Height"
+        onclick="setDisplayMode(false,true)">
 </div>
 
 <div style="margin:auto; font-size:8pt;" id="containersetting">
-	<h2 class="config-panel"> Container Width (in pixels)</h2>
-	<input id="containerwidth" class="stdinput" style="display:inline" onsubmit="applyContainerWidth()"
-		placeholder="The default value is 1200px, or 90% in Double Page Mode.">
-	<input class="favtag-btn config-btn" type="button" style="display:inline" value="Apply"
-		onclick="applyContainerWidth()">
+    <h2 class="config-panel"> Container Width (in pixels)</h2>
+    <input id="containerwidth" class="stdinput" style="display:inline" onsubmit="applyContainerWidth()"
+        placeholder="The default value is 1200px, or 90% in Double Page Mode.">
+    <input class="favtag-btn config-btn" type="button" style="display:inline" value="Apply"
+        onclick="applyContainerWidth()">
 </div>
 
 <div style="margin:auto; font-size:8pt;">
-	<h2 class="config-panel"> Page Rendering </h2>
-	<input id="singlepage" class="favtag-btn config-btn" type="button" value="Single" onclick="setDoublePage(false)">
-	<input id="doublepage" class="favtag-btn config-btn" type="button" value="Double" onclick="setDoublePage(true)">
+    <h2 class="config-panel"> Page Rendering </h2>
+    <input id="singlepage" class="favtag-btn config-btn" type="button" value="Single" onclick="setDoublePage(false)">
+    <input id="doublepage" class="favtag-btn config-btn" type="button" value="Double" onclick="setDoublePage(true)">
 </div>
 
 <div style="margin:auto; font-size:8pt;">
-	<h2 class="config-panel"> Direction </h2>
-	<span class="config-panel"></span>
-	<input id="normalread" class="favtag-btn config-btn" type="button" value="Left to Right" onclick="setRTL(false)">
-	<input id="mangaread" class="favtag-btn config-btn" type="button" value="Right to Left" onclick="setRTL(true)">
+    <h2 class="config-panel"> Direction </h2>
+    <span class="config-panel"></span>
+    <input id="normalread" class="favtag-btn config-btn" type="button" value="Left to Right" onclick="setRTL(false)">
+    <input id="mangaread" class="favtag-btn config-btn" type="button" value="Right to Left" onclick="setRTL(true)">
 </div>
 
 <div style="margin:auto; font-size:8pt;">
-	<h2 class="config-panel"> Header </h2>
-	<input id="showtop" class="favtag-btn config-btn" type="button" value="Visible" onclick="setHideHeader(false)">
-	<input id="hidetop" class="favtag-btn config-btn" type="button" value="Hidden" onclick="setHideHeader(true)">
+    <h2 class="config-panel"> Header </h2>
+    <input id="showtop" class="favtag-btn config-btn" type="button" value="Visible" onclick="setHideHeader(false)">
+    <input id="hidetop" class="favtag-btn config-btn" type="button" value="Hidden" onclick="setHideHeader(true)">
 </div>
 
 <div style="margin:auto; font-size:8pt;">
-	<h2 class="config-panel"> Progression Tracking </h2>
-	<span class="config-panel">Disabling tracking will restart reading from page one every time you reopen the reader.
-	</span>
-	<input id="dobookmark" class="favtag-btn config-btn" type="button" value="Enabled" onclick="setTracking(false)">
-	<input id="nobookmark" class="favtag-btn config-btn" type="button" value="Disabled" onclick="setTracking(true)">
+    <h2 class="config-panel"> Progression Tracking </h2>
+    <span class="config-panel">Disabling tracking will restart reading from page one every time you reopen the reader.
+    </span>
+    <input id="dobookmark" class="favtag-btn config-btn" type="button" value="Enabled" onclick="setTracking(false)">
+    <input id="nobookmark" class="favtag-btn config-btn" type="button" value="Disabled" onclick="setTracking(true)">
 </div>
 
 [% END %]
@@ -270,43 +270,43 @@
 [% BLOCK arrows %]
 <div class="sn">
 
-	<a onclick="goFirst()" style="cursor:pointer;">
-		<i class="fa fa-angle-double-left" style="font-size: 1.5em;"></i>
-	</a>
+    <a onclick="goFirst()" style="cursor:pointer;">
+        <i class="fa fa-angle-double-left" style="font-size: 1.5em;"></i>
+    </a>
 
-	<a id="left" onclick="advancePage(-1)" style="cursor:pointer;">
-		<i class="fa fa-angle-left" style="font-size: 1.5em;"></i>
-	</a>
+    <a id="left" onclick="advancePage(-1)" style="cursor:pointer;">
+        <i class="fa fa-angle-left" style="font-size: 1.5em;"></i>
+    </a>
 
-	<div class="pagecount">
-		<span class="current-page"></span> /
-		<span class="max-page"></span>
-	</div>
+    <div class="pagecount">
+        <span class="current-page"></span> /
+        <span class="max-page"></span>
+    </div>
 
-	<a id="right" onclick="advancePage(1)" style="cursor:pointer;">
-		<i class="fa fa-angle-right" style="font-size: 1.5em;"></i>
-	</a>
+    <a id="right" onclick="advancePage(1)" style="cursor:pointer;">
+        <i class="fa fa-angle-right" style="font-size: 1.5em;"></i>
+    </a>
 
-	<a onclick="goLast()" style="cursor:pointer;">
-		<i class="fa fa-angle-double-right" style="font-size: 1.5em;"></i>
-	</a>
+    <a onclick="goLast()" style="cursor:pointer;">
+        <i class="fa fa-angle-double-right" style="font-size: 1.5em;"></i>
+    </a>
 </div>
 [% END %]
 <!-- -->
 [% BLOCK pagesel %]
 <div style="position: absolute; right: 20px; z-index:20" class="page_dropdown">
 
-	<a href="#" onclick="openOverlay();" title="Archive Overview">
-		<i class="fa fa-th fa-2x" style="padding-right: 10px;"></i>
-	</a>
+    <a href="#" onclick="openOverlay();" title="Archive Overview">
+        <i class="fa fa-th fa-2x" style="padding-right: 10px;"></i>
+    </a>
 
-	<a href="#" onclick="openSettings();" title="Reader Settings">
-		<i class="fa fa-cog fa-2x" style="padding-right: 10px;"></i>
-	</a>
+    <a href="#" onclick="openSettings();" title="Reader Settings">
+        <i class="fa fa-cog fa-2x" style="padding-right: 10px;"></i>
+    </a>
 
-	<a href="#" onclick="toastHelpReader()" title="Help">
-		<i class="fa fa-info-circle fa-2x" style="padding-right: 10px;"></i>
-	</a>
+    <a href="#" onclick="toastHelpReader()" title="Help">
+        <i class="fa fa-info-circle fa-2x" style="padding-right: 10px;"></i>
+    </a>
 
 </div>
 [% END %]

--- a/templates/reader.html.tt2
+++ b/templates/reader.html.tt2
@@ -73,8 +73,6 @@
     </div>
 
     <script>
-
-        let isComingFromPopstate = false;
         Reader.pages = [% imgpaths %].pages;
         Reader.id = "[%id%]";
         Reader.filename = "[% filename %]";

--- a/templates/reader.html.tt2
+++ b/templates/reader.html.tt2
@@ -24,7 +24,7 @@
 
 </head>
 
-<body onload="set_style_from_storage();">
+<body>
 
     <div id="i1" class="sni">
         <div id="i2">
@@ -82,7 +82,7 @@
         img2 = "";
     </script>
 
-    <div id="overlay-shade" onclick="closeOverlay();"></div>
+    <div id="overlay-shade"></div>
     <div id="archivePagesOverlay" class="id1 base-overlay page-overlay" style="display:none" loaded="false">
         <h2 class="ih" style="text-align:center">Archive Overview</h2>
         <div id="tagContainer" class="caption caption-tags caption-reader">
@@ -99,12 +99,9 @@
 
                     <input class="stdbtn" type='button' id="regenerate-thumbnail" value="Regenerate Archive Thumbnail" />
                     <br>
-                    <input class='stdbtn' type='button'
-                        onclick="window.location.href = './reader?id=[% id %]&force_reload=1'"
-                        value='Clean Archive Cache' />
+                    <input id="regenerate-cache" class='stdbtn' type='button' value='Clean Archive Cache' />
                     <br>
-                    <input class='stdbtn' type='button' onclick="openInNewTab('./edit?id=[% id %]')"
-                        value='Edit Archive Metadata' />
+                    <input id="edit-archive" class='stdbtn' type='button' value='Edit Archive Metadata' />
 
                     <h2>Add this archive to a Category</h2>
 
@@ -115,8 +112,7 @@
                         [% END %]
                     </select>
                     <br>
-                    <input value="Add Archive" onclick="addArchiveToCategory('[% id %]', $('#category').val())"
-                        class="stdbtn" id="goback" type="button">
+                    <input value="Add Archive" class="stdbtn" id="add-category" type="button">
                 </div>
                 [% END %]
             </div>


### PR DESCRIPTION
I split this into different commits for ease of digestion and debugging. They *should* be self-contained, so that you can analyze one at a time and then move to the next, though a lot of rebases went into this so I can't guarantee that intermediate commits before the infinite reader one are fully stand-alone.
The edited line count is inflated because I replaced tabs and single quotes with spaces and double quotes in the template and JS file, even for lines I didn't really touch.

Changes:
* Moves all the stray functions into a single namespace ("Reader"), refactors most of the JS code for it, also fixes a lot of small bugs with the previous implementation.
* Removes (almost) all of the inline javascript events
* Adds a native infinite scrolling reader, since these changes broke the old userscript.
* Also adds various shortcuts ("h" for help, "q" for the archive overlay, "o" for the settings, "esc" to close overlays, "shift-space" to go back one page, "d" to toggle double page mode and "p" to toggle manga mode).
* Merges the preloading logic so that it can be turned into a setting in the future (I didn't have enough time to do this this time around but it's something I'd like to have for myself so I'll probably revisit this in the future). For now, it preloads 2 forward and 1 backward pages, doubled in case of double page mode. Also stops preloading if it reaches the end, something the old implementation didn't do.

I tested this on Firefox, Chrome and partially on mobile, and it seems to work fine. Please lemme know if there's any issues I didn't notice. I tried to remove some bad quirks I found with the previous implementation but there's some I didn't have time to tackle or that were buried too deep for me to tackle all at once (like images sometimes failing to load and requiring a fake page change, which is why I didn't add a check to stop trying to browse beyond the first and last page, letting the program just refresh those pages). Regardless, I shouldn't have introduced any new bug or weird behavior. I tried my best to preserve the functionality as it was before, since this was meant to be a refactoring, not rewriting.

Some thoughts:
* the HTML is a mess, because it "magically" injects CSS from many places. It was pretty painful to debug various issues I had at certain points. TBH lanraragi would greatly benefit from a move to [tailwind](https://tailwindcss.com/) or [bootstrap](https://getbootstrap.com/), where CSS comes from precise and clear points (either HTML classes with a speaking name or a CSS file). This however goes to touch the themes, so it's not a trivial thing to do.
* related to this, the css is a huge file, ideally it should be split in modules
* I didn't touch functions external to reader.js because otherwise it would've been a slippery slope of refactoring, however I noticed that it would be fairly trivial to implement a modal to show the edit metadata panel without opening a new tab. Perhaps I'll revisit this in the future.
* shortcuts would be better fit to a [data-shortcut model](https://johndjameson.com/blog/data-attributes-for-keyboard-shortcuts/), but I didn't want to add a new js library since I was already doing too much, so I just attached new ones to the existing method. Perhaps it can be addressed in the future (i'd like to add various shortcuts to the index too, so maybe when I tackle that)
* for notifications, we should be using a library like [Toastr](https://github.com/CodeSeven/toastr/), because jquery.toast hasn't been touched in [four years](https://github.com/kamranahmedse/jquery-toast-plugin). Toastr is not updated often but it offers [a lot more customization](https://codeseven.github.io/toastr/demo.html), and most importantly the ability to interact with existing toasts without having to wrap them around custom html.
* I'm not sure why the program is using a canvas to render double pages, rather than just creating two imgs and giving them the same sizes, but tackling that issue as well would've taken me too much
* I added legacy code to port pre-refactoring localstorage options on first load ([example](https://github.com/Difegue/LANraragi/commit/0530b837f40f75a7ac6330dd8529f003b6460657#diff-0405c5a1ac3d426786115cb5e96449f091d72ff56788998b41c91ac9191e82f4R92)), lemme know if they're not needed and I'll just rebase them out, or we can just wait until a new version to drop them