### PR TITLE
Reader: add preload option

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
         "quotes": ["error", "double"],
         "no-alert": "off",
         "no-else-return": "off",
+        "no-param-reassign": ["error", { "props": false }],
         "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
         "no-multi-assign": ["error", { "ignoreNonDeclaration": true }],
         "no-unused-expressions": [

--- a/public/css/lrr.css
+++ b/public/css/lrr.css
@@ -535,12 +535,18 @@ li {
   height: unset;
 }
 
+#settingsOverlay > div {
+    margin: auto;
+    font-size: 8pt;
+}
+
 /* Infinite Scrolling Reader */
 
 body.infinite-scroll .sn,
 body.infinite-scroll .file-info,
 body.infinite-scroll .reading-direction,
 body.infinite-scroll #toggle-manga-mode,
+body.infinite-scroll #preload-images,
 body.infinite-scroll #toggle-double-mode {
   display: none;
 }

--- a/templates/index.html.tt2
+++ b/templates/index.html.tt2
@@ -203,7 +203,7 @@
 	<div id="overlay-shade" onclick="closeOverlay();"> </div>
 	<div id="settingsOverlay" class="id1 base-overlay small-overlay" style="display:none">
 		<h2 class="ih" style="text-align:center">Index Display Options</h2>
-		<div style="margin:auto; font-size:8pt;">
+		<div>
 
 			<div class="config-panel">
 				<h1 class="ih" style="display:inline"> Use Compact Mode</h1>

--- a/templates/reader.html.tt2
+++ b/templates/reader.html.tt2
@@ -78,8 +78,6 @@
         Reader.filename = "[% filename %]";
         Reader.tags = "[% tags %]";
         Reader.progress = [% progress %] - 1;
-        img1 = "";
-        img2 = "";
     </script>
 
     <div id="overlay-shade"></div>
@@ -147,39 +145,45 @@
 
 <h1 class="ih config-panel">Those options save automatically -- Click around and find out!</h1>
 
-<div id="fit-mode" style="margin:auto; font-size:8pt;">
+<div id="fit-mode">
     <h2 class="config-panel"> Fit display to </h2>
     <input id="fit-container" class="favtag-btn config-btn" type="button" value="Container">
     <input id="fit-width" class="favtag-btn config-btn" type="button" value="Width">
     <input id="fit-height" class="favtag-btn config-btn" type="button" value="Height">
 </div>
 
-<div id="container-width" style="margin:auto; font-size:8pt;">
+<div id="container-width">
     <h2 class="config-panel"> Container Width (in pixels or percentage)</h2>
     <input id="container-width-input" class="stdinput" style="display:inline" placeholder="The default value is 1200px, or 90% in Double Page Mode.">
     <input id="container-width-apply" class="favtag-btn config-btn" type="button" style="display:inline;" value="Apply">
 </div>
 
-<div id="toggle-double-mode" style="margin:auto; font-size:8pt;">
+<div id="toggle-double-mode">
     <h2 class="config-panel"> Page Rendering </h2>
     <input id="single-page" class="favtag-btn config-btn" type="button" value="Single">
     <input id="double-page" class="favtag-btn config-btn" type="button" value="Double">
 </div>
 
-<div id="toggle-manga-mode" style="margin:auto; font-size:8pt;">
+<div id="toggle-manga-mode">
     <h2 class="config-panel"> Reading Direction </h2>
     <span class="config-panel"></span>
     <input id="normal-mode" class="favtag-btn config-btn" type="button" value="Left to Right">
     <input id="manga-mode" class="favtag-btn config-btn" type="button" value="Right to Left">
 </div>
 
-<div id="toggle-header" style="margin:auto; font-size:8pt;">
+<div id="preload-images">
+    <h2 class="config-panel"> How many images to preload</h2>
+    <input id="preload-input" class="stdinput" style="display:inline" placeholder="The default is two images.">
+    <input id="preload-apply" class="favtag-btn config-btn" type="button" style="display:inline;" value="Apply">
+</div>
+
+<div id="toggle-header">
     <h2 class="config-panel"> Header </h2>
     <input id="show-header" class="favtag-btn config-btn" type="button" value="Visible">
     <input id="hide-header" class="favtag-btn config-btn" type="button" value="Hidden">
 </div>
 
-<div id="toggle-progress" style="margin:auto; font-size:8pt;">
+<div id="toggle-progress">
     <h2 class="config-panel"> Progression Tracking </h2>
     <span class="config-panel">Disabling tracking will restart reading from page one every time you reopen the reader.
     </span>
@@ -187,7 +191,7 @@
     <input id="untrack-progress" class="favtag-btn config-btn" type="button" value="Disabled">
 </div>
 
-<div id="toggle-infinite-scroll" style="margin:auto; font-size:8pt;">
+<div id="toggle-infinite-scroll">
     <h2 class="config-panel"> Infinite Scrolling </h2>
     <span class="config-panel">Display all images in a vertical view in the same page.
     </span>


### PR DESCRIPTION
Makes preload size customizable (only works in normal browsing, not infinite scrolling) and properly caches preloaded images.

There's a weird behavior with Chrome that makes it ignore preloading in certain cases and only in single page mode: I could only reproduce it on page reload when going backwards once, then fowards once. Only those two images are reloaded. I'm thinking it's something to do with how chrome handles cache, because I can't reproduce it with firefox, but I could only discover that it was tied to the HEAD requests for the filesize. Caching those stopped it from happening 90% of the time, and given that it requires specific actions to happen, I decided to open this anyway.