### PR TITLE
Setup docker-compose for a dev environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+---
+# Docker compose file for dev environments.
+services:
+  lanraragi:
+    build:
+      dockerfile: tools/build/docker/Dockerfile-dev
+      context: .
+    volumes:
+      - ./:/home/koyomi/lanraragi
+    ports:
+      - "3000:3000"
+    environment:
+      - "LRR_REDIS_ADDRESS=redis:6379"
+    networks:
+      - lrr
+
+  redis:
+    image: "docker.io/redis:7"
+    volumes:
+      - redis_data:/data
+    networks:
+      - lrr
+
+networks:
+  lrr:
+
+volumes:
+  redis_data:

--- a/tools/Documentation/extending-lanraragi/index.md
+++ b/tools/Documentation/extending-lanraragi/index.md
@@ -20,3 +20,8 @@ Said development server can be ran with the `npm run dev-server` command.
 The major difference is that this server will automatically reload when you modify any file within LANraragi. Background worker included!
 
 You'll also probably want to enable **Debug Mode** in the LRR Options, as that will allow you to view debug-tier logs, alongside the raw Mojolicious logs.
+
+## Using docker compose
+
+You can use [Docker Compose](https://docs.docker.com/compose/) for quickly bringing up a LANraragi instance suitable for development.
+Run `docker compose up -d` inside `tools/build/docker` and hack away!

--- a/tools/build/docker/Dockerfile-dev
+++ b/tools/build/docker/Dockerfile-dev
@@ -1,0 +1,45 @@
+# DOCKER-VERSION 0.3.4
+FROM        alpine:3.16
+
+#Default mojo server port
+EXPOSE 3000
+
+# Enable UTF-8 (might not do anything extra on alpine tho)
+ENV LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 \
+    # rootless user id
+    LRR_UID=1000 LRR_GID=1000 \
+    # Environment variables overridable by the user on container deployment
+    LRR_NETWORK=http://*:3000 \
+    # extra variables
+    EV_EXTRA_DEFS=-DEV_NO_ATFORK \
+    # Enable automatic http proxy detection for mojo
+    MOJO_PROXY=1 \
+    # Allow Mojo to automatically pick up the X-Forwarded-For and X-Forwarded-Proto headers
+    MOJO_REVERSE_PROXY=1
+
+RUN \
+  if [ $(getent group ${LRR_GID}) ]; then \
+    adduser -D -u ${LRR_UID} koyomi; \
+  else \
+    addgroup -g ${LRR_GID} koyomi && \
+    adduser -D -u ${LRR_UID} -G koyomi koyomi; \
+fi
+
+WORKDIR /tmp/lrr
+
+#Copy cpanfile and install script before copying the entire context
+#This allows for Docker cache to preserve cpan dependencies
+COPY --chown=koyomi:koyomi /tools/cpanfile /tools/install.pl /tools/build/docker/install-everything.sh tools/
+COPY --chown=koyomi:koyomi /package.json package.json
+
+# Run the install script as root
+RUN sh ./tools/install-everything.sh
+
+RUN rm -rf /tmp/lrr
+
+RUN apk add npm
+# We're done, since this is not a production build.
+
+WORKDIR /home/koyomi/lanraragi
+USER koyomi
+CMD ["npm", "run", "dev-server"]

--- a/tools/build/docker/docker-compose.yml
+++ b/tools/build/docker/docker-compose.yml
@@ -4,9 +4,9 @@ services:
   lanraragi:
     build:
       dockerfile: tools/build/docker/Dockerfile-dev
-      context: .
+      context: ../../..
     volumes:
-      - ./:/home/koyomi/lanraragi
+      - ../../../:/home/koyomi/lanraragi
     ports:
       - "3000:3000"
     environment:


### PR DESCRIPTION
Yo!

This adds a docker-compose based solution for bringing up a generic development environment that doesn't rely on the devcontainer standard. Thanks to this, it's easier to use for non-vscode users. It uses the same alpine version as production (unlike the current devcontainer image), **but** keeps redis in a separate container for simplicity.

It's not tested on windows or macos, but I don't see anything inherently incompatible with those platforms.