### PR TITLE
add magazines to koromo

### DIFF
--- a/lib/LANraragi/Plugin/Metadata/Koromo.pm
+++ b/lib/LANraragi/Plugin/Metadata/Koromo.pm
@@ -102,6 +102,7 @@ sub tags_from_koromo_json {
     my $tags       = $hash->{"Tags"};
     my $characters = $hash->{"Characters"};
     my $series     = $hash->{"Series"};
+    my $magazine   = $hash->{"Magazine"};
     my $parody     = $hash->{"Parody"};
     my $groups     = $hash->{"Groups"};
     my $artist     = $hash->{"Artist"};
@@ -132,6 +133,7 @@ sub tags_from_koromo_json {
 
     push( @found_tags, "series:" . $parody ) unless !$parody;
 
+
     # Don't add bogus artist:ARRAYblabla if artist is an array
     if ($artist) {
         if ( ref $artist eq 'ARRAY' ) {
@@ -143,6 +145,7 @@ sub tags_from_koromo_json {
         }
     }
 
+    push( @found_tags, "magazine:" . $magazine ) unless !$magazine;
     push( @found_tags, "language:" . $language ) unless !$language;
     push( @found_tags, "category:" . $type )     unless !$type;
     push( @found_tags, "source:" . $url )        unless !$url;

--- a/tests/LANraragi/Plugin/Metadata/Koromo.t
+++ b/tests/LANraragi/Plugin/Metadata/Koromo.t
@@ -38,7 +38,7 @@ note("Koromo Tests");
     my %ko_tags = trap { LANraragi::Plugin::Metadata::Koromo::get_tags( "", \%dummyhash, 1 ); };
 
     my $expected_tags =
-      "Teacher, Schoolgirl Outfit, Cheating, Hentai, Ahegao, Creampie, Uncensored, Condom, Unlimited, Heart Pupils, Love Hotel, series:Original Work, artist:▲ Chimaki, language:English, source:https://www.fakku.net/hentai/after-school-english_1632947200";
+      "Teacher, Schoolgirl Outfit, Cheating, Hentai, Ahegao, Creampie, Uncensored, Condom, Unlimited, Heart Pupils, Love Hotel, series:Original Work, artist:▲ Chimaki, magazine:Comic Bavel 2021-11, language:English, source:https://www.fakku.net/hentai/after-school-english_1632947200";
     is( $ko_tags{title}, "After School", "Koromo parsing test 1/2" );
     is( $ko_tags{tags},  $expected_tags, "Koromo parsing test 2/2" );
 }
@@ -63,7 +63,7 @@ note("multiple artists json");
     my %ko_tags = trap { LANraragi::Plugin::Metadata::Koromo::get_tags( "", \%dummyhash, 1 ); };
 
     my $expected_tags =
-      "Teacher, Schoolgirl Outfit, Cheating, Hentai, Ahegao, Creampie, Uncensored, Condom, Unlimited, Heart Pupils, Love Hotel, series:Original Work, artist:First, artist:Second, language:English, source:https://www.fakku.net/hentai/after-school-english_1632947200";
+      "Teacher, Schoolgirl Outfit, Cheating, Hentai, Ahegao, Creampie, Uncensored, Condom, Unlimited, Heart Pupils, Love Hotel, series:Original Work, artist:First, artist:Second, magazine:Comic Bavel 2021-11, language:English, source:https://www.fakku.net/hentai/after-school-english_1632947200";
     is( $ko_tags{title}, "After School", "Koromo parsing test 1/2" );
     is( $ko_tags{tags},  $expected_tags, "Koromo parsing test 2/2" );
 }


### PR DESCRIPTION
the koromo metadata files have a magazine field (e.g COMIC LO..), but the LRR plugin did not add it before. 
Already included in the test samples, so no need to update that. 
oh.. the expected tags do need to be updated in the tests lol