### PR TITLE
Clean up downloaded filenames

### DIFF
--- a/lib/LANraragi/Model/Upload.pm
+++ b/lib/LANraragi/Model/Upload.pm
@@ -172,6 +172,12 @@ sub download_url {
     
     # remove invalid Windows chars
     $filename =~ s@[\\/:"*?<>|]+@@g;
+    
+    my ($fn, $path, $ext) = fileparse($filename, qr/\.[^.]*/);
+    # don't allow the main filename to exceed 255 chars after accounting
+    # for extension and .upload prefix used by `handle_incoming_file`
+    $filename = substr $fn, 0, 254-length($ext)-length(".upload");
+    $filename = $filename . $ext;
     $logger->debug("Filename post clean: $filename");
     $tx->result->save_to("$tempdir\/$filename");
 

--- a/lib/LANraragi/Model/Upload.pm
+++ b/lib/LANraragi/Model/Upload.pm
@@ -169,6 +169,10 @@ sub download_url {
     }
 
     $logger->debug("Filename: $filename");
+    
+    # remove invalid Windows chars
+    $filename =~ s@[\\/:"*?<>|]+@@g;
+    $logger->debug("Filename post clean: $filename");
     $tx->result->save_to("$tempdir\/$filename");
 
     # Update $tempfile to the exact reference created by the host filesystem


### PR DESCRIPTION
Limit to 255 minus extension lengths for ext4, and strip invalid Windows chars.
Fixes #449