### PR TITLE
Reader: fix hiding header not making image reach 98vh

### DIFF
--- a/public/css/lrr.css
+++ b/public/css/lrr.css
@@ -545,12 +545,12 @@ body.infinite-scroll #toggle-double-mode {
   display: none;
 }
 
-body.infinite-scroll #i2 .page_dropdown {
+body.infinite-scroll #i4 .page_dropdown {
   position: fixed;
   top: 20px;
 }
 
-body.infinite-scroll #i4 {
+body.infinite-scroll #i2 {
   display: none;
 }
 

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -408,7 +408,8 @@ Reader.applyContainerWidth = function () {
         // Fit to height forces the image to 90% of visible screen height.
         // If the header is hidden, or if we're in infinite scrolling, then the image
         // can take up to 98% of visible screen height because there's more free space
-        $(".reader-image").attr("style", `max-height: ${Reader.hideHeader || Reader.infiniteScroll ? 98 : 90}vh;`);
+        const height = localStorage.hideHeader === "true" || Reader.infiniteScroll ? 98 : 90;
+        $(".reader-image").attr("style", `max-height: ${height}vh;`);
         $(".sni").attr("style", "width: fit-content; width: -moz-fit-content");
     } else if (Reader.fitMode === "fit-width") {
         $(".reader-image").attr("style", "width: 100%;");
@@ -447,6 +448,7 @@ Reader.toggleHeader = function () {
     localStorage.hideHeader = $("#i2").is(":visible");
     $("#toggle-header input").toggleClass("toggled");
     $("#i2").toggle();
+    Reader.applyContainerWidth();
 };
 
 Reader.toggleProgressTracking = function () {


### PR DESCRIPTION
Reported on discord. Fixes an issue caused by a typo (Reader.hideHeader was actually meant to be localStorage.hideHeader! Embarassing.)