### PR TITLE
Fix awesomplete z-index collision with carousel

### DIFF
--- a/public/css/lrr.css
+++ b/public/css/lrr.css
@@ -503,6 +503,10 @@ li {
   margin: 0 !important;
 }
 
+.awesomplete > ul {
+  z-index: 99 !important;
+}
+
 /*Hide elements within the pages on small screens*/
 
 @media all and (max-width: 1000px) {


### PR DESCRIPTION
Fixes this issue:
![chrome_2021-11-24_09-02-16](https://user-images.githubusercontent.com/1447794/143301242-b8a295d2-ee5f-440d-aa1e-0ed614c77b06.png)
