### PR TITLE
Add OPDS-PS1 1.2 support for lastReadDate

### DIFF
--- a/lib/LANraragi/Controller/Api/Archive.pm
+++ b/lib/LANraragi/Controller/Api/Archive.pm
@@ -206,8 +206,7 @@ sub update_progress {
 
     # Just set the progress value.
     $redis->hset( $id, "progress", $page );
-    my $progressUpdatedTime = time();
-    $redis->hset( $id, "lastreaddate", $progressUpdatedTime);
+    $redis->hset( $id, "lastreadtime", time());
 
     # Update total pages read statistic
     $redis_cfg->incr("LRR_TOTALPAGESTAT");

--- a/lib/LANraragi/Controller/Api/Archive.pm
+++ b/lib/LANraragi/Controller/Api/Archive.pm
@@ -206,6 +206,8 @@ sub update_progress {
 
     # Just set the progress value.
     $redis->hset( $id, "progress", $page );
+    my $progressUpdatedTime = time();
+    $redis->hset( $id, "lastreaddate", $progressUpdatedTime);
 
     # Update total pages read statistic
     $redis_cfg->incr("LRR_TOTALPAGESTAT");

--- a/lib/LANraragi/Model/Opds.pm
+++ b/lib/LANraragi/Model/Opds.pm
@@ -117,6 +117,10 @@ sub get_opds_data {
         $arcdata->{mimetype} = "application/x-cbz";
     }
 
+    if ( $arcdata->{lastreaddate} > 0) {
+      $arcdata->{lastreaddate} = strftime( "%Y-%m-%dT%H:%M:%SZ", gmtime($arcdata->{lastreaddate}) );
+    }
+
     for ( values %{$arcdata} ) { $_ = xml_escape($_); }
 
     return $arcdata;

--- a/lib/LANraragi/Model/Opds.pm
+++ b/lib/LANraragi/Model/Opds.pm
@@ -117,8 +117,8 @@ sub get_opds_data {
         $arcdata->{mimetype} = "application/x-cbz";
     }
 
-    if ( $arcdata->{lastreaddate} > 0) {
-      $arcdata->{lastreaddate} = strftime( "%Y-%m-%dT%H:%M:%SZ", gmtime($arcdata->{lastreaddate}) );
+    if ( $arcdata->{lastreadtime} > 0) {
+      $arcdata->{lastreaddate} = strftime( "%Y-%m-%dT%H:%M:%SZ", gmtime($arcdata->{lastreadtime}) );
     }
 
     for ( values %{$arcdata} ) { $_ = xml_escape($_); }

--- a/lib/LANraragi/Utils/Database.pm
+++ b/lib/LANraragi/Utils/Database.pm
@@ -171,7 +171,7 @@ sub build_json ( $id, %hash ) {
 
     # It's not a new archive, but it might have never been clicked on yet,
     # so grab the value for $isnew stored in redis.
-    my ( $name, $title, $tags, $file, $isnew, $progress, $pagecount ) = @hash{qw(name title tags file isnew progress pagecount)};
+    my ( $name, $title, $tags, $file, $isnew, $progress, $pagecount, $lastreaddate) = @hash{qw(name title tags file isnew progress pagecount lastreaddate)};
 
     # Return undef if the file doesn't exist.
     return unless ( defined($file) && -e $file );
@@ -191,7 +191,8 @@ sub build_json ( $id, %hash ) {
         isnew     => $isnew ? $isnew : "false",
         extension => lc( ( split( /\./, $file ) )[-1] ),
         progress  => $progress ? int($progress) : 0,
-        pagecount => $pagecount ? int($pagecount) : 0
+        pagecount => $pagecount ? int($pagecount) : 0,
+        lastreaddate => $lastreaddate ? int($lastreaddate) : 0
     };
 
     return $arcdata;

--- a/lib/LANraragi/Utils/Database.pm
+++ b/lib/LANraragi/Utils/Database.pm
@@ -171,7 +171,7 @@ sub build_json ( $id, %hash ) {
 
     # It's not a new archive, but it might have never been clicked on yet,
     # so grab the value for $isnew stored in redis.
-    my ( $name, $title, $tags, $file, $isnew, $progress, $pagecount, $lastreaddate) = @hash{qw(name title tags file isnew progress pagecount lastreaddate)};
+    my ( $name, $title, $tags, $file, $isnew, $progress, $pagecount, $lastreadtime) = @hash{qw(name title tags file isnew progress pagecount lastreadtime)};
 
     # Return undef if the file doesn't exist.
     return unless ( defined($file) && -e $file );
@@ -192,7 +192,7 @@ sub build_json ( $id, %hash ) {
         extension => lc( ( split( /\./, $file ) )[-1] ),
         progress  => $progress ? int($progress) : 0,
         pagecount => $pagecount ? int($pagecount) : 0,
-        lastreaddate => $lastreaddate ? int($lastreaddate) : 0
+        lastreadtime => $lastreadtime ? int($lastreadtime) : 0
     };
 
     return $arcdata;

--- a/templates/opds.html.tt2
+++ b/templates/opds.html.tt2
@@ -62,7 +62,9 @@
         <link rel="http://opds-spec.org/acquisition" href="/api/archives/[% arc.arcid %]/download[% api_key_query %]" title="Download/Read"
             type="[% arc.mimetype %]" />
         <link rel="http://vaemendis.net/opds-pse/stream" type="image/jpeg"
-            href="/api/opds/[% arc.arcid %]/pse?page={pageNumber}[% api_key_and %]" pse:count="[% arc.pagecount %]" [% IF arc.progress %] pse:lastRead="[% arc.progress %]" [% END %]/>
+            href="/api/opds/[% arc.arcid %]/pse?page={pageNumber}[% api_key_and %]" pse:count="[% arc.pagecount %]" 
+            [% IF arc.progress %] pse:lastRead="[% arc.progress %]" [% END %] 
+            [% IF arc.lastreaddate %] pse:lastReadDate="[% arc.lastreaddate %]" [% END %]/>
         <link type="text/html" rel="alternate" title="Open in LANraragi" href="/reader?id=[% arc.arcid %][% api_key_and %]" />
     </entry>
     [% END %]

--- a/templates/opds_entry.html.tt2
+++ b/templates/opds_entry.html.tt2
@@ -33,7 +33,9 @@
     <link rel="http://opds-spec.org/acquisition" href="/api/archives/[% arc.arcid %]/download[% api_key_query %]" title="Download/Read"
         type="[% arc.mimetype %]" />
     <link rel="http://vaemendis.net/opds-pse/stream" type="image/jpeg"
-        href="/api/opds/[% arc.arcid %]/pse?page={pageNumber}[% api_key_and %]" pse:count="[% arc.pagecount %]" [% IF arc.progress %] pse:lastRead="[% arc.progress %]" [% END %]/>
+        href="/api/opds/[% arc.arcid %]/pse?page={pageNumber}[% api_key_and %]" pse:count="[% arc.pagecount %]" 
+        [% IF arc.progress %] pse:lastRead="[% arc.progress %]" [% END %] 
+        [% IF arc.lastreaddate %] pse:lastReadDate="[% arc.lastreaddate %]" [% END %] />
     <link type="text/html" rel="alternate" title="Open in LANraragi" href="/reader?id=[% arc.arcid %][% api_key_and %]" />
 
 </entry>

--- a/tests/mocks.pl
+++ b/tests/mocks.pl
@@ -40,7 +40,8 @@ sub setup_redis_mock {
             "progress": 10,
             "tags": "character:segata sanshiro, male:very cool",
             "title": "Saturn Backup Cartridge - Japanese Manual",
-            "file": "package.json"
+            "file": "package.json",
+            "lastreadtime": 1589038280
         },
         "e69e43e1355267f7d32a4f9b7f2fe108d2401ebg": {
             "isnew": "false",
@@ -48,7 +49,8 @@ sub setup_redis_mock {
             "progress": 34,
             "tags": "character:segata, female:very cool too",
             "title": "Saturn Backup Cartridge - American Manual",
-            "file": "package.json"
+            "file": "package.json",
+            "lastreadtime": 1589038280
         },
         "e4c422fd10943dc169e3489a38cdbf57101a5f7e": {
             "isnew": "true",
@@ -56,7 +58,8 @@ sub setup_redis_mock {
             "progress": 0,
             "tags": "parody: jojo's bizarre adventure",
             "title": "Rohan Kishibe goes to Gucci",
-            "file": "package.json"
+            "file": "package.json",
+            "lastreadtime": 0
         },
         "4857fd2e7c00db8b0af0337b94055d8445118630": {
             "isnew": "false",
@@ -64,7 +67,8 @@ sub setup_redis_mock {
             "progress": 34,
             "tags": "artist:shirow masamune",
             "title": "Ghost in the Shell 1.5 - Human-Error Processor vol01ch01",
-            "file": "package.json"
+            "file": "package.json",
+            "lastreadtime": 1589038280
         },
         "2810d5e0a8d027ecefebca6237031a0fa7b91eb3": {
             "isnew": "false",
@@ -72,7 +76,8 @@ sub setup_redis_mock {
             "progress": 34,
             "tags": "parody:fate grand order,  character:abigail williams,  character:artoria pendragon alter,  character:asterios,  character:ereshkigal,  character:gilgamesh,  character:hans christian andersen,  character:hassan of serenity,  character:hector,  character:helena blavatsky,  character:irisviel von einzbern,  character:jeanne alter,  character:jeanne darc,  character:kiara sessyoin,  character:kiyohime,  character:lancer,  character:martha,  character:minamoto no raikou,  character:mochizuki chiyome,  character:mordred pendragon,  character:nitocris,  character:oda nobunaga,  character:osakabehime,  character:penthesilea,  character:queen of sheba,  character:rin tosaka,  character:saber,  character:sakata kintoki,  character:scheherazade,  character:sherlock holmes,  character:suzuka gozen,  character:tamamo no mae,  character:ushiwakamaru,  character:waver velvet,  character:xuanzang,  character:zhuge liang,  group:wadamemo,  artist:wada rco,  artbook,  full color",
             "title": "Fate GO MEMO 2",
-            "file": "package.json"
+            "file": "package.json",
+            "lastreadtime": 1589038280
         },
         "28697b96f0ac5858be2614ed10ca47742c9522fd": {
             "isnew": "false",
@@ -80,7 +85,8 @@ sub setup_redis_mock {
             "progress": 0,
             "tags": "parody:fate grand order,  group:wadamemo,  artist:wada rco,  artbook,  full color, male:very cool too",
             "title": "Fate GO MEMO",
-            "file": "package.json"
+            "file": "package.json",
+            "lastreadtime": 0
         }
     })
       };

--- a/tests/samples/opds/opds_sample.xml
+++ b/tests/samples/opds/opds_sample.xml
@@ -96,7 +96,7 @@
         <link rel="http://opds-spec.org/acquisition" href="/api/archives/2810d5e0a8d027ecefebca6237031a0fa7b91eb3/download" title="Download/Read"
             type="application/x-cbz" />
         <link rel="http://vaemendis.net/opds-pse/stream" type="image/jpeg"
-            href="/api/opds/2810d5e0a8d027ecefebca6237031a0fa7b91eb3/pse?page={pageNumber}" pse:count="34"  pse:lastRead="34" />
+            href="/api/opds/2810d5e0a8d027ecefebca6237031a0fa7b91eb3/pse?page={pageNumber}" pse:count="34"  pse:lastRead="34" pse:lastReadDate="2020-05-09T15:31:20Z" />
         <link type="text/html" rel="alternate" title="Open in LANraragi" href="/reader?id=2810d5e0a8d027ecefebca6237031a0fa7b91eb3" />
     </entry>
     
@@ -126,7 +126,7 @@
         <link rel="http://opds-spec.org/acquisition" href="/api/archives/4857fd2e7c00db8b0af0337b94055d8445118630/download" title="Download/Read"
             type="application/x-cbz" />
         <link rel="http://vaemendis.net/opds-pse/stream" type="image/jpeg"
-            href="/api/opds/4857fd2e7c00db8b0af0337b94055d8445118630/pse?page={pageNumber}" pse:count="34"  pse:lastRead="34" />
+            href="/api/opds/4857fd2e7c00db8b0af0337b94055d8445118630/pse?page={pageNumber}" pse:count="34"  pse:lastRead="34" pse:lastReadDate="2020-05-09T15:31:20Z" />
         <link type="text/html" rel="alternate" title="Open in LANraragi" href="/reader?id=4857fd2e7c00db8b0af0337b94055d8445118630" />
     </entry>
     
@@ -186,7 +186,7 @@
         <link rel="http://opds-spec.org/acquisition" href="/api/archives/e69e43e1355267f7d32a4f9b7f2fe108d2401ebg/download" title="Download/Read"
             type="application/x-cbz" />
         <link rel="http://vaemendis.net/opds-pse/stream" type="image/jpeg"
-            href="/api/opds/e69e43e1355267f7d32a4f9b7f2fe108d2401ebg/pse?page={pageNumber}" pse:count="200"  pse:lastRead="34" />
+            href="/api/opds/e69e43e1355267f7d32a4f9b7f2fe108d2401ebg/pse?page={pageNumber}" pse:count="200"  pse:lastRead="34" pse:lastReadDate="2020-05-09T15:31:20Z" />
         <link type="text/html" rel="alternate" title="Open in LANraragi" href="/reader?id=e69e43e1355267f7d32a4f9b7f2fe108d2401ebg" />
     </entry>
     
@@ -216,7 +216,7 @@
         <link rel="http://opds-spec.org/acquisition" href="/api/archives/e69e43e1355267f7d32a4f9b7f2fe108d2401ebf/download" title="Download/Read"
             type="application/x-cbz" />
         <link rel="http://vaemendis.net/opds-pse/stream" type="image/jpeg"
-            href="/api/opds/e69e43e1355267f7d32a4f9b7f2fe108d2401ebf/pse?page={pageNumber}" pse:count="2"  pse:lastRead="10" />
+            href="/api/opds/e69e43e1355267f7d32a4f9b7f2fe108d2401ebf/pse?page={pageNumber}" pse:count="2"  pse:lastRead="10" pse:lastReadDate="2020-05-09T15:31:20Z" />
         <link type="text/html" rel="alternate" title="Open in LANraragi" href="/reader?id=e69e43e1355267f7d32a4f9b7f2fe108d2401ebf" />
     </entry>
     


### PR DESCRIPTION
This address https://github.com/Difegue/LANraragi/issues/773 by adding lastReadDate support to the OPDS API endpoints. If server side progress is enabled, lastReadDate is saved whenever progress is updated. OPDS API request will include the lastReadDate field if it's available.

This does not add support for the main LRR app, for example:
- lastReadDate is not rendered in the UI
- lastReadDate is not supported in queries
- Documentation has not been updated