### PR TITLE
Allow the tooltip to be outside of the container

### DIFF
--- a/public/css/lrr.css
+++ b/public/css/lrr.css
@@ -182,11 +182,6 @@ p#nb {
   padding: 0px !important;
 }
 
-/* Bugfix for swiper + tippy compatibility */
-.swiper-virtual .swiper-slide {
-  transform: none !important;
-}
-
 .caption-namespace {
   width: 100px !important;
   font-size: 10pt;

--- a/public/js/index_datatables.js
+++ b/public/js/index_datatables.js
@@ -363,6 +363,8 @@ IndexTable.buildTagTooltip = function (target) {
         placement: "auto-start",
         maxWidth: "none",
         interactive: true,
+        // Have to be outside so that it is not hidden by other elements.
+        appendTo: document.body,
     }).show(); // Call show() so that the tooltip shows now
 
     $(target).attr("onmouseover", "");


### PR DESCRIPTION
Append the tooltip to the body element so that it is not hidden by other elements.
This fix makes the previous partial fix (26bf9b50997126bdcd75e9f8ad34092df95454e5) unnecessary.

Fixes: #731