### PR TITLE
Fix the problem of non-ISO8859-1 decoding garbled

### DIFF
--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -304,7 +304,7 @@ sub deleted_file_callback {
 sub add_new_file {
 
     my ( $id, $file, $redis,$outputname ) = @_;
-	$outputname = decode("utf8", $file);
+	my $outputname = redis_decode($file);
     $logger->info("Adding new file $outputname with ID $id");
 
     eval {

--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -303,7 +303,7 @@ sub deleted_file_callback {
 
 sub add_new_file {
 
-    my ( $id, $file, $redis,$outputname ) = @_;
+    my ( $id, $file, $redis) = @_;
 	my $outputname = redis_decode($file);
     $logger->info("Adding new file $outputname with ID $id");
 

--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -303,8 +303,9 @@ sub deleted_file_callback {
 
 sub add_new_file {
 
-    my ( $id, $file, $redis ) = @_;
-    $logger->info("Adding new file $file with ID $id");
+    my ( $id, $file, $redis,$outputname ) = @_;
+	$outputname = decode("utf8", $file);
+    $logger->info("Adding new file $outputname with ID $id");
 
     eval {
         LANraragi::Utils::Database::add_archive_to_redis( $id, $file, $redis );


### PR DESCRIPTION
Fix the problem of non-ISO8859-1 decoding garbled .
some characters like chinese or japanese can not be decoded correctly at shinobu logs ,try to fix it .
before:
![123330](https://user-images.githubusercontent.com/38988286/171465804-c153989f-d405-44cf-8bf3-50ff56917a6a.jpg)

after:
![123340](https://user-images.githubusercontent.com/38988286/171466151-7e07be94-9e38-4955-a716-5fc11b8ac249.jpg)

