### PR TITLE
EHPlugin update for the new search system

### DIFF
--- a/lib/LANraragi/Plugin/Metadata/EHentai.pm
+++ b/lib/LANraragi/Plugin/Metadata/EHentai.pm
@@ -134,21 +134,9 @@ sub lookup_gallery {
         #search with image SHA hash
         $URL =
             $domain
-          . "?advsearch=1&f_sname=on&f_sdt2=on&f_spf=&f_spt=&f_sfu=on&f_sft=on&f_sfl=on&f_shash="
+          . "?f_shash="
           . $thumbhash
-          . "&fs_covers=1&fs_similar=1";
-
-        #Include expunged galleries in the search if the option is enabled.
-        if ($expunged) {
-            $URL = $URL . "&fs_exp=1";
-        }
-
-        # Add the language override, if it's defined.
-        if ( $defaultlanguage ne "" ) {
-
-            # Add f_stags to search in tags for language
-            $URL = $URL . "&f_stags=on&f_search=" . uri_escape_utf8("language:$defaultlanguage");
-        }
+          . "&fs_similar=on&fs_covers=on";
 
         $logger->debug("Using URL $URL (archive thumbnail hash)");
 
@@ -159,10 +147,10 @@ sub lookup_gallery {
         }
     }
 
-    # Regular text search
+    # Regular text search (advanced options: Disable default filters for: Language, Uploader, Tags)
     $URL =
         $domain
-      . "?advsearch=1&f_sname=on&f_sdt2=on&f_spf=&f_spt=&f_sfu=on&f_sft=on&f_sfl=on"
+      . "?advsearch=1&f_sfu=on&f_sft=on&f_sfl=on"
       . "&f_search="
       . uri_escape_utf8( qw(") . $title . qw(") );
 
@@ -179,12 +167,7 @@ sub lookup_gallery {
         $URL = $URL . "+" . uri_escape_utf8("language:$defaultlanguage");
     }
 
-    # Add f_stags to search in tags if we added a tag (or two) in the search
-    if ( $has_artist || $defaultlanguage ne "" ) {
-        $URL = $URL . "&f_stags=on";
-    }
-
-    # Include expunged galleries in the search if the option is enabled.
+    # Search expunged galleries if the option is enabled.
     if ($expunged) {
         $URL = $URL . "&f_sh=on";
     }

--- a/lib/LANraragi/Plugin/Metadata/EHentai.pm
+++ b/lib/LANraragi/Plugin/Metadata/EHentai.pm
@@ -39,7 +39,7 @@ sub plugin_info {
                 desc => "Save the original title when available instead of the English or romanised title"
             },
             { type => "bool", desc => "Fetch additional timestamp (time posted) and uploader metadata" },
-            { type => "bool", desc => "Search expunged galleries as well" },
+            { type => "bool", desc => "Search only expunged galleries" },
 
         ],
         oneshot_arg => "E-H Gallery URL (Will attach tags matching this exact gallery to your archive)",


### PR DESCRIPTION
So while i believe the text search should still work fine i went ahead and updated it anyway.

> File searches can no longer be combined with keyword searches or other filters. This search mode will show both normal and expunged galleries. Default tag, language and uploader filters are now automatically disabled for these searches.

>Selecting "Search Expunged Galleries" will now only search expunged galleries in normal searches. (File searches, GID searches and favorite searches will always display both normal and expunged galleries.)

Additionally from what i understand the image search works best (only works?) when using the full image hash not the thumbnail hash.
~~Also we can now search by gID which can be added as an option later.~~
Added an option for this, worked nicely and will fall back to title name if no gId found or search failed.
`[2022-11-02 19:11:23] [E-Hentai] [debug] Found gID: 2365440, Using URL https://exhentai.org?f_search=gid%3A2365440 (gID from archive title)
[2022-11-02 19:11:23] [E-Hentai] [debug] EH API Tokens are 2365440 / 9ff65b23c7`

read more here: https://forums.e-hentai.org/index.php?showtopic=261743&pid=6201235

