### PR TITLE
retry download_url attempts up to 5 times

### DIFF
--- a/lib/LANraragi/Controller/Api/Other.pm
+++ b/lib/LANraragi/Controller/Api/Other.pm
@@ -109,7 +109,7 @@ sub download_url {
     if ($url) {
 
         # Send a job to Minion to queue the download.
-        my $jobid = $self->minion->enqueue( download_url => [ $url, $catid ] => { priority => 1 } );
+        my $jobid = $self->minion->enqueue( download_url => [ $url, $catid ] => { priority => 1, attempts => 5 } );
 
         $self->render(
             json => {


### PR DESCRIPTION
perhaps make this user configurable later
this function can fail easily with timeouts if queuing many downloads at once