### PR TITLE
fix img lazy loading

### DIFF
--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -272,9 +272,11 @@ Reader.initInfiniteScrollView = function () {
 
     Reader.pages.slice(1).forEach((source) => {
         const img = new Image();
-        img.src = source;
         img.id = `page-${Reader.pages.indexOf(source)}`;
         img.loading = "lazy";
+        img.height = 800;
+        img.width = 600;
+        img.src = source;
         $(img).addClass("reader-image");
         $("#display").append(img);
         observer.observe(img);


### PR DESCRIPTION
Lazy loading will not take effort if the size is unknow, the img will be assumed as 0×0 pixels thus all img will be loaded.

By the way, this patch shows significant difference in loading at Firefox while Chrome still tries loading all img.
It seems that Chrome has more aggressive loading strategy.
I don't if there is a better solution.

