### PR TITLE
avoid await at top level

### DIFF
--- a/templates/reader.html.tt2
+++ b/templates/reader.html.tt2
@@ -28,8 +28,12 @@
     <script src="./js/server.js?[% version %]" type="text/javascript"></script>
     <script src="./js/reader.js?[% version %]" type="text/javascript"></script>
 
-    <script
-        type="module">window.fscreen = (await import('./js/vendor/fscreen.esm.js')).default; Reader.initializeAll();</script>
+    <script type="module">
+        import('./js/vendor/fscreen.esm.js').then( r => {
+            window.fscreen = r.default;
+            Reader.initializeAll();
+        })
+    </script>
 </head>
 
 <body>


### PR DESCRIPTION
`await` at top level seems not be allowed in some old browser (Andoird webview in my case).
By using `then` instead, we can enhance compatibility without any loss.