### PR TITLE
Index: fix paginator overlap for large numbers

### DIFF
--- a/public/css/lrr.css
+++ b/public/css/lrr.css
@@ -107,6 +107,15 @@ table thead .sorting_disabled a:after {
   display: none;
 }
 
+.paginate_button {
+  min-width: 2rem;
+  width: auto !important;
+}
+
+.ellipsis {
+  margin-left: 1rem;
+}
+
 .page-select {
   text-align:right;
 }


### PR DESCRIPTION
Fixes #429. Tested with all themes.

![image](https://user-images.githubusercontent.com/12946050/116436256-82c71c80-a84c-11eb-89b9-cf85fc3b3ed5.png)
