### PR TITLE
NH plugin now can use the id from the file name

### DIFF
--- a/lib/LANraragi/Plugin/Metadata/nHentai.pm
+++ b/lib/LANraragi/Plugin/Metadata/nHentai.pm
@@ -24,7 +24,7 @@ sub plugin_info {
         namespace   => "nhplugin",
         author      => "Difegue",
         version     => "1.7",
-        description => "Searches nHentai for tags matching your archive. <br>Supports reading the ID from files formatted as \"{Id} Title\" and if not tries to search for a matching gallery.",
+        description => "Searches nHentai for tags matching your archive. <br>Supports reading the ID from files formatted as \"{Id} Title\" and if not, tries to search for a matching gallery.",
         icon =>
           "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAAACXBIWXMAAAsTAAALEwEAmpwYAAAA\nB3RJTUUH4wYCFA8s1yKFJwAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUH\nAAACL0lEQVQ4y6XTz0tUURQH8O+59773nLFcaGWTk4UUVCBFiJs27VxEQRH0AyRo4x8Q/Qtt2rhr\nU6soaCG0KYKSwIhMa9Ah+yEhZM/5oZMG88N59717T4sxM8eZCM/ycD6Xwznn0pWhG34mh/+PA8mk\n8jO5heziP0sFYwfgMDFQJg4IUjmquSFGG+OIlb1G9li5kykgTgvzSoUCaIYlo8/Igcjpj5wOkARp\n8AupP0uzJLijCY4zzoXOxdBLshAgABr8VOp7bpAXDEI7IBrhdksnjNr3WzI4LaIRV9fk2iAaYV/y\nA1dPiYjBAALgpQxnhV2XzTCAGWGeq7ACBvCdzKQyTH+voAm2hGlpcmQt2Bc2K+ymAhWPxTzPDQLt\nOKo1FiNBQaArq9WNRQwEgKl7XQ1duzSRSn/88vX0qf7DPQddx1nI5UfHxt+m0sLYPiP3shRAG8MD\nok1XEEXR/EI2ly94nrNYWG6Nx0/2Hp2b94dv34mlZge1e4hVCJ4jc6tl9ZP803n3/i4lpdyzq2N0\n7M3DkSeF5ZVYS8v1qxcGz5+5eey4nPDbmGdE9FpGeWErVNe2tTabX3r0+Nk3PwOgXFkdfz99+exA\nMtFZITEt9F23mpLG0hYTVQCKpfKPlZ/rqWKpYoAPcTmpginW76QBbb0OBaBaDdjaDbNlJmQE3/d0\nMYoaybU9126oPkrEhpr+U2wjtoVVGBowkslEsVSupRKdu0Mduq7q7kqExjSS3V2dvwDLavx0eczM\neAAAAABJRU5ErkJggg==",
         parameters  => [ { type => "bool", desc => "Save archive title" } ],

--- a/lib/LANraragi/Plugin/Metadata/nHentai.pm
+++ b/lib/LANraragi/Plugin/Metadata/nHentai.pm
@@ -23,8 +23,8 @@ sub plugin_info {
         type        => "metadata",
         namespace   => "nhplugin",
         author      => "Difegue",
-        version     => "1.6",
-        description => "Searches nHentai for tags matching your archive.",
+        version     => "1.7",
+        description => "Searches nHentai for tags matching your archive. <br>Supports reading the ID from files formatted as \"{Id} Title\" and if not tries to search for a matching gallery.",
         icon =>
           "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAAACXBIWXMAAAsTAAALEwEAmpwYAAAA\nB3RJTUUH4wYCFA8s1yKFJwAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUH\nAAACL0lEQVQ4y6XTz0tUURQH8O+59773nLFcaGWTk4UUVCBFiJs27VxEQRH0AyRo4x8Q/Qtt2rhr\nU6soaCG0KYKSwIhMa9Ah+yEhZM/5oZMG88N59717T4sxM8eZCM/ycD6Xwznn0pWhG34mh/+PA8mk\n8jO5heziP0sFYwfgMDFQJg4IUjmquSFGG+OIlb1G9li5kykgTgvzSoUCaIYlo8/Igcjpj5wOkARp\n8AupP0uzJLijCY4zzoXOxdBLshAgABr8VOp7bpAXDEI7IBrhdksnjNr3WzI4LaIRV9fk2iAaYV/y\nA1dPiYjBAALgpQxnhV2XzTCAGWGeq7ACBvCdzKQyTH+voAm2hGlpcmQt2Bc2K+ymAhWPxTzPDQLt\nOKo1FiNBQaArq9WNRQwEgKl7XQ1duzSRSn/88vX0qf7DPQddx1nI5UfHxt+m0sLYPiP3shRAG8MD\nok1XEEXR/EI2ly94nrNYWG6Nx0/2Hp2b94dv34mlZge1e4hVCJ4jc6tl9ZP803n3/i4lpdyzq2N0\n7M3DkSeF5ZVYS8v1qxcGz5+5eey4nPDbmGdE9FpGeWErVNe2tTabX3r0+Nk3PwOgXFkdfz99+exA\nMtFZITEt9F23mpLG0hYTVQCKpfKPlZ/rqWKpYoAPcTmpginW76QBbb0OBaBaDdjaDbNlJmQE3/d0\nMYoaybU9126oPkrEhpr+U2wjtoVVGBowkslEsVSupRKdu0Mduq7q7kqExjSS3V2dvwDLavx0eczM\neAAAAABJRU5ErkJggg==",
         parameters  => [ { type => "bool", desc => "Save archive title" } ],
@@ -87,6 +87,14 @@ sub get_gallery_id_from_title {
     my $title  = $_[0];
     my $logger = get_logger( "nHentai", "plugins" );
 
+    my $gallery = "";
+
+    if ( $title =~ /\{(\d*)\}.*$/gm ) {
+        $gallery = $1;
+        $logger->debug("Got $gallery from file.");
+        return $gallery;
+    }
+
     #Strip away hyphens and apostrophes as they apparently break search
     $title =~ s/-|'/ /g;
 
@@ -103,7 +111,6 @@ sub get_gallery_id_from_title {
     # Get the first gallery url of the search results
     my $gURL = ( $dom->at('.cover') ) ? $dom->at('.cover')->attr('href') : "";
 
-    my $gallery = "";
     if ( $gURL =~ /\/g\/(\d*)\//gm ) {
         $gallery = $1;
     }
@@ -157,6 +164,7 @@ sub get_tags_from_NH {
         $returned .= $namespace . $tag->{"name"};
 
     }
+    $returned .= ", source:https://nhentai.net/g/$gID";
 
     $logger->info("Sending the following tags to LRR: $returned");
 

--- a/lib/LANraragi/Plugin/Scripts/nHentaiSourceConverter.pm
+++ b/lib/LANraragi/Plugin/Scripts/nHentaiSourceConverter.pm
@@ -1,0 +1,57 @@
+package LANraragi::Plugin::Scripts::nHentaiSourceConverter;
+
+use strict;
+use warnings;
+no warnings 'uninitialized';
+
+use LANraragi::Utils::Logging qw(get_logger);
+use LANraragi::Utils::Database qw(invalidate_cache);
+use LANraragi::Model::Config;
+
+#Meta-information about your plugin.
+sub plugin_info {
+
+    return (
+        #Standard metadata
+        name      => "nHentai Source Converter",
+        type      => "script",
+        namespace => "nhsrcconv",
+        author    => "Guerra24",
+        version   => "1.0",
+        description =>
+          "Converts \"source:id\" tags with 6 or less digits into \"source:https://nhentai.net/g/id\""
+    );
+
+}
+
+# Mandatory function to be implemented by your script
+sub run_script {
+    shift;
+    my $lrr_info = shift;    # Global info hash
+
+    my $logger = get_logger( "nHentai Source Converter", "plugins" );
+    my $redis  = LANraragi::Model::Config->get_redis;
+
+    my @keys = $redis->keys('????????????????????????????????????????');    #40-character long keys only => Archive IDs
+
+    my $count = 0;
+    #Parse the archive list and add them to JSON.
+    foreach my $id (@keys) {
+
+        my %hash = $redis->hgetall($id);
+        my ( $tags ) = @hash{qw(tags)};
+
+        if ( $tags =~ s/source:(\d{1,6})/source:https:\/\/nhentai\.net\/g\/$1/igm ) {
+            $count++;
+        }
+
+        $redis->hset( $id, "tags",  $tags );
+    }
+
+    invalidate_cache();
+    $redis->quit();
+
+    return ( modified => $count );
+}
+
+1;

--- a/tests/modules.t
+++ b/tests/modules.t
@@ -4,7 +4,7 @@ use utf8;
 use Cwd;
 
 use Mojo::Base 'Mojolicious';
-use Test::More tests => 54;
+use Test::More tests => 55;
 use Test::Mojo;
 use Test::MockObject;
 
@@ -52,7 +52,8 @@ my @modules = (
     "LANraragi::Plugin::Metadata::RegexParse", "LANraragi::Plugin::Metadata::Fakku",
     "LANraragi::Plugin::Login::EHentai",       "LANraragi::Plugin::Scripts::SourceFinder",
     "LANraragi::Plugin::Scripts::FolderToCat", "LANraragi::Plugin::Download::EHentai",
-    "LANraragi::Plugin::Download::Chaika",     "LANraragi::Plugin::Scripts::Normalizer"
+    "LANraragi::Plugin::Download::Chaika",     "LANraragi::Plugin::Scripts::nHentaiSourceConverter",
+    "LANraragi::Plugin::Scripts::Normalizer"
 );
 
 # Test all modules load properly

--- a/tests/plugins.t
+++ b/tests/plugins.t
@@ -69,7 +69,7 @@ my $test_nH_gID = LANraragi::Plugin::Metadata::nHentai::get_gallery_id_from_titl
 
 is( $test_nH_gID, $nH_gID, 'nHentai search test' );
 
-my $nH_tags = "language:japanese, artist:masamune shirow, full color, non-h, artbook, category:manga";
+my $nH_tags = "language:japanese, artist:masamune shirow, full color, non-h, artbook, category:manga, source: website.net/g/52249";
 my ( $test_nH_tags, $test_nH_title ) = LANraragi::Plugin::Metadata::nHentai::get_tags_from_NH($nH_gID);
 
 is( split( ", ", $test_nH_tags ), split( ", ", $nH_tags ), 'nHentai API Tag retrieval test' );


### PR DESCRIPTION
Also added a small script plugin to convert `source:123456` tags into the full url tags. I just stole code from *The Normalizer* so I don't know if this is the correct way of doing it.