### PR TITLE
Filter more credit pages & move covers to start

### DIFF
--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -248,9 +248,9 @@ sub get_filelist {
     @files = sort { &expand($a) cmp &expand($b) } @files;
 
     # Move front cover pages to the start of a gallery, and miscelanious pages such as translator credits to the end.
-    my @cover_pages      = grep { /cover\.[^\.]*/i } @files;
-    my @credit_pages     = grep { /^999999|^bumper|^end_card_save_file|notes\.[^\.]*|note\.[^\.]*|artist_info_store_links|credit|999nhnl\.|^group\./i } @files;
-    my @non_credit_pages = grep { !/^999999|^bumper|^end_card_save_file|notes\.[^\.]*|note\.[^\.]*|artist_info_store_links|credit|999nhnl\.|^group\./i } @files;
+    my @cover_pages      = grep { /cover\.[^\.]*$/i } @files;
+    my @credit_pages     = grep { /^999999|^bumper|^end_card_save_file|notes\.[^\.]*$|note\.[^\.]*$|artist_info_store_links|credit|999nhnl\.|^group\./i } @files;
+    my @non_credit_pages = grep { !/^999999|^bumper|^end_card_save_file|notes\.[^\.]*$|note\.[^\.]*$|artist_info_store_links|credit|999nhnl\.|^group\./i } @files;
     @files = ( @cover_pages, @non_credit_pages, @credit_pages );
 
     # Return files and sizes in a hashref

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -248,13 +248,13 @@ sub get_filelist {
     @files = sort { &expand($a) cmp &expand($b) } @files;
 
     # Move front cover pages to the start of a gallery, and miscellaneous pages such as translator credits to the end.
-    my @cover_pages      = grep { /^(?!.*(back|end|rear|recover)).*cover.*/i } @files;
-    my @credit_pages     = grep { /^999999|^bumper|^ramble\.[^\.]*$|^end_card_save_file|notes\.[^\.]*$|note\.[^\.]*$|^artist_info|credit|999nhnl\.|^group\.[^\.]*$/i } @files;
+    my @cover_pages      = grep { /^(?!.*(back|end|rear|recover|discover)).*cover.*/i } @files;
+    my @credit_pages     = grep { /^end_card_save_file|notes\.[^\.]*$|note\.[^\.]*$|^artist_info|credit|999nhnl\./i } @files;
     # Get all the leftover pages
     my %credit_hash = map { $_ => 1 } @credit_pages;
     my %cover_hash = map { $_ => 1 } @cover_pages;
     my @other_pages = grep { !$credit_hash{$_} && !$cover_hash{$_} } @files;
-@files = ( @cover_pages, @other_pages, @credit_pages );
+    @files = ( @cover_pages, @other_pages, @credit_pages );
     # Return files and sizes in a hashref
     return ( \@files, \@sizes );
 }

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -247,10 +247,10 @@ sub get_filelist {
 
     @files = sort { &expand($a) cmp &expand($b) } @files;
 
-    # Move front cover pages to the start of a gallery, and miscelanious pages such as translator credits to the end.
+    # Move front cover pages to the start of a gallery, and miscellaneous pages such as translator credits to the end.
     my @cover_pages      = grep { /cover\.[^\.]*$/i } @files;
-    my @credit_pages     = grep { /^999999|^bumper|^ramble\.[^\.]*$|^end_card_save_file|notes\.[^\.]*$|note\.[^\.]*$|artist_info_store_links|credit|999nhnl\.|^group\.[^\.]*$/i } @files;
-    my @non_credit_pages = grep { !/^999999|^bumper|^ramble\.[^\.]*$|^end_card_save_file|notes\.[^\.]*$|note\.[^\.]*$|artist_info_store_links|credit|999nhnl\.|^group\.[^\.]*$|cover\.[^\.]*$/i } @files;
+    my @credit_pages     = grep { /^999999|^bumper|^ramble\.[^\.]*$|^end_card_save_file|notes\.[^\.]*$|note\.[^\.]*$|^artist_info|credit|999nhnl\.|^group\.[^\.]*$/i } @files;
+    my @non_credit_pages = grep { !/^999999|^bumper|^ramble\.[^\.]*$|^end_card_save_file|notes\.[^\.]*$|note\.[^\.]*$|^artist_info|credit|999nhnl\.|^group\.[^\.]*$|cover\.[^\.]*$/i } @files;
     @files = ( @cover_pages, @non_credit_pages, @credit_pages );
 
     # Return files and sizes in a hashref

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -249,8 +249,8 @@ sub get_filelist {
 
     # Move front cover pages to the start of a gallery, and miscelanious pages such as translator credits to the end.
     my @cover_pages      = grep { /cover\.[^\.]*$/i } @files;
-    my @credit_pages     = grep { /^999999|^bumper|^end_card_save_file|notes\.[^\.]*$|note\.[^\.]*$|artist_info_store_links|credit|999nhnl\.|^group\./i } @files;
-    my @non_credit_pages = grep { !/^999999|^bumper|^end_card_save_file|notes\.[^\.]*$|note\.[^\.]*$|artist_info_store_links|credit|999nhnl\.|^group\./i } @files;
+    my @credit_pages     = grep { /^999999|^bumper|^ramble\.[^\.]*$|^end_card_save_file|notes\.[^\.]*$|note\.[^\.]*$|artist_info_store_links|credit|999nhnl\.|^group\.[^\.]*$/i } @files;
+    my @non_credit_pages = grep { !/^999999|^bumper|^ramble\.[^\.]*$|^end_card_save_file|notes\.[^\.]*$|note\.[^\.]*$|artist_info_store_links|credit|999nhnl\.|^group\.[^\.]*$|cover\.[^\.]*$/i } @files;
     @files = ( @cover_pages, @non_credit_pages, @credit_pages );
 
     # Return files and sizes in a hashref

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -247,10 +247,11 @@ sub get_filelist {
 
     @files = sort { &expand($a) cmp &expand($b) } @files;
 
-    # Move any pages containing "credit" to the end of the array.
-    my @credit_pages     = grep { /credit/i } @files;
-    my @non_credit_pages = grep { !/credit/i } @files;
-    @files = ( @non_credit_pages, @credit_pages );
+    # Move front cover pages to the start of a gallery, and miscelanious pages such as translator credits to the end.
+    my @cover_pages      = grep { /cover\.[^\.]*/i } @files;
+    my @credit_pages     = grep { /^999999|^bumper|^end_card_save_file|notes\.[^\.]*|note\.[^\.]*|artist_info_store_links|credit|999nhnl\.|^group\./i } @files;
+    my @non_credit_pages = grep { !/^999999|^bumper|^end_card_save_file|notes\.[^\.]*|note\.[^\.]*|artist_info_store_links|credit|999nhnl\.|^group\./i } @files;
+    @files = ( @cover_pages, @non_credit_pages, @credit_pages );
 
     # Return files and sizes in a hashref
     return ( \@files, \@sizes );

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -251,7 +251,7 @@ sub get_filelist {
     my @cover_pages      = grep { /^(?!.*(back|end|rear|recover)).*cover.*/i } @files;
     my @credit_pages     = grep { /^999999|^bumper|^ramble\.[^\.]*$|^end_card_save_file|notes\.[^\.]*$|note\.[^\.]*$|^artist_info|credit|999nhnl\.|^group\.[^\.]*$/i } @files;
     my @non_credit_pages = grep { !/^999999|^bumper|^ramble\.[^\.]*$|^end_card_save_file|notes\.[^\.]*$|note\.[^\.]*$|^artist_info|credit|999nhnl\.|^group\.[^\.]*$|^(?!.*(back|end|rear|recover)).*cover.*/i } @files;
-
+@files = ( @cover_pages, @other_pages, @credit_pages );
     # Return files and sizes in a hashref
     return ( \@files, \@sizes );
 }

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -248,10 +248,9 @@ sub get_filelist {
     @files = sort { &expand($a) cmp &expand($b) } @files;
 
     # Move front cover pages to the start of a gallery, and miscellaneous pages such as translator credits to the end.
-    my @cover_pages      = grep { /cover\.[^\.]*$/i } @files;
+    my @cover_pages      = grep { /^(?!.*(back|end|rear|recover)).*cover.*/i } @files;
     my @credit_pages     = grep { /^999999|^bumper|^ramble\.[^\.]*$|^end_card_save_file|notes\.[^\.]*$|note\.[^\.]*$|^artist_info|credit|999nhnl\.|^group\.[^\.]*$/i } @files;
-    my @non_credit_pages = grep { !/^999999|^bumper|^ramble\.[^\.]*$|^end_card_save_file|notes\.[^\.]*$|note\.[^\.]*$|^artist_info|credit|999nhnl\.|^group\.[^\.]*$|cover\.[^\.]*$/i } @files;
-    @files = ( @cover_pages, @non_credit_pages, @credit_pages );
+    my @non_credit_pages = grep { !/^999999|^bumper|^ramble\.[^\.]*$|^end_card_save_file|notes\.[^\.]*$|note\.[^\.]*$|^artist_info|credit|999nhnl\.|^group\.[^\.]*$|^(?!.*(back|end|rear|recover)).*cover.*/i } @files;
 
     # Return files and sizes in a hashref
     return ( \@files, \@sizes );

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -250,7 +250,10 @@ sub get_filelist {
     # Move front cover pages to the start of a gallery, and miscellaneous pages such as translator credits to the end.
     my @cover_pages      = grep { /^(?!.*(back|end|rear|recover)).*cover.*/i } @files;
     my @credit_pages     = grep { /^999999|^bumper|^ramble\.[^\.]*$|^end_card_save_file|notes\.[^\.]*$|note\.[^\.]*$|^artist_info|credit|999nhnl\.|^group\.[^\.]*$/i } @files;
-    my @non_credit_pages = grep { !/^999999|^bumper|^ramble\.[^\.]*$|^end_card_save_file|notes\.[^\.]*$|note\.[^\.]*$|^artist_info|credit|999nhnl\.|^group\.[^\.]*$|^(?!.*(back|end|rear|recover)).*cover.*/i } @files;
+    # Get all the leftover pages
+    my %credit_hash = map { $_ => 1 } @credit_pages;
+    my %cover_hash = map { $_ => 1 } @cover_pages;
+    my @other_pages = grep { !$credit_hash{$_} && !$cover_hash{$_} } @files;
 @files = ( @cover_pages, @other_pages, @credit_pages );
     # Return files and sizes in a hashref
     return ( \@files, \@sizes );


### PR DESCRIPTION
There are a number of scanlators who name their files in a way that puts the credit/translation note pages at the start of a gallery. This PR filters them so they are at the end of a gallery instead.

artist_info - [RedLantern]
9999nhnl - [nhnl]
end_card_save_file - [LunaticSeibah]
9999999* - [MegaFaget]
bumper - [cowboy]
ramble - [degenerate]

And also filters out filenames ending in "note." or "notes." with the period being the file extension, this aims to remove commonly used names for translation notes. I also added a filter to locate filenames ending with "cover." and set them to be the first images in a gallery, so we more reliably find front covers & correct thumbnails for galleries.

I tried to use stricter regex for the commonly used names/characters to avoid false positives, but more may be required.
