### PR TITLE
Chaika plugin adds more tags

### DIFF
--- a/lib/LANraragi/Plugin/Metadata/Chaika.pm
+++ b/lib/LANraragi/Plugin/Metadata/Chaika.pm
@@ -19,11 +19,15 @@ sub plugin_info {
         type        => "metadata",
         namespace   => "trabant",
         author      => "Difegue",
-        version     => "2.2",
+        version     => "2.3",
         description => "Searches chaika.moe for tags matching your archive. This will try to use the thumbnail first, and fallback to a default text search.",
         icon =>
           "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAACXBIWXMAAAsTAAALEwEAmpwYAAAA\nB3RJTUUH4wYCFQocjU4r+QAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUH\nAAAEZElEQVQ4y42T3WtTdxzGn/M7J+fk5SRpTk7TxMZkXU84tTbVNrUT3YxO7HA4pdtQZDe7cgx2\ns8vBRvEPsOwFYTDYGJUpbDI2wV04cGXCGFLonIu1L2ptmtrmxeb1JDkvv121ZKVze66f74eH7/f5\nMmjRwMCAwrt4/9KDpflMJpPHvyiR2DPcJklJ3TRDDa0xk36cvrm8vDwHAAwAqKrqjjwXecPG205w\nHBuqa9rk77/d/qJYLD7cCht5deQIIczbgiAEKLVAKXWUiqVV06Tf35q8dYVJJBJem2A7Kwi2nQzD\nZig1CG93+PO5/KN6tf5NKpVqbsBUVVVFUUxwHJc1TXNBoxojS7IbhrnLMMx9pVJlBqFQKBKPxwcB\nkJYgjKIo3QCE1nSKoghbfJuKRqN2RVXexMaQzWaLezyeEUEQDjscjk78PxFFUYRkMsltJgGA3t7e\nyMLCwie6rr8iCILVbDbvMgwzYRjGxe0o4XC4s1AoHPP5fMP5/NNOyzLKAO6Ew+HrDADBbre/Ryk9\nnzx81FXJNlEpVpF+OqtpWu2MpmnXWmH9/f2umZmZi4cOHXnLbILLzOchhz1YerJAs9m1GwRAg2GY\nh7GYah488BJYzYW+2BD61AFBlmX/1nSNRqN9//792ujoaIPVRMjOKHoie3DytVGmp2fXCAEAjuMm\nu7u7Umosho6gjL/u/QHeEgvJZHJ2K/D+/fuL4+PjXyvPd5ldkShy1UXcmb4DnjgQj/fd5gDA6/XS\nYCAwTwh9oT3QzrS1+VDVi+vd3Tsy26yQVoFF3dAXJVmK96p9EJ0iLNOwKKU3CQCk0+lSOpP5WLDz\nF9Q9kZqyO0SloOs6gMfbHSU5NLRiUOuax2/HyZPHEOsLw2SbP83eu/fLxrkNp9P554XxCzVa16MC\n7+BPnTk9cfmH74KJE8nmga7Xy5JkZ8VKifGIHpoBb1VX8hNTd3/t/7lQ3OeXfFPvf/jBRw8ezD/a\n7M/aWq91cGgnJaZ2VcgSdnV1XRNNd3vAoBVVYusmnEQS65hfgSG6c+zy3Kre7nF/KrukcMW0Zg8O\nD08DoJutDxxOEb5IPUymwrq8ft1gLKfkFojkkRxemERCAQUACPFWRazYLJcrFGwQhyufbQQ7rFpy\nLMkCwGZC34qPIuwp+XPOjBFwazQ/txrdFS2GGS/Xuj+pUKLGk1Kjvlded3s72lyGW+PLbGVcmrAA\ngN0wTk1NWYODg9XOKltGtpazi5GigzroUnHN5nUHG1ylRsG7rDXHmnEpu4CeEtEKkqNc6QqlLc/M\n8uT5lLH5eq0aGxsju1O7GQB498a5s/0x9dRALPaQEDZnYwnhWJtMCCNrjeb0UP34Z6e/PW22zjPP\n+vwXBwfPvbw38XnXjk7GsiwKAIQQhjAMMrlsam45d+zLH6/8o6vkWcBcrXbVKQhf6bpucCwLjmUB\nSmmhXC419eblrbD/TAgAkUjE987xE0c7ZDmk66ajUCnq+cL63fErl25s5/8baQPaWLhx6goAAAAA\nSUVORK5CYII=",
-        parameters  => [ { type => "bool", desc => "Save archive title" } ],
+        parameters  => [
+            { type => "bool", desc => "Save archive title" },
+            { type => "bool", desc => "Add tags without a namespace to the 'other:' namespace instead" },
+            { type => "string", desc => "Add a custom 'source:' tag to your archive. Example: chaika. Will NOT add a tag if blank" }
+        ],
         oneshot_arg => "Chaika Gallery or Archive URL (Will attach matching tags to your archive)"
     );
 
@@ -34,7 +38,7 @@ sub get_tags {
 
     shift;
     my $lrr_info = shift;    # Global info hash
-    my ($savetitle) = @_;    # Plugin parameters
+    my ( $savetitle, $addother, $addsource ) = @_;    # Plugin parameters
 
     my $logger   = get_plugin_logger();
     my $newtags  = "";
@@ -43,17 +47,17 @@ sub get_tags {
     # Parse the given link to see if we can extract type and ID
     my $oneshotarg = $lrr_info->{oneshot_param};
     if ( $oneshotarg =~ /https?:\/\/panda\.chaika\.moe\/(gallery|archive)\/([0-9]*)\/?.*/ ) {
-        ( $newtags, $newtitle ) = tags_from_chaika_id( $1, $2 );
+        ( $newtags, $newtitle ) = tags_from_chaika_id( $1, $2, $addother, $addsource );
     } else {
 
         # Try SHA-1 reverse search first
         $logger->info("Using thumbnail hash " . $lrr_info->{thumbnail_hash});
-        ( $newtags, $newtitle ) = tags_from_sha1( $lrr_info->{thumbnail_hash} );
+        ( $newtags, $newtitle ) = tags_from_sha1( $lrr_info->{thumbnail_hash}, $addother, $addsource );
 
         # Try text search if it fails
         if ( $newtags eq "" ) {
             $logger->info("No results, falling back to text search.");
-            ( $newtags, $newtitle ) = search_for_archive( $lrr_info->{archive_title}, $lrr_info->{existing_tags} );
+            ( $newtags, $newtitle ) = search_for_archive( $lrr_info->{archive_title}, $lrr_info->{existing_tags}, $addother, $addsource );
         }
     }
 
@@ -79,8 +83,7 @@ sub get_tags {
 sub search_for_archive {
 
     my $logger = get_plugin_logger();
-    my $title  = $_[0];
-    my $tags   = $_[1];
+    my ( $title, $tags, $addother, $addsource ) = @_;
 
     #Auto-lowercase the title for better results
     $title = lc($title);
@@ -103,7 +106,7 @@ sub search_for_archive {
     my $textrep = $res->body;
     $logger->debug("Chaika API returned this JSON: $textrep");
 
-    my ( $chaitags, $chaititle ) = parse_chaika_json( $res->json->{"galleries"}->[0] );
+    my ( $chaitags, $chaititle ) = parse_chaika_json( $res->json->{"galleries"}->[0], $addother, $addsource );
 
     return ( $chaitags, $chaititle );
 }
@@ -111,17 +114,17 @@ sub search_for_archive {
 # Uses the jsearch API to get the best json for a file.
 sub tags_from_chaika_id {
 
-    my ( $type, $ID ) = @_;
+    my ( $type, $ID, $addother, $addsource ) = @_;
 
     my $json = get_json_from_chaika( $type, $ID );
-    return parse_chaika_json( $json );
+    return parse_chaika_json( $json, $addother, $addsource );
 }
 
 # tags_from_sha1
 # Uses chaika's SHA-1 search with the first page hash we have.
 sub tags_from_sha1 {
 
-    my ( $sha1 ) = @_;
+    my ( $sha1, $addother, $addsource ) = @_;
 
     my $logger = get_plugin_logger();
 
@@ -129,7 +132,7 @@ sub tags_from_sha1 {
     # Said JSON is an array containing multiple archive objects.
     # We just take the first one.
     my $json_by_sha1 = get_json_from_chaika( 'sha1', $sha1 );
-    return parse_chaika_json( $json_by_sha1->[0] );
+    return parse_chaika_json( $json_by_sha1->[0], $addother, $addsource );
 }
 
 # Calls chaika's API
@@ -154,15 +157,39 @@ sub get_json_from_chaika {
 # Parses the JSON obtained from the Chaika API to get the tags.
 sub parse_chaika_json {
 
-    my ( $json ) = @_;
+    my ( $json, $addother, $addsource ) = @_;
+    
+    my $logger = get_plugin_logger();
+    $logger->debug("Chaika JSON: " . $json);
 
     my $tags = $json->{"tags"} || ();
     foreach my $tag (@$tags) {
         #Replace underscores with spaces
         $tag =~ s/_/ /g;
+        
+        #Add 'other' namespace if none
+        if ($addother && index($tag, ":") == -1) {
+            $tag = "other:" . $tag;
+        }
     }
 
-    return ( join( ', ', @$tags ), $json->{"title"} );
+    my $download = $json->{"download"} ? $json->{"download"} : $json->{"archives"}->[0]->{"link"};
+    my $gallery = $json->{"gallery"} ? $json->{"gallery"} : $json->{"id"};
+    if ( $tags ) {
+        push(@$tags, "category:" . lc $json->{"category"});
+        push(@$tags, "download:" . $download);
+        push(@$tags, "gallery:" . $json->{"gallery"});
+        push(@$tags, "timestamp:" . $json->{"posted"});
+        if ($addsource ne "") {
+            push(@$tags, "source:" . $addsource);
+        }
+    }
+    if ($gallery && $gallery != "") {
+      $logger->debug("Found these tags: " . join( ', ', @$tags ));
+      return ( join( ', ', @$tags ), $json->{"title"} );
+    } else {
+      return "";
+    }
 }
 
 1;


### PR DESCRIPTION
The json from Chaika contains a few more useful info that I wanted to add as tags, namely download URL, gallery ID, category and timestamp. This commit add those, as well as 2 new options. First option allows adding tags without namespace to the 'other:' namespace instead, mimicking the behaviour of E-Hentai. Second option allows tagging galleries found on Chaika with a custom 'source:' tag.

This doesn't fix any existing issue and is mainly for my own use, but I thought others might find it useful as well.