### PR TITLE
Fix tagger input element size on g and ex themes

### DIFF
--- a/public/themes/ex.css
+++ b/public/themes/ex.css
@@ -157,8 +157,10 @@ tr.gtr1{background:#363940}
     background:#34353b;
     border:1px solid #000000;
     max-width: 450px;
+    width: 60%;
     margin: 4px 1px 0;
     font-size: 9pt;
+    display: table-cell;
 }
 
 .searchbtn{min-width: 100px !important;}

--- a/public/themes/g.css
+++ b/public/themes/g.css
@@ -227,8 +227,10 @@ tr.gtr1 {
     border: 1px solid #5C0D11;
     color: #5C0D11;
     max-width: 450px;
+    width: 60%;
     margin: 4px 1px 0;
     font-size: 9pt;
+    display: table-cell;
 }
 
 .searchbtn {


### PR DESCRIPTION
The `.tagger` element on `g.css` and `ex.css` themes is weirdly smaller than rest of inputs. This solves it by adjusting it to the same relative width as title/filename inputs.