### PR TITLE
Add nHentai-Plugin to bypass CF JS-Challenge

### DIFF
--- a/lib/LANraragi/Plugin/Login/nHentai.pm
+++ b/lib/LANraragi/Plugin/Login/nHentai.pm
@@ -20,9 +20,9 @@ sub plugin_info {
         description =>
           "Bypasses the Cloudflare Javascript-challenge by re-using cookies from your browser. Both CF cookies and the user-agent must originate from the same webbrowser.",
         parameters => [
-            { type => "string", desc => "user-agent" },
-			{ type => "string", desc => "csrftoken cookie of domain nhentai.net" },
-			{ type => "string", desc => "cf_clearance cookie of domain .nhentai.net" }
+              { type => "string", desc => "Browser UserAgent string (Can be found at http://useragentstring.com/ for your browser)" },
+			{ type => "string", desc => "csrftoken cookie for domain nhentai.net" },
+			{ type => "string", desc => "cf_clearance cookie for domain nhentai.net" }
         ]
     );
 

--- a/lib/LANraragi/Plugin/Login/nHentai.pm
+++ b/lib/LANraragi/Plugin/Login/nHentai.pm
@@ -1,0 +1,83 @@
+package LANraragi::Plugin::Login::nHentai;
+
+use strict;
+use warnings;
+no warnings 'uninitialized';
+
+use Mojo::UserAgent;
+use LANraragi::Utils::Logging qw(get_logger);
+
+#Meta-information about your plugin.
+sub plugin_info {
+
+    return (
+		#Standard metadata
+        name      => "nHentai CF Bypass",
+        type      => "login",
+        namespace => "nhentaicfbypass",
+        author    => "Pheromir",
+        version   => "0.1",
+        description =>
+          "Bypasses the Cloudflare Javascript-challenge by re-using cookies from your browser. Both CF cookies and the user-agent must originate from the same webbrowser.",
+        parameters => [
+            { type => "string", desc => "user-agent" },
+			{ type => "string", desc => "csrftoken cookie of domain nhentai.net" },
+			{ type => "string", desc => "cf_clearance cookie of domain .nhentai.net" }
+        ]
+    );
+
+}
+
+
+# Mandatory function to be implemented by your login plugin
+# Returns a Mojo::UserAgent object only!
+sub do_login {
+
+    # Login plugins only receive the parameters entered by the user.
+    shift;
+    my ( $useragent, $csrftoken, $cf_clearance ) = @_;
+    return get_user_agent( $useragent, $csrftoken, $cf_clearance );
+}
+
+# get_user_agent(useragent, cf cookies)
+# Try crafting a Mojo::UserAgent object that can access nHentai.
+# Returns the UA object created.
+sub get_user_agent {
+
+    my ( $useragent, $csrftoken, $cf_clearance ) = @_;
+
+    my $logger = get_logger( "nHentai Cloudflare Bypass", "plugins" );
+    my $ua     = Mojo::UserAgent->new;
+
+    if ( $useragent ne "" && $csrftoken ne "" && $cf_clearance ne "") {
+        $logger->info("Useragent and Cookies provided ($useragent $csrftoken $cf_clearance)!");
+        $ua->transactor->name($useragent);
+
+        #Setup the needed cookies
+        $ua->cookie_jar->add(
+            Mojo::Cookie::Response->new(
+                name   => 'csrftoken',
+                value  => $csrftoken,
+                domain => 'nhentai.net',
+                path   => '/'
+            )
+        );
+
+        $ua->cookie_jar->add(
+            Mojo::Cookie::Response->new(
+                name   => 'cf_clearance',
+                value  => $cf_clearance,
+                domain => 'nhentai.net',
+                path   => '/'
+            )
+        );
+
+    } else {
+        $logger->info("No cookies provided, returning blank UserAgent.");
+    }
+
+    return $ua;
+
+}
+
+1;


### PR DESCRIPTION
Added a new plugin to pass cookies and a useragent to LRR to bypass the Cloudflare JavaScript-Challenge.
I specifially named it like that (instead of "nHentai Login" or something like that) so it doesn't get confused with an actual login to the website.

The login plugin is based on the login-example from the documentation and your ehlogin.
for the Metadata-Plugin I changed the author to "Difegue and others" as it is the same way in the E-Hentai Metadata Plugin as an example.

I hope everything's fine, but you might check twice to be sure, as it's the first time I used pearl.

Tested one archive by providing a URL (see screenshot) and one archive by uploading it with the gID in the name ("{id} name") - both worked.

![firefox_2022-05-25-18-45-10](https://user-images.githubusercontent.com/13359741/170320036-691202f4-3a95-4224-9d23-57049c446a5c.png)

