### PR TITLE
Add category message

### DIFF
--- a/lib/LANraragi/Controller/Api/Category.pm
+++ b/lib/LANraragi/Controller/Api/Category.pm
@@ -101,7 +101,15 @@ sub add_to_category {
     my ( $result, $err ) = LANraragi::Model::Category::add_to_category( $catid, $arcid );
 
     if ($result) {
-        render_api_response( $self, "add_to_category" );
+        my $successMessage = "Added $arcid to Category $catid!";
+        my %category = LANraragi::Model::Category::get_category($catid);
+        my $title = LANraragi::Model::Archive::get_title($arcid);
+
+        if (%category && defined($title)) {
+            $successMessage = "Added \"$title\" to category \"$category{name}\"!";
+        }
+
+        render_api_response( $self, "add_to_category", undef, $successMessage );
     } else {
         render_api_response( $self, "add_to_category", $err );
     }

--- a/lib/LANraragi/Model/Archive.pm
+++ b/lib/LANraragi/Model/Archive.pm
@@ -4,6 +4,9 @@ use strict;
 use warnings;
 use utf8;
 
+use feature qw(signatures);
+no warnings 'experimental::signatures';
+
 use Cwd 'abs_path';
 use Redis;
 use Time::HiRes qw(usleep);
@@ -17,6 +20,22 @@ use LANraragi::Utils::Logging qw(get_logger);
 use LANraragi::Utils::Archive qw(extract_single_file extract_thumbnail);
 use LANraragi::Utils::Database
   qw(redis_encode redis_decode invalidate_cache set_title set_tags get_archive_json get_archive_json_multi);
+
+# get_archive(id)
+#   Returns the title for the archive matching the given id.
+#   Returns undef if the id doesn't exist.
+sub get_title($id) {
+
+    my $logger = get_logger( "Archives", "lanraragi" );
+    my $redis  = LANraragi::Model::Config->get_redis;
+
+    if ( $id eq "" ) {
+        $logger->debug("No archive ID provided.");
+        return ();
+    }
+
+    return $redis->hget( $id, "title" );
+}
 
 # Functions used when dealing with archives.
 

--- a/lib/LANraragi/Utils/Generic.pm
+++ b/lib/LANraragi/Utils/Generic.pm
@@ -67,14 +67,15 @@ sub is_archive {
 # Renders the basic success API JSON template.
 # Specifying an error message argument will set the success variable to 0.
 sub render_api_response {
-    my ( $mojo, $operation, $errormessage ) = @_;
+    my ( $mojo, $operation, $errormessage, $successMessage ) = @_;
     my $failed = ( defined $errormessage );
 
     $mojo->render(
         json => {
-            operation => $operation,
-            error     => $failed ? $errormessage : "",
-            success   => $failed ? 0 : 1
+            operation       => $operation,
+            error           => $failed ? $errormessage : "",
+            success         => $failed ? 0 : 1,
+            successMessage  => $failed ? "" : $successMessage,
         },
         status => $failed ? 400 : 200
     );

--- a/public/js/server.js
+++ b/public/js/server.js
@@ -22,9 +22,13 @@ Server.callAPI = function (endpoint, method, successMessage, errorMessage, succe
             if (Object.prototype.hasOwnProperty.call(data, "success") && !data.success) {
                 throw new Error(data.error);
             } else {
-                if (successMessage !== null) {
+                let message = successMessage;
+                if ("successMessage" in data && data.successMessage !== null) {
+                    message = data.successMessage;
+                }
+                if (message !== null) {
                     LRR.toast({
-                        heading: successMessage,
+                        heading: message,
                         icon: "success",
                         hideAfter: 7000,
                     });

--- a/tools/Documentation/api-documentation/category-api.md
+++ b/tools/Documentation/api-documentation/category-api.md
@@ -197,7 +197,8 @@ Archive ID to add.
 ```
 {
   "operation": "add_to_category",
-  "success": 1
+  "success": 1,
+  "successMessage": "Added \"Name of archive\" to category \"Name of category\""
 }
 ```
 {% endswagger-response %}


### PR DESCRIPTION
This PR makes the toast after adding an archive to a category more helpful.
Before:
![image](https://user-images.githubusercontent.com/124937394/226067042-58b21a4a-27a2-4dd8-bd76-410c6136c659.png)
After:
![image](https://user-images.githubusercontent.com/124937394/226066947-7a370d2c-ed25-4631-b81c-fa140ff7ba8a.png)

More interestingly, it also adds support for backend code (aka perl) to return the success message that appears in toasts.