### PR TITLE
add support for jxl thumbnails

### DIFF
--- a/lib/LANraragi/Controller/Config.pm
+++ b/lib/LANraragi/Controller/Config.pm
@@ -44,6 +44,7 @@ sub index {
         usedatemodified => $self->LRR_CONF->use_lastmodified,
         enablecryptofs  => $self->LRR_CONF->enable_cryptofs,
         hqthumbpages    => $self->LRR_CONF->get_hqthumbpages,
+        jxlthumbpages   => $self->LRR_CONF->get_jxlthumbpages,
         csshead         => generate_themes_header($self),
         tempsize        => get_tempsize,
         replacedupe     => $self->LRR_CONF->get_replacedupe
@@ -85,6 +86,7 @@ sub save_config {
         usedatemodified => ( scalar $self->req->param('usedatemodified') ? '1' : '0' ),
         enablecryptofs  => ( scalar $self->req->param('enablecryptofs')  ? '1' : '0' ),
         hqthumbpages    => ( scalar $self->req->param('hqthumbpages')    ? '1' : '0' ),
+        jxlthumbpages   => ( scalar $self->req->param('jxlthumbpages')   ? '1' : '0' ),
         replacedupe     => ( scalar $self->req->param('replacedupe')     ? '1' : '0' ),
     );
 

--- a/lib/LANraragi/Model/Archive.pm
+++ b/lib/LANraragi/Model/Archive.pm
@@ -103,22 +103,26 @@ sub serve_thumbnail {
     my $thumbdir = LANraragi::Model::Config->get_thumbdir;
     my $use_jxl = LANraragi::Model::Config->get_jxlthumbpages;
     my $format = $use_jxl ? 'jxl' : 'jpg';
+    my $fallback_format = $format eq 'jxl' ? 'jpg' : 'jxl';
 
     # Thumbnails are stored in the content directory, thumb subfolder.
     # Another subfolder with the first two characters of the id is used for FS optimization.
     my $subfolder = substr( $id, 0, 2 );
-    my $thumbname = "$thumbdir/$subfolder/$id.$format";
 
-    if ( $page - 1 > 0 ) {
-        $thumbname = "$thumbdir/$subfolder/$id/$page.$format";
+    # Check for the page and set the appropriate thumbnail name and fallback thumbnail name
+    my $thumbname = ( $page - 1 > 0 ) ? "$thumbdir/$subfolder/$id/$page.$format" : "$thumbdir/$subfolder/$id.$format";
+    my $fallback_thumbname = ( $page - 1 > 0 ) ? "$thumbdir/$subfolder/$id/$page.$fallback_format" : "$thumbdir/$subfolder/$id.$fallback_format";
+
+    # Check if the preferred format thumbnail exists, if not, try the alternate format
+    unless ( -e $thumbname ) {
+        $thumbname = $fallback_thumbname;
     }
 
     # Queue a minion job to generate the thumbnail. Thumbnail jobs have the lowest priority.
     unless ( -e $thumbname ) {
         my $job_id = $self->minion->enqueue( thumbnail_task => [ $thumbdir, $id, $page ] => { priority => 0, attempts => 3 } );
 
-        if ($no_fallback) {
-
+        if ( $no_fallback ) {
             $self->render(
                 json => {
                     operation => "serve_thumbnail",
@@ -128,14 +132,11 @@ sub serve_thumbnail {
                 status => 202    # 202 Accepted
             );
         } else {
-
             # If the thumbnail doesn't exist, serve the default thumbnail.
             $self->render_file( filepath => "./public/img/noThumb.png" );
         }
         return;
-
     } else {
-
         # Simply serve the thumbnail.
         $self->render_file( filepath => $thumbname );
     }

--- a/lib/LANraragi/Model/Archive.pm
+++ b/lib/LANraragi/Model/Archive.pm
@@ -110,8 +110,9 @@ sub serve_thumbnail {
     my $subfolder = substr( $id, 0, 2 );
 
     # Check for the page and set the appropriate thumbnail name and fallback thumbnail name
-    my $thumbname = ( $page - 1 > 0 ) ? "$thumbdir/$subfolder/$id/$page.$format" : "$thumbdir/$subfolder/$id.$format";
-    my $fallback_thumbname = ( $page - 1 > 0 ) ? "$thumbdir/$subfolder/$id/$page.$fallback_format" : "$thumbdir/$subfolder/$id.$fallback_format";
+    my $thumbbase = ( $page - 1 > 0 ) ? "$thumbdir/$subfolder/$id/$page" : "$thumbdir/$subfolder/$id";
+    my $thumbname = "$thumbbase.$format";
+    my $fallback_thumbname = "$thumbbase.$fallback_format";
 
     # Check if the preferred format thumbnail exists, if not, try the alternate format
     unless ( -e $thumbname ) {

--- a/lib/LANraragi/Model/Archive.pm
+++ b/lib/LANraragi/Model/Archive.pm
@@ -57,11 +57,13 @@ sub update_thumbnail {
     $page = 1 unless $page;
 
     my $thumbdir = LANraragi::Model::Config->get_thumbdir;
+    my $use_jxl = LANraragi::Model::Config->get_jxlthumbpages;
+    my $format = $use_jxl ? 'jxl' : 'jpg';
 
     # Thumbnails are stored in the content directory, thumb subfolder.
     # Another subfolder with the first two characters of the id is used for FS optimization.
     my $subfolder = substr( $id, 0, 2 );
-    my $thumbname = "$thumbdir/$subfolder/$id.jpg";    # Path to main thumbnail
+    my $thumbname = "$thumbdir/$subfolder/$id.$format";    # Path to main thumbnail
 
     my $newthumb = "";
 
@@ -99,14 +101,16 @@ sub serve_thumbnail {
     $no_fallback = ( $no_fallback && $no_fallback eq "true" ) || "0";    # Prevent undef warnings by checking the variable first
 
     my $thumbdir = LANraragi::Model::Config->get_thumbdir;
+    my $use_jxl = LANraragi::Model::Config->get_jxlthumbpages;
+    my $format = $use_jxl ? 'jxl' : 'jpg';
 
     # Thumbnails are stored in the content directory, thumb subfolder.
     # Another subfolder with the first two characters of the id is used for FS optimization.
     my $subfolder = substr( $id, 0, 2 );
-    my $thumbname = "$thumbdir/$subfolder/$id.jpg";
+    my $thumbname = "$thumbdir/$subfolder/$id.$format";
 
     if ( $page - 1 > 0 ) {
-        $thumbname = "$thumbdir/$subfolder/$id/$page.jpg";
+        $thumbname = "$thumbdir/$subfolder/$id/$page.$format";
     }
 
     # Queue a minion job to generate the thumbnail. Thumbnail jobs have the lowest priority.

--- a/lib/LANraragi/Model/Config.pm
+++ b/lib/LANraragi/Model/Config.pm
@@ -185,6 +185,7 @@ sub enable_dateadded     { return &get_redis_conf( "usedateadded",    "1" ) }
 sub use_lastmodified     { return &get_redis_conf( "usedatemodified", "0" ) }
 sub enable_cryptofs      { return &get_redis_conf( "enablecryptofs",  "0" ) }
 sub get_hqthumbpages     { return &get_redis_conf( "hqthumbpages",    "0" ) }
+sub get_jxlthumbpages    { return &get_redis_conf( "jxlthumbpages",   "0" ) }
 sub get_replacedupe      { return &get_redis_conf( "replacedupe",     "0" ) }
 
 1;

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -41,29 +41,35 @@ sub is_pdf {
 
 # use ImageMagick to make a thumbnail, height = 500px (view in index is 280px tall)
 # If use_hq is true, the scale algorithm will be used instead of sample.
-sub generate_thumbnail ( $orig_path, $thumb_path, $use_hq ) {
+# If use_jxl is true, JPEG XL will be used instead of JPEG.
+sub generate_thumbnail ( $orig_path, $thumb_path, $use_hq, $use_jxl ) {
 
     my $img = Image::Magick->new;
+
+    my $format = $use_jxl ? 'jxl' : 'jpg';
 
     # For JPEG, the size option (or jpeg:size option) provides a hint to the JPEG decoder
     # that it can reduce the size on-the-fly during decoding. This saves memory because
     # it never has to allocate memory for the full-sized image
-    $img->Set( option => 'jpeg:size=500x' );
+    if ($format eq 'jpg') {
+        $img->Set(option => 'jpeg:size=500x');
+    }
 
     # If the image is a gif, only take the first frame
-    if ( $orig_path =~ /\.gif$/ ) {
-        $img->Read( $orig_path . "[0]" );
+    if ($orig_path =~ /\.gif$/) {
+        $img->Read($orig_path . "[0]");
     } else {
         $img->Read($orig_path);
     }
 
     # The "-scale" resize operator is a simplified, faster form of the resize command.
     if ($use_hq) {
-        $img->Scale( geometry => '500x1000' );
-    } else {    # Sample is very fast due to not applying filters.
-        $img->Sample( geometry => '500x1000' );
+        $img->Scale(geometry => '500x1000');
+    } else { # Sample is very fast due to not applying filters.
+        $img->Sample(geometry => '500x1000');
     }
-    $img->Set( quality => "50", magick => "jpg" );
+
+    $img->Set(quality => "50", magick => $format);
     $img->Write($thumb_path);
     undef $img;
 }
@@ -150,9 +156,13 @@ sub extract_thumbnail ( $thumbdir, $id, $page, $use_hq ) {
 
     my $logger = get_logger( "Archive", "lanraragi" );
 
+    # JPG is used for thumbnails by default
+    my $use_jxl = LANraragi::Model::Config->get_jxlthumbpages;
+    my $format = $use_jxl ? 'jxl' : 'jpg';
+
     # Another subfolder with the first two characters of the id is used for FS optimization.
     my $subfolder = substr( $id, 0, 2 );
-    my $thumbname = "$thumbdir/$subfolder/$id.jpg";
+    my $thumbname = "$thumbdir/$subfolder/$id.$format";
     make_path("$thumbdir/$subfolder");
 
     my $redis = LANraragi::Model::Config->get_redis;
@@ -176,7 +186,7 @@ sub extract_thumbnail ( $thumbdir, $id, $page, $use_hq ) {
     if ( $page - 1 > 0 ) {
 
         # Non-cover thumbnails land in a dedicated folder.
-        $thumbname = "$thumbdir/$subfolder/$id/$page.jpg";
+        $thumbname = "$thumbdir/$subfolder/$id/$page.$format";
         make_path("$thumbdir/$subfolder/$id");
     } else {
 
@@ -189,7 +199,7 @@ sub extract_thumbnail ( $thumbdir, $id, $page, $use_hq ) {
     }
 
     # Thumbnail generation
-    generate_thumbnail( $arcimg, $thumbname, $use_hq );
+    generate_thumbnail( $arcimg, $thumbname, $use_hq, $use_jxl );
 
     # Clean up safe folder
     remove_tree($temppath);

--- a/lib/LANraragi/Utils/Database.pm
+++ b/lib/LANraragi/Utils/Database.pm
@@ -226,9 +226,12 @@ sub delete_archive($id) {
     if ( -e $filename ) {
         unlink $filename;
 
+        my $use_jxl = LANraragi::Model::Config->get_jxlthumbpages;
+        my $format = $use_jxl ? 'jxl' : 'jpg';
         my $thumbdir  = LANraragi::Model::Config->get_thumbdir;
         my $subfolder = substr( $id, 0, 2 );
-        my $thumbname = "$thumbdir/$subfolder/$id.jpg";
+        my $thumbname = "$thumbdir/$subfolder/$id.$format";
+        # this should probablydelete the thumbpages folder too?
 
         unlink $thumbname;
 

--- a/lib/LANraragi/Utils/Database.pm
+++ b/lib/LANraragi/Utils/Database.pm
@@ -11,6 +11,7 @@ use Digest::SHA qw(sha256_hex);
 use Mojo::JSON qw(decode_json);
 use Encode;
 use File::Basename;
+use File::Path qw(remove_tree);
 use Redis;
 use Cwd;
 use Unicode::Normalize;
@@ -226,14 +227,17 @@ sub delete_archive($id) {
     if ( -e $filename ) {
         unlink $filename;
 
-        my $use_jxl = LANraragi::Model::Config->get_jxlthumbpages;
-        my $format = $use_jxl ? 'jxl' : 'jpg';
         my $thumbdir  = LANraragi::Model::Config->get_thumbdir;
         my $subfolder = substr( $id, 0, 2 );
-        my $thumbname = "$thumbdir/$subfolder/$id.$format";
-        # this should probablydelete the thumbpages folder too?
 
-        unlink $thumbname;
+        my $jpg_thumbname = "$thumbdir/$subfolder/$id.jpg";
+        unlink $jpg_thumbname;
+
+        my $jxl_thumbname = "$thumbdir/$subfolder/$id.jxl";
+        unlink $jxl_thumbname;
+
+        # Delete the thumbpages folder
+        remove_tree("$thumbdir/$subfolder/$id/");
 
         return $filename;
     }

--- a/lib/LANraragi/Utils/Minion.pm
+++ b/lib/LANraragi/Utils/Minion.pm
@@ -72,8 +72,10 @@ sub add_tasks {
                     sub {
                         foreach my $id (@$_) {
 
+                            my $use_jxl = LANraragi::Model::Config->get_jxlthumbpages;
+                            my $format = $use_jxl ? 'jxl' : 'jpg';
                             my $subfolder = substr( $id, 0, 2 );
-                            my $thumbname = "$thumbdir/$subfolder/$id.jpg";
+                            my $thumbname = "$thumbdir/$subfolder/$id.$format";
 
                             unless ( $force == 0 && -e $thumbname ) {
                                 eval {

--- a/templates/templates_config/config_tags.html.tt2
+++ b/templates/templates_config/config_tags.html.tt2
@@ -29,6 +29,22 @@
 
 <tr>
     <td class="option-td">
+        <h2 class="ih"> Use JPEG XL for thumbnails </h2>
+    </td>
+    <td class="config-td">
+        [% IF jxlthumbpages %]
+        <input id="jxlthumbpages" name="jxlthumbpages" class="fa" type="checkbox" checked> [% ELSE %]
+        <input id="jxlthumbpages" name="jxlthumbpages" class="fa" type="checkbox"> [% END %]
+        <label for="jxlthumbpages">
+            <br>LANraragi generates JPEG thumbnails for compatibility and performance reasons.
+            <br>If this option is checked, it will instead generate thumbnails using JPEG XL.
+            thumbnails.
+        </label>
+    </td>
+</tr>
+
+<tr>
+    <td class="option-td">
         <input id="genthumb-button" class='stdbtn' type='button' value='Generate Missing Thumbnails' />
     </td>
     <td class="config-td">

--- a/templates/templates_config/config_tags.html.tt2
+++ b/templates/templates_config/config_tags.html.tt2
@@ -38,7 +38,6 @@
         <label for="jxlthumbpages">
             <br>LANraragi generates JPEG thumbnails for compatibility and performance reasons.
             <br>If this option is checked, it will instead generate thumbnails using JPEG XL.
-            thumbnails.
         </label>
     </td>
 </tr>


### PR DESCRIPTION
This adds an optional toggle to enable JXL thumbnails.

**Why?** 
Saves a bit of space (~25-30% per file) and quality is superior. 

thumbnail & Use high-quality thumbnails for pages enabled 
![scale](https://github.com/Difegue/LANraragi/assets/76823966/abbad875-a732-4e20-8b61-765e307a5772)

Use high-quality thumbnails for pages disabled
![sample](https://github.com/Difegue/LANraragi/assets/76823966/77ac49c3-404a-4d9e-af7e-eb5da7be97d9)

If this is OK, it could also be a good option for the "Resize Images in Reader" function, as there the gains from JXL in size and quality would be most notable. 
 
Caveats:
~Enabling the option will regenerate all thumbnails as LRR is now looking for .jxl not .jpg.~
Old .jpg (or .jxl if the option is being disabled instead) files will not be deleted automatically.

