### PR TITLE
Reader: don't trigger R shortcut (for random archive) if there's a modifier key pressed

### DIFF
--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -208,6 +208,7 @@ Reader.handleShortcuts = function (e) {
         Reader.toggleArchiveOverlay();
         break;
     case 82: // r
+        if (e.ctrlKey || e.shiftKey || e.metaKey) { break; }
         document.location.href = "/random";
         break;
     default:


### PR DESCRIPTION
Otherwise it might catch CTRL+R which is the shortcut to refresh a page.