### PR TITLE
Fix "Uncaught TypeError" when attempting to navigate past last page in infinte scroll mode

### DIFF
--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -470,7 +470,7 @@ Reader.goToPage = function (page) {
     Reader.showingSinglePage = false;
 
     if (Reader.infiniteScroll) {
-        $("#display img").get(page).scrollIntoView({ behavior: "smooth" });
+        $("#display img").get(Reader.currentPage).scrollIntoView({ behavior: "smooth" });
     } else {
         $("#img_doublepage").attr("src", "");
         $("#display").removeClass("double-mode");


### PR DESCRIPTION
Pretty much what the title says.
Fixes an exception if you try to navigate to the next page using keyboard shortcuts in infinite scroll mode.