### PR TITLE
'File exists' error when extracting files from archive

### DIFF
--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -360,7 +360,7 @@ sub extract_file_from_archive ( $archive, $filename ) {
     my $tmp = File::Temp->new( DIR => $path );
     $tmp->unlink_on_destroy(0);
 
-    return extract_single_file( $archive, $filename, $tmp->filename );
+    return extract_single_file( $archive, $filename, dirname( $tmp->filename ) );
 }
 
 1;

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -357,10 +357,8 @@ sub extract_file_from_archive ( $archive, $filename ) {
     my $path = get_temp . "/plugin";
     mkdir $path;
 
-    my $tmp = File::Temp->new( DIR => $path );
-    $tmp->unlink_on_destroy(0);
-
-    return extract_single_file( $archive, $filename, dirname( $tmp->filename ) );
+    my $tmp = tempdir( DIR => $path, CLEANUP => 1 );
+    return extract_single_file( $archive, $filename, $tmp );
 }
 
 1;


### PR DESCRIPTION
From what i understand, when `$tmp->filename` is passed as the `$destination` parameter, it includes the filename of the temporary file. 
This caauses :
> Error: mkdir /usr/lib/lanraragi/public/temp/plugin/AIrR2CZ_1q: File exists

when importing tags from koromo or eze for example, because its trying to create a directory with the same name as the temporary file.
 By removing the filename, we ensure $destination is a valid dir path.

