### PR TITLE
Reader: fix race condition causing header refresh to be triggered by the error thumbnail

### DIFF
--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -277,6 +277,7 @@ Reader.updateMetadata = function () {
     const img = $("#img")[0];
     const imageUrl = new URL(img.src);
     const filename = imageUrl.searchParams.get("path");
+    if (!filename) { return; }
 
     if (Reader.showingSinglePage) {
         // HEAD request to get filesize


### PR DESCRIPTION
[Reported on discord](https://discord.com/channels/612709831744290847/612711732514652202/836846834940772362). A user reported a race condition that caused the header to display the wrong filename on first load.
I couldn't reproduce this on any browser, but I suspect it has to do with the error thumbnail triggering the onload property. 
Since pages [are always served with a filename](https://github.com/Difegue/LANraragi/blob/5fb4e11ec360c44b0edb2c7b7d443185285c047d/lib/LANraragi/Model/Reader.pm#L163), we can effectively abort metadata fetching if there's no filename, and avoid reloading the metadata header for the error thumbnail.

Unfortunately onload/onerror events are finicky when dealing with dynamically loaded images. The "actual" fix, that is, preventing the onload event from firing at all from the error thumbnail, would probably be a headache to figure out, especially since I could not reproduce this issue at all.