### PR TITLE
Koromo multiple artists

### DIFF
--- a/lib/LANraragi/Plugin/Metadata/Koromo.pm
+++ b/lib/LANraragi/Plugin/Metadata/Koromo.pm
@@ -130,8 +130,19 @@ sub tags_from_koromo_json {
         push( @found_tags, "artist:" . $tag );
     }
 
-    push( @found_tags, "series:" . $parody )     unless !$parody;
-    push( @found_tags, "artist:" . $artist )     unless !$artist;
+    push( @found_tags, "series:" . $parody ) unless !$parody;
+
+    # Don't add bogus artist:ARRAYblabla if artist is an array
+    if ($artist) {
+        if ( ref $artist eq 'ARRAY' ) {
+            foreach my $tag (@$artist) {
+                push( @found_tags, "artist:" . $tag );
+            }
+        } else {
+            push( @found_tags, "artist:" . $artist ) unless !$artist;
+        }
+    }
+
     push( @found_tags, "language:" . $language ) unless !$language;
     push( @found_tags, "category:" . $type )     unless !$type;
     push( @found_tags, "source:" . $url )        unless !$url;

--- a/tests/LANraragi/Plugin/Metadata/Koromo.t
+++ b/tests/LANraragi/Plugin/Metadata/Koromo.t
@@ -43,4 +43,29 @@ note("Koromo Tests");
     is( $ko_tags{tags},  $expected_tags, "Koromo parsing test 2/2" );
 }
 
+note("multiple artists json");
+{
+    # Copy the koromo sample json to a temporary directory as it's deleted once parsed
+    my ( $fh, $filename ) = tempfile();
+    cp( $SAMPLES . "/koromo/koromo_multiauthor.json", $fh );
+
+    # Mock LANraragi::Utils::Archive's subs to return the temporary sample JSON
+    # Since we're using exports, the methods are under the plugin's namespace.
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::Koromo::get_plugin_logger         = sub { return get_logger_mock(); };
+    local *LANraragi::Plugin::Metadata::Koromo::extract_file_from_archive = sub { $filename };
+    local *LANraragi::Plugin::Metadata::Koromo::is_file_in_archive        = sub { 1 };
+
+    my %dummyhash = ( something => 22, file_path => "test" );
+
+    # Since this is calling the sub directly and not in an object context,
+    # we pass a dummy string as first parameter to replace the object.
+    my %ko_tags = trap { LANraragi::Plugin::Metadata::Koromo::get_tags( "", \%dummyhash, 1 ); };
+
+    my $expected_tags =
+      "Teacher, Schoolgirl Outfit, Cheating, Hentai, Ahegao, Creampie, Uncensored, Condom, Unlimited, Heart Pupils, Love Hotel, series:Original Work, artist:First, artist:Second, language:English, source:https://www.fakku.net/hentai/after-school-english_1632947200";
+    is( $ko_tags{title}, "After School", "Koromo parsing test 1/2" );
+    is( $ko_tags{tags},  $expected_tags, "Koromo parsing test 2/2" );
+}
+
 done_testing();

--- a/tests/samples/koromo/koromo_multiauthor.json
+++ b/tests/samples/koromo/koromo_multiauthor.json
@@ -1,0 +1,44 @@
+{
+    "Artist": [
+        "First",
+        "Second"
+    ],
+    "Description": "Naughty things feel so good! ❤",
+    "Favorites": 713,
+    "Language": "English",
+    "Magazine": "Comic Bavel 2021-11",
+    "Pages": 20,
+    "Parody": "Original Work",
+    "Publisher": "FAKKU",
+    "Related": [
+        "https://www.fakku.net/hentai/after-school-encounter-english",
+        "https://www.fakku.net/hentai/after-school-thrills-english",
+        "https://www.fakku.net/hentai/after-school-goddess-2-english",
+        "https://www.fakku.net/hentai/mark-of-the-saint-5-english",
+        "https://www.fakku.net/hentai/after-school-with-a-pushover-gal-english",
+        "https://www.fakku.net/hentai/killing-time-after-school-english",
+        "https://www.fakku.net/hentai/after-school-revenge-time-english",
+        "https://www.fakku.net/hentai/after-school-service-time-english",
+        "https://www.fakku.net/hentai/after-school-temptation-english-1485463915",
+        "https://www.fakku.net/hentai/after-school-activities-english",
+        "https://www.fakku.net/hentai/after-school-humiliation-english",
+        "https://www.fakku.net/hentai/after-school-disclosure-english"
+    ],
+    "Tags": [
+        "Teacher",
+        "Schoolgirl Outfit",
+        "Cheating",
+        "Hentai",
+        "Ahegao",
+        "Creampie",
+        "Uncensored",
+        "Condom",
+        "Unlimited",
+        "Heart Pupils",
+        "Love Hotel"
+    ],
+    "Thumb": "https://t.fakku.net/images/manga/a/after-school-english_1632947200_1632947200/thumbs/001.thumb.jpg",
+    "Title": "After School",
+    "URL": "https://www.fakku.net/hentai/after-school-english_1632947200",
+    "Released": "2021-10-12 16:00:03 UTC"
+}


### PR DESCRIPTION
If the koromo plugin is run on an info.json where the artist field is actually an array you'd get a garbage artist tag (artist:ARRAY-blabla). I'm not sure if it's because of an update to koromo, or if it's because it's a format mixup since info.json is apparently a very popular filename.

 This fixes this by allowing the artist field to be an array. Another way would be to return an error instead, but eh whatever.