### PR TITLE
Allow configuring redis hostname through an env variable

### DIFF
--- a/lib/LANraragi/Model/Config.pm
+++ b/lib/LANraragi/Model/Config.pm
@@ -16,6 +16,9 @@ my $home = Mojo::Home->new;
 $home->detect;
 
 my $config = Mojolicious::Plugin::Config->register( Mojolicious->new, { file => $home . '/lrr.conf' } );
+if ($ENV{LRR_REDIS_ADDRESS}) {
+    $config->{redis_address} = $ENV{LRR_REDIS_ADDRESS};
+}
 
 # Address and port of your redis instance.
 sub get_redisad { return $config->{redis_address} }

--- a/tools/Documentation/extending-lanraragi/architecture.md
+++ b/tools/Documentation/extending-lanraragi/architecture.md
@@ -17,7 +17,8 @@ Those variables were introduced for the Homebrew package, but they can be declar
 * `LRR_TEMP_DIRECTORY` - Temporary directory override. If this variable is set to a path, the temporary folder will be there instead of `/public/temp`.
 * `LRR_LOG_DIRECTORY` - Log directory override. Changes the location of the `log` folder.
 * `LRR_FORCE_DEBUG` - Debug Mode override. This will force Debug Mode to be enabled regardless of the user setting.
-* `LRR_NETWORK` - Network Interface. See the dedicated page in Advanced Operations.
+* `LRR_NETWORK` - Network Interface. See the dedicated page in Advanced Operations.  
+* `LRR_REDIS_ADDRESS` - Redis adress override. This has priority over the `redis_address` specified in `lrr.conf`.  
 
 ## Coding Style
 


### PR DESCRIPTION
Allow setting the redis hostname through an environment variable, using whatever is set in lrr.conf as default. This makes it much easier to run redis in a separate container.