### PR TITLE
Sort speed increase

### DIFF
--- a/lib/LANraragi/Model/Search.pm
+++ b/lib/LANraragi/Model/Search.pm
@@ -374,6 +374,7 @@ sub sort_results {
 	
     my $re = qr/$sortkey/;
 	
+        # Map our archives to a hash, where the key is the ID and the value is the first tag we found that matches the sortkey/namespace. (If no tag, defaults to "zzzz")
 	my %tmpfilter = map {$_ => ($redis->hget( $_, "tags" ) =~ m/.*${re}:(.*)(\,.*|$)/) ? $1 : "zzzz" } @filtered;
 	
 	my @sorted = map { $_->[0] }

--- a/lib/LANraragi/Model/Search.pm
+++ b/lib/LANraragi/Model/Search.pm
@@ -377,10 +377,10 @@ sub sort_results {
         # Map our archives to a hash, where the key is the ID and the value is the first tag we found that matches the sortkey/namespace. (If no tag, defaults to "zzzz")
 	my %tmpfilter = map {$_ => ($redis->hget( $_, "tags" ) =~ m/.*${re}:(.*)(\,.*|$)/) ? $1 : "zzzz" } @filtered;
 	
-	my @sorted = map { $_->[0] }
-	  sort { ncmp($a->[1], $b->[1]) }
-	  map  { [$_, lc($tmpfilter{$_})] }
-	  keys %tmpfilter;
+	my @sorted = map { $_->[0] } # Map back to only having the ID
+	  sort { ncmp($a->[1], $b->[1]) } # Sort by the tag
+	  map  { [$_, lc($tmpfilter{$_})] } # Map to an array containing the ID and the lowercased tag
+	  keys %tmpfilter; # List of IDs
 	
 	if ($sortorder) {
 		@sorted = reverse @sorted;


### PR DESCRIPTION
The current sorting algorithm runs hget every time and compares these values, 
which has the disadvantage of heavy load and slow speed.

In addition, there was a huge problem with the existing alignment method.
The problem is that the larger the library, the more exponential it requires.
The load is also severe because hget is executed every operation.
The current method also tries to sort this value against the previous value each time.

To solve this problem,
The key values of the @filtered array and the value of the key value corresponding to the sort key are converted to Hash.
The key sorted based on the value value of this hash has been returned to the @sorted array.

We can process more quickly than before.
Currently, more than 100,000 sortings are often unsuccessful, but if you change them this way, 500,000 sortings can also be successful.


Based on the same performance for 100,000 sortings, traditionally it takes more than 300 seconds and the operation fails, but the improved code takes about 13 seconds.