### PR TITLE
Fix broken encoding for titles

### DIFF
--- a/lib/LANraragi/Model/Archive.pm
+++ b/lib/LANraragi/Model/Archive.pm
@@ -34,7 +34,7 @@ sub get_title($id) {
         return ();
     }
 
-    return $redis->hget( $id, "title" );
+    return redis_decode($redis->hget( $id, "title" ));
 }
 
 # Functions used when dealing with archives.


### PR DESCRIPTION
get_title didn't handle text encoding properly, which caused non-trivial characters getting fucked in the "add to/remove from category" toasts.