### PR TITLE
Improve docker dev

### DIFF
--- a/tools/build/docker/Dockerfile-dev
+++ b/tools/build/docker/Dockerfile-dev
@@ -38,6 +38,11 @@ RUN sh ./tools/install-everything.sh
 RUN rm -rf /tmp/lrr
 
 RUN apk add npm
+
+# Add sudo to make dev more practical, and allow passwordless sudo
+RUN apk add --update sudo
+RUN echo "koyomi ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/koyomi && chmod 0440 /etc/sudoers.d/koyomi
+
 # We're done, since this is not a production build.
 
 WORKDIR /home/koyomi/lanraragi

--- a/tools/build/docker/Dockerfile-dev
+++ b/tools/build/docker/Dockerfile-dev
@@ -32,8 +32,8 @@ WORKDIR /tmp/lrr
 COPY --chown=koyomi:koyomi /tools/cpanfile /tools/install.pl /tools/build/docker/install-everything.sh tools/
 COPY --chown=koyomi:koyomi /package.json package.json
 
-# Run the install script as root
-RUN sh ./tools/install-everything.sh
+# Run the install script as root, in dev mode to prevent wget etc from being uninstalled
+RUN sh ./tools/install-everything.sh -d
 
 RUN rm -rf /tmp/lrr
 

--- a/tools/build/docker/install-everything.sh
+++ b/tools/build/docker/install-everything.sh
@@ -1,5 +1,20 @@
 #!/bin/sh
 
+usage() { echo "Usage: $0 [-d]" 1>&2; exit 1; }
+
+DEV=0
+
+while getopts "d" o; do
+    case "${o}" in
+        d)
+            DEV=1
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
 #Just do everything
 apk update
 apk add tzdata
@@ -48,7 +63,9 @@ fi
 cd tools && cpanm --notest --installdeps . -M https://cpan.metacpan.org && cd ..
 npm run lanraragi-installer install-full
 
-#Cleanup to lighten the image
-apk del perl-dev g++ make gnupg wget curl nodejs npm openssl-dev file
-rm -rf public/js/vendor/*.map public/css/vendor/*.map
-rm -rf /root/.cpanm/* /root/.npm/ /usr/local/share/man/* node_modules /var/cache/apk/*
+if [ $DEV -eq 0 ]; then
+  #Cleanup to lighten the image
+  apk del perl-dev g++ make gnupg wget curl nodejs npm openssl-dev file
+  rm -rf public/js/vendor/*.map public/css/vendor/*.map
+  rm -rf /root/.cpanm/* /root/.npm/ /usr/local/share/man/* node_modules /var/cache/apk/*
+fi

--- a/tools/cpanfile
+++ b/tools/cpanfile
@@ -30,6 +30,7 @@ requires 'Logfile::Rotate', 1.04;
 requires 'Compress::Zlib',  2.087;
 
 # Test Utils
+requires 'App::Prove',       1.7046;
 requires 'Test::Harness',    3.42;
 requires 'Test::MockObject', 1.20200122;
 requires 'Test::Trap',       0.3.4;


### PR DESCRIPTION
The new generic docker container had a few warts. This fixes a few things:

* Adds sudo support
* Install prove to make `npm run test` work out of the box
* Make cpanm work