### PR TITLE
Fix checkbox color in Edge and WebView2

### DIFF
--- a/public/css/config.css
+++ b/public/css/config.css
@@ -6,6 +6,7 @@ input[type='checkbox'] {
     font-size:20px;
     cursor:pointer;
     margin-left: 0px;
+    color: inherit;
 }
 
 input[type='checkbox']::before {


### PR DESCRIPTION
Edge with wrong color.
![devenv_2021-09-28_13-54-42](https://user-images.githubusercontent.com/9023392/135205260-d4b6c52a-92b4-4ccd-bccb-b24f2cb25df2.png)
