### PR TITLE
Fix .collapsible-title padding override applying outside of carousel

### DIFF
--- a/public/themes/ex.css
+++ b/public/themes/ex.css
@@ -187,7 +187,7 @@ td.itdc{text-align:center;padding:0 1px 0 2px;margin:0;border-right:1px solid #4
     margin-bottom: 2px;
 }
 
-.collapsible-title {
+.index-carousel .collapsible-title {
     padding: 0.5rem;
 }
 

--- a/public/themes/g.css
+++ b/public/themes/g.css
@@ -333,7 +333,7 @@ div#toppane {
     margin-bottom: 2px;
 }
 
-.collapsible-title {
+.index-carousel .collapsible-title {
     padding: 0.5rem;
 }
 


### PR DESCRIPTION
This override has been added in v0.8.2 in order to solve visual issue on carousel, however by applying it globally it decreases size of other collapsible elements, such as settings tiles.