### PR TITLE
Fix eh downloader autostart behavior

### DIFF
--- a/lib/LANraragi/Plugin/Download/EHentai.pm
+++ b/lib/LANraragi/Plugin/Download/EHentai.pm
@@ -96,11 +96,11 @@ sub provide_url {
     $content = $response->body;
     $logger->debug("/archiver.php result: $content");
 
-    my $finalURL = "";
+    my $finalURL = URI->new();
     eval {
         # Parse that to get the final URL
         if ( $content =~ /.*document.location = "(.*)".*/gim ) {
-            $finalURL = $1;
+            $finalURL = URI->new($1);
             $logger->info("Final URL obtained: $finalURL");
         }
     };
@@ -109,10 +109,8 @@ sub provide_url {
         return ( error => "Couldn't proceed with an original size download: <pre>$content</pre>" );
     }
 
-    # If the URL doesn't already have autostart, append start=1 to get an URL that automatically triggers the download.
-    unless ( $finalURL =~ /.*autostart=1.*/gi ) {
-        $finalURL .= "?start=1";
-    }
+    # Append start=1 to get an URL that automatically triggers the download.
+    $finalURL->query("start=1");
 
     # All done!
     return ( download_url => $finalURL );

--- a/lib/LANraragi/Plugin/Download/EHentai.pm
+++ b/lib/LANraragi/Plugin/Download/EHentai.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 no warnings 'uninitialized';
 
+use URI;
 use Mojo::UserAgent;
 
 use LANraragi::Utils::Logging qw(get_logger);

--- a/lib/LANraragi/Plugin/Download/EHentai.pm
+++ b/lib/LANraragi/Plugin/Download/EHentai.pm
@@ -110,7 +110,7 @@ sub provide_url {
         return ( error => "Couldn't proceed with an original size download: <pre>$content</pre>" );
     }
 
-    # Append start=1 to get an URL that automatically triggers the download.
+    # Set URL query parameters to ?start=1 to automatically trigger the download.
     $finalURL->query("start=1");
 
     # All done!

--- a/tools/cpanfile
+++ b/tools/cpanfile
@@ -17,6 +17,7 @@ requires 'Sort::Naturally', 1.03;
 requires 'Authen::Passphrase', 0.008;
 requires 'File::ReadBackwards', 1.05;
 requires 'URI::Escape', 1.74;
+requires 'URI', 5.09;
 
 # Used by Installer
 requires 'IPC::Cmd', 1.02;


### PR DESCRIPTION
Prior to this, any of the "X Select, Auto Start" options in the uconfig page would cause the download to fail with a mysterious "Unsupported File Extension" error. The issue stems from the ?autostart=1 query param not being replaced with ?start=1. No query leads to a webpage with the URL, ?autostart=1 is the same thing but with a js trigger to redirect to ?start=1, which in turn is the real file.