### PR TITLE
Fix taglist overflowing on stats page

### DIFF
--- a/templates/stats.html.tt2
+++ b/templates/stats.html.tt2
@@ -78,13 +78,12 @@
 				<div class="collapsible-body">
 					<div id="tagList"
 						style="max-width: 80vw; display: flex; height:calc(2048px - 25vw); flex-direction: column; flex-wrap:wrap; align-items:flex-start">
-					</div>
+					</div><br>
 					(These statistics only show tags that appear at least twice in your database.)
 				</div>
 			</li>
 		</ul>
 
-		<br>
 		<br>
 		<input type="button" value="Return to Library" onclick="window.location.replace('./');" class="stdbtn"
 			id="goback">
@@ -116,7 +115,10 @@
 					const namespacedTag = LRR.buildNamespacedTag(tag.namespace, tag.text);
 					const url = LRR.getTagSearchURL(tag.namespace, tag.text);
 
-					let html = `<a href="${url}" class="${tag.namespace}-tag" > ${namespacedTag} <b>(${tag.weight})</b></div><br/>`;
+					const ocss = 'max-width: 95%; display: flex;';
+					const icss = 'text-overflow: ellipsis; white-space: nowrap; overflow: hidden; min-width: 0; max-width: 100%;';
+
+					let html = `<a href="${url}" title="${namespacedTag}" class="${tag.namespace}-tag" style="${ocss}"><span style="${icss}">${namespacedTag}</span>&nbsp;<b>(${tag.weight})</b>`;
 					tagList.append(html);
 				});
 


### PR DESCRIPTION
Before:
![chrome_2021-11-24_20-18-38](https://user-images.githubusercontent.com/1447794/143300670-aef31bd6-8a84-44e1-95c4-291b94d88ed5.png)

After:
![chrome_2021-11-24_20-17-28](https://user-images.githubusercontent.com/1447794/143300695-b7bfbf7a-7444-473f-a28e-576bcfb1cfc9.png)
