### PR TITLE
Add support for parsing timstamp,category,uploader tags to the eze plugin

### DIFF
--- a/lib/LANraragi/Model/Archive.pm
+++ b/lib/LANraragi/Model/Archive.pm
@@ -124,7 +124,7 @@ sub find_untagged_archives {
                 remove_newlines($t);
 
                 # The following are basic and therefore don't count as "tagged"
-                $nondefaulttags += 1 unless $t =~ /(artist|uploader|parody|series|category|language|event|group|date_added|timestamp):.*/;
+                $nondefaulttags += 1 unless $t =~ /(artist|parody|series|language|event|group|date_added|timestamp):.*/;
             }
 
             #If the archive has no tags, or the tags namespaces are only from

--- a/lib/LANraragi/Model/Archive.pm
+++ b/lib/LANraragi/Model/Archive.pm
@@ -124,7 +124,7 @@ sub find_untagged_archives {
                 remove_newlines($t);
 
                 # The following are basic and therefore don't count as "tagged"
-                $nondefaulttags += 1 unless $t =~ /(artist|parody|series|language|event|group|date_added):.*/;
+                $nondefaulttags += 1 unless $t =~ /(artist|uploader|parody|series|category|language|event|group|date_added|timestamp):.*/;
             }
 
             #If the archive has no tags, or the tags namespaces are only from

--- a/lib/LANraragi/Plugin/Metadata/EHentai.pm
+++ b/lib/LANraragi/Plugin/Metadata/EHentai.pm
@@ -35,7 +35,7 @@ sub plugin_info {
             { type => "bool",   desc => "Fetch using thumbnail first (falls back to title)" },
             { type => "bool",   desc => "Use ExHentai (enable to search for fjorded content without star cookie)" },
             {   type => "bool",
-                desc => "Save the original Japanese title when available instead of the English or " . "romanised title"
+                desc => "Save the original title when available instead of the English or romanised title"
             },
             { type => "bool", desc => "Fetch additional timestamp (time posted) and uploader metadata" },
             { type => "bool", desc => "Search expunged galleries as well" },

--- a/lib/LANraragi/Plugin/Metadata/Eze.pm
+++ b/lib/LANraragi/Plugin/Metadata/Eze.pm
@@ -6,6 +6,7 @@ use warnings;
 #Plugins can freely use all Perl packages already installed on the system
 #Try however to restrain yourself to the ones already installed for LRR (see tools/cpanfile) to avoid extra installations by the end-user.
 use Mojo::JSON qw(from_json);
+use Time::Local qw(timelocal_posix timegm_posix);
 
 #You can also use the LRR Internal API when fitting.
 use LANraragi::Model::Plugins;
@@ -23,12 +24,18 @@ sub plugin_info {
         type      => "metadata",
         namespace => "ezeplugin",
         author    => "Difegue",
-        version   => "2.2",
+        version   => "2.3",
         description =>
-          "Collects metadata embedded into your archives as eze-style info.json files. ({'gallery_info': {xxx} } syntax)",
+          "Collects metadata from eze-style info.json file in archives or {archive_name}.json file nearby the archive file. ({'gallery_info': {xxx} } syntax)",
         icon =>
           "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAACXBIWXMAAAsTAAALEwEAmpwYAAAA\nB3RJTUUH4wYCFDYBnHlU6AAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUH\nAAAETUlEQVQ4y22UTWhTWRTHf/d9JHmNJLFpShMcKoRIqxXE4sKpjgthYLCLggU/wI1CUWRUxlmU\nWblw20WZMlJc1yKKKCjCdDdYuqgRiygq2mL8aJpmQot5uabv3XdnUftG0bu593AOv3M45/yvGBgY\n4OrVqwRBgG3bGIaBbduhDSClxPM8tNZMTEwwMTGB53lYloXWmkgkwqdPnygUCljZbJbW1lYqlQqG\nYYRBjuNw9+5dHj16RD6fJ51O09bWxt69e5mammJ5eZm1tTXi8Tiu6xKNRrlx4wZWNBqlXq8Tj8cx\nTRMhBJZlMT4+zuXLlxFCEIvFqFarBEFAKpXCcRzq9TrpdJparcbIyAiHDh1icXERyzAMhBB4nofv\n+5imiWmavHr1inQ6jeM4ZLNZDMMglUqxuLiIlBLXdfn48SNKKXp6eqhUKiQSCaxkMsna2hqe52Hb\nNsMdec3n8+Pn2+vpETt37qSlpYVyucz8/DzT09Ns3bqVYrEIgOM4RCIRrI1MiUQCz/P43vE8jxcv\nXqCUwvM8Zmdn2bJlC6lUitHRUdrb2zFNE9/3sd6/f4/jOLiuSzKZDCH1wV/EzMwM3d3dNN69o729\nnXK5jFKKPXv2sLS0RF9fHydOnMD3fZRSaK0xtNYEQYBpmtTr9RC4b98+LMsCwLZtHj9+TCwWI5/P\nI6Xk5MmTXLhwAaUUG3MA4M6dOzQaDd68eYOUkqHIZj0U2ay11mzfvp1du3YhhGBgYIDjx4/T3d1N\nvV4nCAKklCilcF2XZrOJlBIBcOnSJc6ePYsQgj9yBf1l//7OJcXPH1Y1wK/Ff8SfvT995R9d/SA8\nzyMaja5Xq7Xm1q1bLCwssLS09M1Atm3bFr67urq+8W8oRUqJlBJLCMHNmze5d+8e2Ww2DPyrsSxq\ntRqZTAattZibm6PZbHJFVoUQgtOxtAbwfR8A13WJxWIYANVqFd/36e/v/ypzIpEgCAKEEMzNzYXN\n34CN/FsSvu+jtSaTyeC67jrw4cOHdHZ2kslkQmCz2SQSiYT269evMU0zhF2RVaH1ejt932dlZYXh\n4eF14MLCArZtI6UMAb+1/qBPx9L6jNOmAY4dO/b/agBnnDb9e1un3vhQzp8/z/Xr19eBQgjevn3L\n1NTUd5WilKJQKGAYxje+lpYWrl27xuTk5PqKARSLRfr6+hgaGiKbzfLy5UvGx8dRSqGUwnEcDMNA\nKYUQIlRGNBplZmaGw4cPE4/HOXDgAMbs7Cy9vb1cvHiR+fl5Hjx4QC6XwzAMYrEYz549Y3p6mufP\nn4d6NU0Tx3GYnJzk6NGjNJtNduzYQUdHB+LL8mu1Gv39/WitGRsb4/79+3R1dbF7925yuVw4/Uaj\nwalTpzhy5AhjY2P4vs/BgwdJp9OYG7ByuUwmk6FUKgFw7tw5SqUSlUqFp0+fkkgk2LRpEysrKzx5\n8oTBwUG01ty+fZv9+/eTz+dZXV3lP31rAEu+yXjEAAAAAElFTkSuQmCC",
-        parameters => [ { type => "bool", desc => "Save archive title" } ]
+        parameters => [
+            { type => "bool", desc => "Save archive title" },
+            { type => "bool",
+              desc => "Save the original title when available instead of the English or romanised title"
+            },
+            { type => "bool", desc => "Fetch additional timestamp (time posted) and uploader metadata" },
+        ]
     );
 
 }
@@ -38,10 +45,11 @@ sub get_tags {
 
     shift;
     my $lrr_info = shift;     # Global info hash
-    my ($save_title) = @_;    # Plugin parameters
+    my ($save_title, $origin_title, $additional_tags) = @_;    # Plugin parameters
 
     my $logger = get_plugin_logger();
     my $path_in_archive = is_file_in_archive( $lrr_info->{file_path}, "info.json" );
+
     if ($path_in_archive) {
 
         #Extract info.json
@@ -64,7 +72,7 @@ sub get_tags {
         $logger->debug("Found and loaded the following JSON: $stringjson");
 
         #Parse it
-        my ( $tags, $title ) = tags_from_eze_json($hashjson);
+        my ( $tags, $title ) = tags_from_eze_json($origin_title, $additional_tags, $hashjson);
 
         #Delete it
         unlink $filepath;
@@ -89,7 +97,7 @@ sub get_tags {
 #Goes through the JSON hash obtained from an info.json file and return the contained tags.
 sub tags_from_eze_json {
 
-    my $hash   = $_[0];
+    my ($origin_title, $additional_tags, $hash) = @_;
     my $return = "";
 
     #Tags are in gallery_info -> tags -> one array per namespace
@@ -97,6 +105,11 @@ sub tags_from_eze_json {
 
     # Titles returned by eze are in complete E-H notation.
     my $title = $hash->{"gallery_info"}->{"title"};
+
+    if ($origin_title && $hash->{"gallery_info"}->{"title_original"} ) {
+        $title = $hash->{"gallery_info"}->{"title_original"};
+    }
+
     remove_spaces($title);
 
     foreach my $namespace ( sort keys %$tags ) {
@@ -115,6 +128,30 @@ sub tags_from_eze_json {
     my $site   = $hash->{"gallery_info"}->{"source"}->{"site"};
     my $gid    = $hash->{"gallery_info"}->{"source"}->{"gid"};
     my $gtoken = $hash->{"gallery_info"}->{"source"}->{"token"};
+    my $category = $hash->{"gallery_info"}->{"category"};
+    my $uploader = $hash->{"gallery_info_full"}->{"uploader"};
+    my $timestamp = $hash->{"gallery_info_full"}->{"date_uploaded"};
+
+    if ( $timestamp ) {
+        # convert microsecond to second
+        $timestamp = $timestamp / 1000;
+    } else {
+        my $upload_date = $hash->{"gallery_info"}->{"upload_date"};
+        my $time = timegm_posix($$upload_date[5],$$upload_date[4],$$upload_date[3],$$upload_date[2],$$upload_date[1]-1,$$upload_date[0]-1900);
+        $timestamp = $time;
+    }
+
+    if ( $category ) {
+        $return .= ", category:$category";
+    }
+
+    if ( $additional_tags && $uploader ) {
+        $return .= ", uploader:$uploader";
+    }
+
+    if ( $additional_tags && $timestamp ) {
+        $return .= ", timestamp:$timestamp";
+    }
 
     if ( $site && $gid && $gtoken ) {
         $return .= ", source:$site.org/g/$gid/$gtoken";

--- a/lib/LANraragi/Plugin/Metadata/Eze.pm
+++ b/lib/LANraragi/Plugin/Metadata/Eze.pm
@@ -6,7 +6,7 @@ use warnings;
 #Plugins can freely use all Perl packages already installed on the system
 #Try however to restrain yourself to the ones already installed for LRR (see tools/cpanfile) to avoid extra installations by the end-user.
 use Mojo::JSON qw(from_json);
-use Time::Local qw(timelocal_posix timegm_posix);
+use Time::Local qw(timegm_modern);
 
 #You can also use the LRR Internal API when fitting.
 use LANraragi::Model::Plugins;
@@ -137,7 +137,7 @@ sub tags_from_eze_json {
         $timestamp = $timestamp / 1000;
     } else {
         my $upload_date = $hash->{"gallery_info"}->{"upload_date"};
-        my $time = timegm_posix($$upload_date[5],$$upload_date[4],$$upload_date[3],$$upload_date[2],$$upload_date[1]-1,$$upload_date[0]-1900);
+        my $time = timegm_modern($$upload_date[5],$$upload_date[4],$$upload_date[3],$$upload_date[2],$$upload_date[1]-1,$$upload_date[0]);
         $timestamp = $time;
     }
 

--- a/lib/LANraragi/Plugin/Metadata/Eze.pm
+++ b/lib/LANraragi/Plugin/Metadata/Eze.pm
@@ -88,7 +88,7 @@ sub get_tags {
     $logger->debug("Loaded the following JSON: $stringjson");
 
     #Parse it
-    my ( $tags, $title ) = tags_from_eze_json($hashjson);
+    my ( $tags, $title ) = tags_from_eze_json($origin_title, $additional_tags, $hashjson);
 
     if ($delete_after_parse){
         #Delete it

--- a/tests/LANraragi/Plugin/Metadata/Eze.t
+++ b/tests/LANraragi/Plugin/Metadata/Eze.t
@@ -29,17 +29,15 @@ sub test_eze {
     # Mock LANraragi::Utils::Archive's subs to return the temporary sample JSON
     # Since we're using exports, the methods are under the plugin's namespace.
     no warnings 'once', 'redefine';
-    local *LANraragi::Plugin::Metadata::Eze::get_plugin_logger         = sub { return get_logger_mock(); };
-    local *LANraragi::Plugin::Metadata::Eze::extract_file_from_archive = sub { $filename };
-    local *LANraragi::Plugin::Metadata::Eze::is_file_in_archive        = sub { 1 };
+    local *LANraragi::Plugin::Metadata::Eze::get_plugin_logger      = sub { return get_logger_mock(); };
+    local *LANraragi::Plugin::Metadata::Eze::path_in_archive        = sub { 0 };
+    local *LANraragi::Plugin::Metadata::Eze::path_nearby_json       = sub { $filename };
 
-    my %dummyhash = ( something => 22, file_path => "test" );
+    my %dummyhash = ( something => 42, file_path => "dummy" );
 
     # Since this is calling the sub directly and not in an object context,
     # we pass a dummy string as first parameter to replace the object.
-    my ( $tags, $title ) = trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, $save_title, $origin_title, $additional_tags ); };
-
-    return ( tags => $tags, title => $title );
+    return trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, $save_title, $origin_title, $additional_tags ); };
 
 }
 
@@ -50,11 +48,11 @@ note("eze-lite Tests, save_title on, origin_title on, additional_tags on");
 
     is( $ezetags{title},
         "(C72) [Mitarashi Club (Mitarashi Kousei)] Akiko-san to Issho (Kanon) [English] [Belldandy100] [Decensored]",
-        "eze-lite Tests, save_title on, origin_title on, additional_tags on parsing test 1/2"
+        "title parsing test 1/2"
     );
     is( $ezetags{tags}, 
         "artist:mitarashi kousei, character:akiko minase, character:yuuichi aizawa, female:aunt, female:lingerie, female:sole female, group:mitarashi club, language:english, language:translated, male:sole male, misc:multi-work series, parody:kanon, timestamp:1517540580, source:website.org/g/1179590/7c5815c77b",
-        "eze-lite Tests, save_title on, origin_title on, additional_tags on parsing test 2/2"
+        "tags parsing test 2/2"
     );
 }
 
@@ -65,11 +63,11 @@ note("eze-full Tests, save_title off, origin_title off, additional_tags off");
 
     is( $ezetags{title},
         undef,
-        "eze-full Tests, save_title off, origin_title off, additional_tags off parsing test 1/2"
+        "title parsing test 1/2"
     );
     is( $ezetags{tags},
         "artist:hiten, female:defloration, female:pantyhose, female:sole female, group:hitenkei, language:chinese, language:translated, male:sole male, parody:original, category:doujinshi, source:exhentai.org/g/1017975/49b3c275a1",
-        "eze-full Tests, save_title off, origin_title off, additional_tags off parsing test 2/2"
+        "tags parsing test 2/2"
     );
 }
 
@@ -80,11 +78,11 @@ note("eze-full Tests, save_title on, origin_title off, additional_tags on");
 
     is( $ezetags{title},
         "(C91) [HitenKei (Hiten)] R.E.I.N.A [Chinese] [無邪気漢化組]",
-        "eze-full Tests, save_title on, origin_title off, additional_tags on parsing test 1/2"
+        "title parsing test 1/2"
     );
     is( $ezetags{tags},
         "artist:hiten, female:defloration, female:pantyhose, female:sole female, group:hitenkei, language:chinese, language:translated, male:sole male, parody:original, category:doujinshi, uploader:cocy, timestamp:1484412360, source:exhentai.org/g/1017975/49b3c275a1",
-        "eze-full Tests, save_title on, origin_title off, additional_tags on parsing test 2/2"
+        "tags parsing test 2/2"
     );
 }
 
@@ -95,11 +93,11 @@ note("eze-full Tests, save_title on, origin_title on, additional_tags on");
 
     is( $ezetags{title},
         "(C91) [HitenKei (Hiten)] R.E.I.N.A [中国翻訳]",
-        "eze-full Tests, save_title on, origin_title on, additional_tags on parsing test 1/2"
+        "title parsing test 1/2"
     );
     is( $ezetags{tags},
         "artist:hiten, female:defloration, female:pantyhose, female:sole female, group:hitenkei, language:chinese, language:translated, male:sole male, parody:original, category:doujinshi, uploader:cocy, timestamp:1484412360, source:exhentai.org/g/1017975/49b3c275a1",
-        "eze-full Tests, save_title on, origin_title on, additional_tags on parsing test 2/2"
+        "tags parsing test 2/2"
     );
 }
 

--- a/tests/LANraragi/Plugin/Metadata/Eze.t
+++ b/tests/LANraragi/Plugin/Metadata/Eze.t
@@ -18,12 +18,14 @@ require "$cwd/tests/mocks.pl";
 
 use_ok('LANraragi::Plugin::Metadata::Eze');
 
-note("eze-lite Tests, with save original title but no original title exist");
-{
+sub test_eze {
+
+    my ($jsonpath, $save_title, $origin_title, $additional_tags) = @_;
+
     # Copy the eze sample json to a temporary directory as it's deleted once parsed
     my ( $fh, $filename ) = tempfile();
-    cp( $SAMPLES . "/eze/eze_lite_sample.json", $fh );
-
+    cp( $SAMPLES . $jsonpath, $fh );
+    
     # Mock LANraragi::Utils::Archive's subs to return the temporary sample JSON
     # Since we're using exports, the methods are under the plugin's namespace.
     no warnings 'once', 'redefine';
@@ -32,114 +34,73 @@ note("eze-lite Tests, with save original title but no original title exist");
     local *LANraragi::Plugin::Metadata::Eze::is_file_in_archive        = sub { 1 };
 
     my %dummyhash = ( something => 22, file_path => "test" );
-    my $save_title = 1;
-    my $origin_title = 1;
-    my $additional_tags = 1;
 
     # Since this is calling the sub directly and not in an object context,
     # we pass a dummy string as first parameter to replace the object.
-    my %ezetags = trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, $save_title, $origin_title, $additional_tags ); };
+    my ( $tags, $title ) = trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, $save_title, $origin_title, $additional_tags ); };
 
-    my $ezetags =
-      "artist:mitarashi kousei, character:akiko minase, character:yuuichi aizawa, female:aunt, female:lingerie, female:sole female, group:mitarashi club, language:english, language:translated, male:sole male, misc:multi-work series, parody:kanon, timestamp:1517540580, source:website.org/g/1179590/7c5815c77b";
+    return ( tags => $tags, title => $title );
+
+}
+
+note("eze-lite Tests, save_title on, origin_title on, additional_tags on");
+{
+    
+    my %ezetags = test_eze("/eze/eze_lite_sample.json", 1, 1, 1);
+
     is( $ezetags{title},
         "(C72) [Mitarashi Club (Mitarashi Kousei)] Akiko-san to Issho (Kanon) [English] [Belldandy100] [Decensored]",
-        "eze-lite, with save original title but no original title exist parsing test 1/2"
+        "eze-lite Tests, save_title on, origin_title on, additional_tags on parsing test 1/2"
     );
-    is( $ezetags{tags}, $ezetags, "eze-lite, with save original title but no original title exist parsing test 2/2" );
+    is( $ezetags{tags}, 
+        "artist:mitarashi kousei, character:akiko minase, character:yuuichi aizawa, female:aunt, female:lingerie, female:sole female, group:mitarashi club, language:english, language:translated, male:sole male, misc:multi-work series, parody:kanon, timestamp:1517540580, source:website.org/g/1179590/7c5815c77b",
+        "eze-lite Tests, save_title on, origin_title on, additional_tags on parsing test 2/2"
+    );
 }
 
-note("eze-full Tests without 'save_title', without 'additional_tags'");
+note("eze-full Tests, save_title off, origin_title off, additional_tags off");
 {
-    # Copy the eze sample json to a temporary directory as it's deleted once parsed
-    my ( $fh, $filename ) = tempfile();
-    cp( $SAMPLES . "/eze/eze_full_sample.json", $fh );
+        
+    my %ezetags = test_eze("/eze/eze_full_sample.json", 0, 0, 0);
 
-    # Mock LANraragi::Utils::Archive's subs to return the temporary sample JSON
-    # Since we're using exports, the methods are under the plugin's namespace.
-    no warnings 'once', 'redefine';
-    local *LANraragi::Plugin::Metadata::Eze::get_plugin_logger         = sub { return get_logger_mock(); };
-    local *LANraragi::Plugin::Metadata::Eze::extract_file_from_archive = sub { $filename };
-    local *LANraragi::Plugin::Metadata::Eze::is_file_in_archive        = sub { 1 };
-
-    my %dummyhash = ( something => 22, file_path => "test" );
-    my $save_title = 0;
-    my $origin_title = 0;
-    my $additional_tags = 0;
-
-    # Since this is calling the sub directly and not in an object context,
-    # we pass a dummy string as first parameter to replace the object.
-    my %ezetags = trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, $save_title, $origin_title, $additional_tags ); };
-
-    my $ezetags =
-      "artist:hiten, female:defloration, female:pantyhose, female:sole female, group:hitenkei, language:chinese, language:translated, male:sole male, parody:original, category:doujinshi, source:exhentai.org/g/1017975/49b3c275a1";
-    is( !$ezetags{title},
-        1,
-        "eze-full without 'save_title', without 'additional_tags' parsing test 1/2"
+    is( $ezetags{title},
+        undef,
+        "eze-full Tests, save_title off, origin_title off, additional_tags off parsing test 1/2"
     );
-    is( $ezetags{tags}, $ezetags, "eze-full without 'save_title', without 'additional_tags' parsing test 2/2" );
+    is( $ezetags{tags},
+        "artist:hiten, female:defloration, female:pantyhose, female:sole female, group:hitenkei, language:chinese, language:translated, male:sole male, parody:original, category:doujinshi, source:exhentai.org/g/1017975/49b3c275a1",
+        "eze-full Tests, save_title off, origin_title off, additional_tags off parsing test 2/2"
+    );
 }
 
-note("eze-full Tests with 'save_title', with 'additional_tags'");
+note("eze-full Tests, save_title on, origin_title off, additional_tags on");
 {
-    # Copy the eze sample json to a temporary directory as it's deleted once parsed
-    my ( $fh, $filename ) = tempfile();
-    cp( $SAMPLES . "/eze/eze_full_sample.json", $fh );
+        
+    my %ezetags = test_eze("/eze/eze_full_sample.json", 1, 0, 1);
 
-    # Mock LANraragi::Utils::Archive's subs to return the temporary sample JSON
-    # Since we're using exports, the methods are under the plugin's namespace.
-    no warnings 'once', 'redefine';
-    local *LANraragi::Plugin::Metadata::Eze::get_plugin_logger         = sub { return get_logger_mock(); };
-    local *LANraragi::Plugin::Metadata::Eze::extract_file_from_archive = sub { $filename };
-    local *LANraragi::Plugin::Metadata::Eze::is_file_in_archive        = sub { 1 };
-
-    my %dummyhash = ( something => 22, file_path => "test" );
-    my $save_title = 1;
-    my $origin_title = 0;
-    my $additional_tags = 1;
-
-    # Since this is calling the sub directly and not in an object context,
-    # we pass a dummy string as first parameter to replace the object.
-    my %ezetags = trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, $save_title, $origin_title, $additional_tags ); };
-
-    my $ezetags =
-      "artist:hiten, female:defloration, female:pantyhose, female:sole female, group:hitenkei, language:chinese, language:translated, male:sole male, parody:original, category:doujinshi, uploader:cocy, timestamp:1484412360, source:exhentai.org/g/1017975/49b3c275a1";
     is( $ezetags{title},
         "(C91) [HitenKei (Hiten)] R.E.I.N.A [Chinese] [無邪気漢化組]",
-        "eze-full with 'save_title', with 'additional_tags' parsing test 1/2"
+        "eze-full Tests, save_title on, origin_title off, additional_tags on parsing test 1/2"
     );
-    is( $ezetags{tags}, $ezetags, "eze-full with 'save_title', with 'additional_tags' parsing test 2/2" );
+    is( $ezetags{tags},
+        "artist:hiten, female:defloration, female:pantyhose, female:sole female, group:hitenkei, language:chinese, language:translated, male:sole male, parody:original, category:doujinshi, uploader:cocy, timestamp:1484412360, source:exhentai.org/g/1017975/49b3c275a1",
+        "eze-full Tests, save_title on, origin_title off, additional_tags on parsing test 2/2"
+    );
 }
 
-note("eze-full Tests with save original title, with 'additional_tags'");
+note("eze-full Tests, save_title on, origin_title on, additional_tags on");
 {
-    # Copy the eze sample json to a temporary directory as it's deleted once parsed
-    my ( $fh, $filename ) = tempfile();
-    cp( $SAMPLES . "/eze/eze_full_sample.json", $fh );
+        
+    my %ezetags = test_eze("/eze/eze_full_sample.json", 1, 1, 1);
 
-    # Mock LANraragi::Utils::Archive's subs to return the temporary sample JSON
-    # Since we're using exports, the methods are under the plugin's namespace.
-    no warnings 'once', 'redefine';
-    local *LANraragi::Plugin::Metadata::Eze::get_plugin_logger         = sub { return get_logger_mock(); };
-    local *LANraragi::Plugin::Metadata::Eze::extract_file_from_archive = sub { $filename };
-    local *LANraragi::Plugin::Metadata::Eze::is_file_in_archive        = sub { 1 };
-
-    my %dummyhash = ( something => 22, file_path => "test" );
-    my $save_title = 1;
-    my $origin_title = 1;
-    my $additional_tags = 1;
-
-    # Since this is calling the sub directly and not in an object context,
-    # we pass a dummy string as first parameter to replace the object.
-    my %ezetags = trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, $save_title, $origin_title, $additional_tags ); };
-
-    my $ezetags =
-      "artist:hiten, female:defloration, female:pantyhose, female:sole female, group:hitenkei, language:chinese, language:translated, male:sole male, parody:original, category:doujinshi, uploader:cocy, timestamp:1484412360, source:exhentai.org/g/1017975/49b3c275a1";
     is( $ezetags{title},
         "(C91) [HitenKei (Hiten)] R.E.I.N.A [中国翻訳]",
-        "eze-full with save original title, with 'additional_tags' parsing test 1/2"
+        "eze-full Tests, save_title on, origin_title on, additional_tags on parsing test 1/2"
     );
-    is( $ezetags{tags}, $ezetags, "eze-full with save original title, with 'additional_tags' parsing test 2/2" );
+    is( $ezetags{tags},
+        "artist:hiten, female:defloration, female:pantyhose, female:sole female, group:hitenkei, language:chinese, language:translated, male:sole male, parody:original, category:doujinshi, uploader:cocy, timestamp:1484412360, source:exhentai.org/g/1017975/49b3c275a1",
+        "eze-full Tests, save_title on, origin_title on, additional_tags on parsing test 2/2"
+    );
 }
 
 done_testing();

--- a/tests/LANraragi/Plugin/Metadata/Eze.t
+++ b/tests/LANraragi/Plugin/Metadata/Eze.t
@@ -18,11 +18,13 @@ require "$cwd/tests/mocks.pl";
 
 use_ok('LANraragi::Plugin::Metadata::Eze');
 
-note("eze-lite Tests, save_title on, origin_title off, additional_tags off");
-{
+sub eve_test {
+    
+    my ($jsonpath, $save_title, $origin_title, $additional_tags) = @_;
+
     # Copy the eze sample json to a temporary directory as it's deleted once parsed
     my ( $fh, $filename ) = tempfile();
-    cp( $SAMPLES . "/eze/eze_lite_sample.json", $fh );
+    cp( $SAMPLES . $jsonpath , $fh );
 
     # Mock LANraragi::Utils::Archive's subs to return the temporary sample JSON
     # Since we're using exports, the methods are under the plugin's namespace.
@@ -35,7 +37,19 @@ note("eze-lite Tests, save_title on, origin_title off, additional_tags off");
 
     # Since this is calling the sub directly and not in an object context,
     # we pass a dummy string as first parameter to replace the object.
-    my %ezetags = trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, 1, 0, 0 ); };
+    my %ezetags = trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, $save_title, $origin_title, $additional_tags ); };
+
+    return %ezetags;
+
+}
+
+note("eze-lite Tests, save_title on, origin_title off, additional_tags off");
+{
+    my $save_title = 1;
+    my $origin_title = 0;
+    my $additional_tags = 0;
+    
+    my %ezetags = eve_test("/eze/eze_lite_sample.json", $save_title, $origin_title, $additional_tags);
 
     is( $ezetags{title},
         "(C72) [Mitarashi Club (Mitarashi Kousei)] Akiko-san to Issho (Kanon) [English] [Belldandy100] [Decensored]",
@@ -50,25 +64,11 @@ note("eze-lite Tests, save_title on, origin_title off, additional_tags off");
 
 note("eze-lite Tests, save_title on, origin_title on, additional_tags on");
 {
-    # Copy the eze sample json to a temporary directory as it's deleted once parsed
-    my ( $fh, $filename ) = tempfile();
-    cp( $SAMPLES . "/eze/eze_lite_sample.json", $fh );
-
-    # Mock LANraragi::Utils::Archive's subs to return the temporary sample JSON
-    # Since we're using exports, the methods are under the plugin's namespace.
-    no warnings 'once', 'redefine';
-    local *LANraragi::Plugin::Metadata::Eze::get_plugin_logger         = sub { return get_logger_mock(); };
-    local *LANraragi::Plugin::Metadata::Eze::extract_file_from_archive = sub { $filename };
-    local *LANraragi::Plugin::Metadata::Eze::is_file_in_archive        = sub { 1 };
-
-    my %dummyhash = ( something => 42, file_path => "dummy" );
     my $save_title = 1;
     my $origin_title = 1;
     my $additional_tags = 1;
-
-    # Since this is calling the sub directly and not in an object context,
-    # we pass a dummy string as first parameter to replace the object.
-    my %ezetags = trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, $save_title, $origin_title, $additional_tags ); };
+    
+    my %ezetags = eve_test("/eze/eze_lite_sample.json", $save_title, $origin_title, $additional_tags);
 
     is( $ezetags{title},
         "(C72) [Mitarashi Club (Mitarashi Kousei)] Akiko-san to Issho (Kanon) [English] [Belldandy100] [Decensored]",
@@ -76,31 +76,17 @@ note("eze-lite Tests, save_title on, origin_title on, additional_tags on");
     );
     is( $ezetags{tags},
         "artist:mitarashi kousei, character:akiko minase, character:yuuichi aizawa, female:aunt, female:lingerie, female:sole female, group:mitarashi club, language:english, language:translated, male:sole male, misc:multi-work series, parody:kanon, timestamp:1517540580, source:website.org/g/1179590/7c5815c77b",
-        "tags parsing test 1/2"
+        "tags parsing test 2/2"
     );
 }
 
 note("eze-full Tests, save_title off, origin_title off, additional_tags off");
 {
-    # Copy the eze sample json to a temporary directory as it's deleted once parsed
-    my ( $fh, $filename ) = tempfile();
-    cp( $SAMPLES . "/eze/eze_full_sample.json", $fh );
-
-    # Mock LANraragi::Utils::Archive's subs to return the temporary sample JSON
-    # Since we're using exports, the methods are under the plugin's namespace.
-    no warnings 'once', 'redefine';
-    local *LANraragi::Plugin::Metadata::Eze::get_plugin_logger         = sub { return get_logger_mock(); };
-    local *LANraragi::Plugin::Metadata::Eze::extract_file_from_archive = sub { $filename };
-    local *LANraragi::Plugin::Metadata::Eze::is_file_in_archive        = sub { 1 };
-
-    my %dummyhash = ( something => 42, file_path => "dummy" );
     my $save_title = 0;
     my $origin_title = 0;
     my $additional_tags = 0;
-
-    # Since this is calling the sub directly and not in an object context,
-    # we pass a dummy string as first parameter to replace the object.
-    my %ezetags = trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, $save_title, $origin_title, $additional_tags ); };
+    
+    my %ezetags = eve_test("/eze/eze_full_sample.json", $save_title, $origin_title, $additional_tags);
 
     is( $ezetags{title},
         undef,
@@ -108,31 +94,17 @@ note("eze-full Tests, save_title off, origin_title off, additional_tags off");
     );
     is( $ezetags{tags},
         "artist:hiten, female:defloration, female:pantyhose, female:sole female, group:hitenkei, language:chinese, language:translated, male:sole male, parody:original, category:doujinshi, source:exhentai.org/g/1017975/49b3c275a1",
-        "tags parsing test 1/2"
+        "tags parsing test 2/2"
     );
 }
 
 note("eze-full Tests, save_title on, origin_title off, additional_tags on");
 {
-    # Copy the eze sample json to a temporary directory as it's deleted once parsed
-    my ( $fh, $filename ) = tempfile();
-    cp( $SAMPLES . "/eze/eze_full_sample.json", $fh );
-
-    # Mock LANraragi::Utils::Archive's subs to return the temporary sample JSON
-    # Since we're using exports, the methods are under the plugin's namespace.
-    no warnings 'once', 'redefine';
-    local *LANraragi::Plugin::Metadata::Eze::get_plugin_logger         = sub { return get_logger_mock(); };
-    local *LANraragi::Plugin::Metadata::Eze::extract_file_from_archive = sub { $filename };
-    local *LANraragi::Plugin::Metadata::Eze::is_file_in_archive        = sub { 1 };
-
-    my %dummyhash = ( something => 42, file_path => "dummy" );
     my $save_title = 1;
     my $origin_title = 0;
     my $additional_tags = 1;
-
-    # Since this is calling the sub directly and not in an object context,
-    # we pass a dummy string as first parameter to replace the object.
-    my %ezetags = trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, $save_title, $origin_title, $additional_tags ); };
+    
+    my %ezetags = eve_test("/eze/eze_full_sample.json", $save_title, $origin_title, $additional_tags);
 
     is( $ezetags{title},
         "(C91) [HitenKei (Hiten)] R.E.I.N.A [Chinese] [無邪気漢化組]",
@@ -140,31 +112,17 @@ note("eze-full Tests, save_title on, origin_title off, additional_tags on");
     );
     is( $ezetags{tags},
         "artist:hiten, female:defloration, female:pantyhose, female:sole female, group:hitenkei, language:chinese, language:translated, male:sole male, parody:original, category:doujinshi, uploader:cocy, timestamp:1484412360, source:exhentai.org/g/1017975/49b3c275a1",
-        "tags parsing test 1/2"
+        "tags parsing test 2/2"
     );
 }
 
 note("eze-full Tests, save_title on, origin_title on, additional_tags on");
 {
-    # Copy the eze sample json to a temporary directory as it's deleted once parsed
-    my ( $fh, $filename ) = tempfile();
-    cp( $SAMPLES . "/eze/eze_full_sample.json", $fh );
-
-    # Mock LANraragi::Utils::Archive's subs to return the temporary sample JSON
-    # Since we're using exports, the methods are under the plugin's namespace.
-    no warnings 'once', 'redefine';
-    local *LANraragi::Plugin::Metadata::Eze::get_plugin_logger         = sub { return get_logger_mock(); };
-    local *LANraragi::Plugin::Metadata::Eze::extract_file_from_archive = sub { $filename };
-    local *LANraragi::Plugin::Metadata::Eze::is_file_in_archive        = sub { 1 };
-
-    my %dummyhash = ( something => 42, file_path => "dummy" );
     my $save_title = 1;
     my $origin_title = 1;
     my $additional_tags = 1;
-
-    # Since this is calling the sub directly and not in an object context,
-    # we pass a dummy string as first parameter to replace the object.
-    my %ezetags = trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, $save_title, $origin_title, $additional_tags ); };
+    
+    my %ezetags = eve_test("/eze/eze_full_sample.json", $save_title, $origin_title, $additional_tags);
 
     is( $ezetags{title},
         "(C91) [HitenKei (Hiten)] R.E.I.N.A [中国翻訳]",
@@ -172,7 +130,7 @@ note("eze-full Tests, save_title on, origin_title on, additional_tags on");
     );
     is( $ezetags{tags},
         "artist:hiten, female:defloration, female:pantyhose, female:sole female, group:hitenkei, language:chinese, language:translated, male:sole male, parody:original, category:doujinshi, uploader:cocy, timestamp:1484412360, source:exhentai.org/g/1017975/49b3c275a1",
-        "tags parsing test 1/2"
+        "tags parsing test 2/2"
     );
 }
 

--- a/tests/LANraragi/Plugin/Metadata/Eze.t
+++ b/tests/LANraragi/Plugin/Metadata/Eze.t
@@ -18,48 +18,89 @@ require "$cwd/tests/mocks.pl";
 
 use_ok('LANraragi::Plugin::Metadata::Eze');
 
-sub test_eze {
-
-    my ($jsonpath, $save_title, $origin_title, $additional_tags) = @_;
-
+note("eze-lite Tests, save_title on, origin_title off, additional_tags off");
+{
     # Copy the eze sample json to a temporary directory as it's deleted once parsed
     my ( $fh, $filename ) = tempfile();
-    cp( $SAMPLES . $jsonpath, $fh );
-    
+    cp( $SAMPLES . "/eze/eze_lite_sample.json", $fh );
+
     # Mock LANraragi::Utils::Archive's subs to return the temporary sample JSON
     # Since we're using exports, the methods are under the plugin's namespace.
     no warnings 'once', 'redefine';
-    local *LANraragi::Plugin::Metadata::Eze::get_plugin_logger      = sub { return get_logger_mock(); };
-    local *LANraragi::Plugin::Metadata::Eze::path_in_archive        = sub { 0 };
-    local *LANraragi::Plugin::Metadata::Eze::path_nearby_json       = sub { $filename };
+    local *LANraragi::Plugin::Metadata::Eze::get_plugin_logger         = sub { return get_logger_mock(); };
+    local *LANraragi::Plugin::Metadata::Eze::extract_file_from_archive = sub { $filename };
+    local *LANraragi::Plugin::Metadata::Eze::is_file_in_archive        = sub { 1 };
 
     my %dummyhash = ( something => 42, file_path => "dummy" );
 
     # Since this is calling the sub directly and not in an object context,
     # we pass a dummy string as first parameter to replace the object.
-    return trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, $save_title, $origin_title, $additional_tags ); };
-
-}
-
-note("eze-lite Tests, save_title on, origin_title on, additional_tags on");
-{
-    
-    my %ezetags = test_eze("/eze/eze_lite_sample.json", 1, 1, 1);
+    my %ezetags = trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, 1, 0, 0 ); };
 
     is( $ezetags{title},
         "(C72) [Mitarashi Club (Mitarashi Kousei)] Akiko-san to Issho (Kanon) [English] [Belldandy100] [Decensored]",
         "title parsing test 1/2"
     );
-    is( $ezetags{tags}, 
-        "artist:mitarashi kousei, character:akiko minase, character:yuuichi aizawa, female:aunt, female:lingerie, female:sole female, group:mitarashi club, language:english, language:translated, male:sole male, misc:multi-work series, parody:kanon, timestamp:1517540580, source:website.org/g/1179590/7c5815c77b",
+    is( $ezetags{tags},
+        "artist:mitarashi kousei, character:akiko minase, character:yuuichi aizawa, female:aunt, female:lingerie, female:sole female, group:mitarashi club, language:english, language:translated, male:sole male, misc:multi-work series, parody:kanon, source:website.org/g/1179590/7c5815c77b",
         "tags parsing test 2/2"
+    );
+}
+
+
+note("eze-lite Tests, save_title on, origin_title on, additional_tags on");
+{
+    # Copy the eze sample json to a temporary directory as it's deleted once parsed
+    my ( $fh, $filename ) = tempfile();
+    cp( $SAMPLES . "/eze/eze_lite_sample.json", $fh );
+
+    # Mock LANraragi::Utils::Archive's subs to return the temporary sample JSON
+    # Since we're using exports, the methods are under the plugin's namespace.
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::Eze::get_plugin_logger         = sub { return get_logger_mock(); };
+    local *LANraragi::Plugin::Metadata::Eze::extract_file_from_archive = sub { $filename };
+    local *LANraragi::Plugin::Metadata::Eze::is_file_in_archive        = sub { 1 };
+
+    my %dummyhash = ( something => 42, file_path => "dummy" );
+    my $save_title = 1;
+    my $origin_title = 1;
+    my $additional_tags = 1;
+
+    # Since this is calling the sub directly and not in an object context,
+    # we pass a dummy string as first parameter to replace the object.
+    my %ezetags = trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, $save_title, $origin_title, $additional_tags ); };
+
+    is( $ezetags{title},
+        "(C72) [Mitarashi Club (Mitarashi Kousei)] Akiko-san to Issho (Kanon) [English] [Belldandy100] [Decensored]",
+        "title parsing test 1/2"
+    );
+    is( $ezetags{tags},
+        "artist:mitarashi kousei, character:akiko minase, character:yuuichi aizawa, female:aunt, female:lingerie, female:sole female, group:mitarashi club, language:english, language:translated, male:sole male, misc:multi-work series, parody:kanon, timestamp:1517540580, source:website.org/g/1179590/7c5815c77b",
+        "tags parsing test 1/2"
     );
 }
 
 note("eze-full Tests, save_title off, origin_title off, additional_tags off");
 {
-        
-    my %ezetags = test_eze("/eze/eze_full_sample.json", 0, 0, 0);
+    # Copy the eze sample json to a temporary directory as it's deleted once parsed
+    my ( $fh, $filename ) = tempfile();
+    cp( $SAMPLES . "/eze/eze_full_sample.json", $fh );
+
+    # Mock LANraragi::Utils::Archive's subs to return the temporary sample JSON
+    # Since we're using exports, the methods are under the plugin's namespace.
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::Eze::get_plugin_logger         = sub { return get_logger_mock(); };
+    local *LANraragi::Plugin::Metadata::Eze::extract_file_from_archive = sub { $filename };
+    local *LANraragi::Plugin::Metadata::Eze::is_file_in_archive        = sub { 1 };
+
+    my %dummyhash = ( something => 42, file_path => "dummy" );
+    my $save_title = 0;
+    my $origin_title = 0;
+    my $additional_tags = 0;
+
+    # Since this is calling the sub directly and not in an object context,
+    # we pass a dummy string as first parameter to replace the object.
+    my %ezetags = trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, $save_title, $origin_title, $additional_tags ); };
 
     is( $ezetags{title},
         undef,
@@ -67,14 +108,31 @@ note("eze-full Tests, save_title off, origin_title off, additional_tags off");
     );
     is( $ezetags{tags},
         "artist:hiten, female:defloration, female:pantyhose, female:sole female, group:hitenkei, language:chinese, language:translated, male:sole male, parody:original, category:doujinshi, source:exhentai.org/g/1017975/49b3c275a1",
-        "tags parsing test 2/2"
+        "tags parsing test 1/2"
     );
 }
 
 note("eze-full Tests, save_title on, origin_title off, additional_tags on");
 {
-        
-    my %ezetags = test_eze("/eze/eze_full_sample.json", 1, 0, 1);
+    # Copy the eze sample json to a temporary directory as it's deleted once parsed
+    my ( $fh, $filename ) = tempfile();
+    cp( $SAMPLES . "/eze/eze_full_sample.json", $fh );
+
+    # Mock LANraragi::Utils::Archive's subs to return the temporary sample JSON
+    # Since we're using exports, the methods are under the plugin's namespace.
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::Eze::get_plugin_logger         = sub { return get_logger_mock(); };
+    local *LANraragi::Plugin::Metadata::Eze::extract_file_from_archive = sub { $filename };
+    local *LANraragi::Plugin::Metadata::Eze::is_file_in_archive        = sub { 1 };
+
+    my %dummyhash = ( something => 42, file_path => "dummy" );
+    my $save_title = 1;
+    my $origin_title = 0;
+    my $additional_tags = 1;
+
+    # Since this is calling the sub directly and not in an object context,
+    # we pass a dummy string as first parameter to replace the object.
+    my %ezetags = trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, $save_title, $origin_title, $additional_tags ); };
 
     is( $ezetags{title},
         "(C91) [HitenKei (Hiten)] R.E.I.N.A [Chinese] [無邪気漢化組]",
@@ -82,14 +140,31 @@ note("eze-full Tests, save_title on, origin_title off, additional_tags on");
     );
     is( $ezetags{tags},
         "artist:hiten, female:defloration, female:pantyhose, female:sole female, group:hitenkei, language:chinese, language:translated, male:sole male, parody:original, category:doujinshi, uploader:cocy, timestamp:1484412360, source:exhentai.org/g/1017975/49b3c275a1",
-        "tags parsing test 2/2"
+        "tags parsing test 1/2"
     );
 }
 
 note("eze-full Tests, save_title on, origin_title on, additional_tags on");
 {
-        
-    my %ezetags = test_eze("/eze/eze_full_sample.json", 1, 1, 1);
+    # Copy the eze sample json to a temporary directory as it's deleted once parsed
+    my ( $fh, $filename ) = tempfile();
+    cp( $SAMPLES . "/eze/eze_full_sample.json", $fh );
+
+    # Mock LANraragi::Utils::Archive's subs to return the temporary sample JSON
+    # Since we're using exports, the methods are under the plugin's namespace.
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::Eze::get_plugin_logger         = sub { return get_logger_mock(); };
+    local *LANraragi::Plugin::Metadata::Eze::extract_file_from_archive = sub { $filename };
+    local *LANraragi::Plugin::Metadata::Eze::is_file_in_archive        = sub { 1 };
+
+    my %dummyhash = ( something => 42, file_path => "dummy" );
+    my $save_title = 1;
+    my $origin_title = 1;
+    my $additional_tags = 1;
+
+    # Since this is calling the sub directly and not in an object context,
+    # we pass a dummy string as first parameter to replace the object.
+    my %ezetags = trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, $save_title, $origin_title, $additional_tags ); };
 
     is( $ezetags{title},
         "(C91) [HitenKei (Hiten)] R.E.I.N.A [中国翻訳]",
@@ -97,7 +172,7 @@ note("eze-full Tests, save_title on, origin_title on, additional_tags on");
     );
     is( $ezetags{tags},
         "artist:hiten, female:defloration, female:pantyhose, female:sole female, group:hitenkei, language:chinese, language:translated, male:sole male, parody:original, category:doujinshi, uploader:cocy, timestamp:1484412360, source:exhentai.org/g/1017975/49b3c275a1",
-        "tags parsing test 2/2"
+        "tags parsing test 1/2"
     );
 }
 

--- a/tests/LANraragi/Plugin/Metadata/Eze.t
+++ b/tests/LANraragi/Plugin/Metadata/Eze.t
@@ -18,11 +18,11 @@ require "$cwd/tests/mocks.pl";
 
 use_ok('LANraragi::Plugin::Metadata::Eze');
 
-note("eze Tests");
+note("eze-lite Tests, with save original title but no original title exist");
 {
     # Copy the eze sample json to a temporary directory as it's deleted once parsed
     my ( $fh, $filename ) = tempfile();
-    cp( $SAMPLES . "/eze/eze_sample.json", $fh );
+    cp( $SAMPLES . "/eze/eze_lite_sample.json", $fh );
 
     # Mock LANraragi::Utils::Archive's subs to return the temporary sample JSON
     # Since we're using exports, the methods are under the plugin's namespace.
@@ -32,18 +32,114 @@ note("eze Tests");
     local *LANraragi::Plugin::Metadata::Eze::is_file_in_archive        = sub { 1 };
 
     my %dummyhash = ( something => 22, file_path => "test" );
+    my $save_title = 1;
+    my $origin_title = 1;
+    my $additional_tags = 1;
 
     # Since this is calling the sub directly and not in an object context,
     # we pass a dummy string as first parameter to replace the object.
-    my %ezetags = trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, 1 ); };
+    my %ezetags = trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, $save_title, $origin_title, $additional_tags ); };
 
     my $ezetags =
-      "artist:mitarashi kousei, character:akiko minase, character:yuuichi aizawa, female:aunt, female:lingerie, female:sole female, group:mitarashi club, language:english, language:translated, male:sole male, misc:multi-work series, parody:kanon, source:website.org/g/1179590/7c5815c77b";
+      "artist:mitarashi kousei, character:akiko minase, character:yuuichi aizawa, female:aunt, female:lingerie, female:sole female, group:mitarashi club, language:english, language:translated, male:sole male, misc:multi-work series, parody:kanon, timestamp:1517540580, source:website.org/g/1179590/7c5815c77b";
     is( $ezetags{title},
         "(C72) [Mitarashi Club (Mitarashi Kousei)] Akiko-san to Issho (Kanon) [English] [Belldandy100] [Decensored]",
-        "eze parsing test 1/2"
+        "eze-lite, with save original title but no original title exist parsing test 1/2"
     );
-    is( $ezetags{tags}, $ezetags, "eze parsing test 2/2" );
+    is( $ezetags{tags}, $ezetags, "eze-lite, with save original title but no original title exist parsing test 2/2" );
+}
+
+note("eze-full Tests without 'save_title', without 'additional_tags'");
+{
+    # Copy the eze sample json to a temporary directory as it's deleted once parsed
+    my ( $fh, $filename ) = tempfile();
+    cp( $SAMPLES . "/eze/eze_full_sample.json", $fh );
+
+    # Mock LANraragi::Utils::Archive's subs to return the temporary sample JSON
+    # Since we're using exports, the methods are under the plugin's namespace.
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::Eze::get_plugin_logger         = sub { return get_logger_mock(); };
+    local *LANraragi::Plugin::Metadata::Eze::extract_file_from_archive = sub { $filename };
+    local *LANraragi::Plugin::Metadata::Eze::is_file_in_archive        = sub { 1 };
+
+    my %dummyhash = ( something => 22, file_path => "test" );
+    my $save_title = 0;
+    my $origin_title = 0;
+    my $additional_tags = 0;
+
+    # Since this is calling the sub directly and not in an object context,
+    # we pass a dummy string as first parameter to replace the object.
+    my %ezetags = trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, $save_title, $origin_title, $additional_tags ); };
+
+    my $ezetags =
+      "artist:hiten, female:defloration, female:pantyhose, female:sole female, group:hitenkei, language:chinese, language:translated, male:sole male, parody:original, category:doujinshi, source:exhentai.org/g/1017975/49b3c275a1";
+    is( !$ezetags{title},
+        1,
+        "eze-full without 'save_title', without 'additional_tags' parsing test 1/2"
+    );
+    is( $ezetags{tags}, $ezetags, "eze-full without 'save_title', without 'additional_tags' parsing test 2/2" );
+}
+
+note("eze-full Tests with 'save_title', with 'additional_tags'");
+{
+    # Copy the eze sample json to a temporary directory as it's deleted once parsed
+    my ( $fh, $filename ) = tempfile();
+    cp( $SAMPLES . "/eze/eze_full_sample.json", $fh );
+
+    # Mock LANraragi::Utils::Archive's subs to return the temporary sample JSON
+    # Since we're using exports, the methods are under the plugin's namespace.
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::Eze::get_plugin_logger         = sub { return get_logger_mock(); };
+    local *LANraragi::Plugin::Metadata::Eze::extract_file_from_archive = sub { $filename };
+    local *LANraragi::Plugin::Metadata::Eze::is_file_in_archive        = sub { 1 };
+
+    my %dummyhash = ( something => 22, file_path => "test" );
+    my $save_title = 1;
+    my $origin_title = 0;
+    my $additional_tags = 1;
+
+    # Since this is calling the sub directly and not in an object context,
+    # we pass a dummy string as first parameter to replace the object.
+    my %ezetags = trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, $save_title, $origin_title, $additional_tags ); };
+
+    my $ezetags =
+      "artist:hiten, female:defloration, female:pantyhose, female:sole female, group:hitenkei, language:chinese, language:translated, male:sole male, parody:original, category:doujinshi, uploader:cocy, timestamp:1484412360, source:exhentai.org/g/1017975/49b3c275a1";
+    is( $ezetags{title},
+        "(C91) [HitenKei (Hiten)] R.E.I.N.A [Chinese] [無邪気漢化組]",
+        "eze-full with 'save_title', with 'additional_tags' parsing test 1/2"
+    );
+    is( $ezetags{tags}, $ezetags, "eze-full with 'save_title', with 'additional_tags' parsing test 2/2" );
+}
+
+note("eze-full Tests with save original title, with 'additional_tags'");
+{
+    # Copy the eze sample json to a temporary directory as it's deleted once parsed
+    my ( $fh, $filename ) = tempfile();
+    cp( $SAMPLES . "/eze/eze_full_sample.json", $fh );
+
+    # Mock LANraragi::Utils::Archive's subs to return the temporary sample JSON
+    # Since we're using exports, the methods are under the plugin's namespace.
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::Eze::get_plugin_logger         = sub { return get_logger_mock(); };
+    local *LANraragi::Plugin::Metadata::Eze::extract_file_from_archive = sub { $filename };
+    local *LANraragi::Plugin::Metadata::Eze::is_file_in_archive        = sub { 1 };
+
+    my %dummyhash = ( something => 22, file_path => "test" );
+    my $save_title = 1;
+    my $origin_title = 1;
+    my $additional_tags = 1;
+
+    # Since this is calling the sub directly and not in an object context,
+    # we pass a dummy string as first parameter to replace the object.
+    my %ezetags = trap { LANraragi::Plugin::Metadata::Eze::get_tags( "", \%dummyhash, $save_title, $origin_title, $additional_tags ); };
+
+    my $ezetags =
+      "artist:hiten, female:defloration, female:pantyhose, female:sole female, group:hitenkei, language:chinese, language:translated, male:sole male, parody:original, category:doujinshi, uploader:cocy, timestamp:1484412360, source:exhentai.org/g/1017975/49b3c275a1";
+    is( $ezetags{title},
+        "(C91) [HitenKei (Hiten)] R.E.I.N.A [中国翻訳]",
+        "eze-full with save original title, with 'additional_tags' parsing test 1/2"
+    );
+    is( $ezetags{tags}, $ezetags, "eze-full with save original title, with 'additional_tags' parsing test 2/2" );
 }
 
 done_testing();

--- a/tests/samples/eze/eze_full_sample.json
+++ b/tests/samples/eze/eze_full_sample.json
@@ -1,0 +1,109 @@
+{
+  "gallery_info": {
+    "title": "(C91) [HitenKei (Hiten)] R.E.I.N.A [Chinese] [無邪気漢化組]",
+    "title_original": "(C91) [HitenKei (Hiten)] R.E.I.N.A [中国翻訳]",
+    "category": "doujinshi",
+    "tags": {
+      "language": [
+        "chinese",
+        "translated"
+      ],
+      "parody": [
+        "original"
+      ],
+      "group": [
+        "hitenkei"
+      ],
+      "artist": [
+        "hiten"
+      ],
+      "male": [
+        "sole male"
+      ],
+      "female": [
+        "defloration",
+        "pantyhose",
+        "sole female"
+      ]
+    },
+    "language": "Chinese",
+    "translated": true,
+    "favorite_category": null,
+    "upload_date": [
+      2017,
+      1,
+      14,
+      16,
+      46,
+      0
+    ],
+    "source": {
+      "site": "exhentai",
+      "gid": 1017975,
+      "token": "49b3c275a1",
+      "parent_gallery": null,
+      "newer_versions": []
+    }
+  },
+  "gallery_info_full": {
+    "gallery": {
+      "gid": 1017975,
+      "token": "49b3c275a1"
+    },
+    "title": "(C91) [HitenKei (Hiten)] R.E.I.N.A [Chinese] [無邪気漢化組]",
+    "title_original": "(C91) [HitenKei (Hiten)] R.E.I.N.A [中国翻訳]",
+    "date_uploaded": 1484412360000,
+    "category": "doujinshi",
+    "uploader": "cocy",
+    "rating": {
+      "average": 4.85,
+      "count": 557
+    },
+    "favorites": {
+      "category": -1,
+      "category_title": "",
+      "count": 5166
+    },
+    "parent": null,
+    "newer_versions": [],
+    "thumbnail": "https://exhentai.org/t/03/a6/03a6180e6de784661608a2c7416588dae530110a-4062963-2116-3000-png_250.jpg",
+    "thumbnail_size": "large",
+    "thumbnail_rows": 4,
+    "image_count": 23,
+    "images_resized": false,
+    "total_file_size_approx": 56675532,
+    "visible": true,
+    "visible_reason": "",
+    "language": "Chinese",
+    "translated": true,
+    "tags": {
+      "language": [
+        "chinese",
+        "translated"
+      ],
+      "parody": [
+        "original"
+      ],
+      "group": [
+        "hitenkei"
+      ],
+      "artist": [
+        "hiten"
+      ],
+      "male": [
+        "sole male"
+      ],
+      "female": [
+        "defloration",
+        "pantyhose",
+        "sole female"
+      ]
+    },
+    "tags_have_namespace": true,
+    "torrent_count": 1,
+    "archiver_key": "458297--6d569f8eddc13d17401566b8786598987906ee0b",
+    "source": "html",
+    "source_site": "exhentai",
+    "date_generated": 1649871435117
+  }
+}

--- a/tests/samples/eze/eze_lite_sample.json
+++ b/tests/samples/eze/eze_lite_sample.json
@@ -1,7 +1,7 @@
 {
 	"gallery_info": {
 		"title": "(C72) [Mitarashi Club (Mitarashi Kousei)] Akiko-san to Issho (Kanon) [English] [Belldandy100] [Decensored]",
-		"title_original": "(C72) [みたらし倶楽部 (みたらし侯成)] 秋子さんといっしょ (カノン) [英訳] [無修正]",
+		"title_original": "",
 		"category": "",
 		"tags": {
 			"language": [

--- a/tools/Documentation/api-documentation/miscellaneous-other-api.md
+++ b/tools/Documentation/api-documentation/miscellaneous-other-api.md
@@ -283,10 +283,18 @@ You can either use `login`, `metadata`, `script`, or `all` to get all previous t
       {
         "desc": "Save archive title",
         "type": "bool"
+      },
+      {
+        "desc": "Save the original title when available instead of the English or romanised title",
+        "type": "bool"
+      },
+      {
+        "desc": "Fetch additional timestamp (time posted) and uploader metadata",
+        "type": "bool"
       }
     ],
     "type": "metadata",
-    "version": "2.2"
+    "version": "2.3"
   },
   {
     "author": "Pao",

--- a/tools/cpanfile
+++ b/tools/cpanfile
@@ -52,3 +52,6 @@ requires 'File::ChangeNotify', 0.31;
 
 # Plugin system
 requires 'Module::Pluggable', 5.2;
+
+# Eze plugin
+requires 'Time::Local', 1.30;


### PR DESCRIPTION
fixed #584 

BREAK CHANGES: the parameters for tags_from_eze_json has changed to ($save_title, $origin_title, $additional_tags)

* Add support for date_uploaded and category tags from eze plugin

* get category from gallery_info, fallback to gallery_info_full

* change date_uploaded to timestamp add uploader tag for eze
this make the eze tag more E-Hentai plugin style

* add EH-plugin like options for eze
test cases are modified for cross-condition tests

* better description

* update basic tags of eze for untagged-archives

* Update miscellaneous-other-api.md

* update version number