### PR TITLE
Metadata plugin for ksk yaml files

### DIFF
--- a/lib/LANraragi/Plugin/Metadata/Ksk.pm
+++ b/lib/LANraragi/Plugin/Metadata/Ksk.pm
@@ -3,11 +3,11 @@ package LANraragi::Plugin::Metadata::Ksk;
 use strict;
 use warnings;
 
-use YAML::Tiny;
-
 use LANraragi::Model::Plugins;
 use LANraragi::Utils::Logging qw(get_plugin_logger);
 use LANraragi::Utils::Archive qw(is_file_in_archive extract_file_from_archive);
+
+use YAML::Syck qw(LoadFile);
 
 sub plugin_info {
 
@@ -39,9 +39,9 @@ sub get_tags {
 
     my $filepath = extract_file_from_archive( $file, $path_in_archive );
 
-    my $parsed_data = YAML::Tiny->read($filepath);
+    my $parsed_data = LoadFile($filepath);
 
-    my ( $tags, $title ) = tags_from_ksk_yaml( $parsed_data->[0], $assume_english );
+    my ( $tags, $title ) = tags_from_ksk_yaml( $parsed_data, $assume_english );
 
     unlink $filepath;
 

--- a/lib/LANraragi/Plugin/Metadata/Ksk.pm
+++ b/lib/LANraragi/Plugin/Metadata/Ksk.pm
@@ -1,0 +1,95 @@
+package LANraragi::Plugin::Metadata::Ksk;
+
+use strict;
+use warnings;
+
+use YAML::Tiny;
+
+use LANraragi::Model::Plugins;
+use LANraragi::Utils::Logging qw(get_plugin_logger);
+use LANraragi::Utils::Archive qw(is_file_in_archive extract_file_from_archive);
+
+sub plugin_info {
+
+    return (
+        name        => "ksk",
+        type        => "metadata",
+        namespace   => "kskplugin",
+        author      => "Hackerman",
+        version     => "0.001",
+        description => "Collects metadata embedded into your archives as koushoku.yaml files.",
+        icon =>
+          "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAABmJLR0QAAAAAAAD5Q7t/AAAACXBI\nWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4wYDFCYzptBwXAAAAB1pVFh0Q29tbWVudAAAAAAAQ3Jl\nYXRlZCB3aXRoIEdJTVBkLmUHAAAAjUlEQVQ4y82UwQ7AIAhDqeH/f7k7kRgmiozDPKppyisAkpTG\nM6T5vAQBCIAeQQBCUkiWRTV68KJZ1FuG5vY/oazYGdcWh7diy1Bml5We1yiMW4dmQr+W65mPjFjU\n5PMg2P9jKKvUdxWMU8neqYUW4cBpffnxi8TsXk/Qs8GkGGaWhmes1ZmNmr8kuMPwAJzzZSoHwxbF\nAAAAAElFTkSuQmCC",
+        parameters => [ { type => "bool", desc => "Save archive title" }, { type => "bool", desc => "Assume english" } ],
+    );
+}
+
+sub get_tags {
+    shift;
+    my $lrr_info = shift;
+    my ( $save_title, $assume_english ) = @_;
+    my $logger = get_plugin_logger();
+    my $file   = $lrr_info->{file_path};
+
+    my $path_in_archive = is_file_in_archive( $file, "koushoku.yaml" );
+
+    if ( !$path_in_archive ) {
+        return ( error => "No koushoku.yaml file found in archive" );
+    }
+
+    my $filepath = extract_file_from_archive( $file, $path_in_archive );
+
+    my $parsed_data = YAML::Tiny->read($filepath);
+
+    my ( $tags, $title ) = tags_from_ksk_yaml( $parsed_data->[0], $assume_english );
+
+    unlink $filepath;
+
+    #Return tags
+    $logger->info("Sending the following tags to LRR: $tags");
+    if ( $save_title && $title ) {
+        $logger->info("Parsed title is $title");
+        return ( tags => $tags, title => $title );
+    } else {
+        return ( tags => $tags );
+    }
+}
+
+sub tags_from_ksk_yaml {
+    my $hash           = $_[0];
+    my $assume_english = $_[1];
+    my @found_tags;
+    my $logger = get_plugin_logger();
+
+    my $title    = $hash->{"Title"};
+    my $tags     = $hash->{"Tags"};
+    my $parody   = $hash->{"Parody"};
+    my $artists  = $hash->{"Artist"};
+    my $magazine = $hash->{"Magazine"};
+    my $url      = $hash->{"URL"};
+
+    foreach my $tag (@$tags) {
+        push( @found_tags, $tag );
+    }
+    foreach my $tag (@$artists) {
+        push( @found_tags, "artist:" . $tag );
+    }
+    foreach my $tag (@$parody) {
+        push( @found_tags, "series:" . $tag );
+    }
+    foreach my $tag (@$magazine) {
+        push( @found_tags, "magazine:" . $tag );
+    }
+    if ($assume_english) {
+        push( @found_tags, "language:english" );
+    }
+
+    push( @found_tags, "source:" . $url ) unless !$url;
+
+    #Done-o
+    my $concat_tags = join( ", ", @found_tags );
+    return ( $concat_tags, $title );
+
+}
+
+1;

--- a/lib/LANraragi/Plugin/Metadata/Ksk.pm
+++ b/lib/LANraragi/Plugin/Metadata/Ksk.pm
@@ -12,14 +12,14 @@ use YAML::Syck qw(LoadFile);
 sub plugin_info {
 
     return (
-        name        => "ksk",
+        name        => "Koushoku.yaml",
         type        => "metadata",
-        namespace   => "kskplugin",
-        author      => "Hackerman",
+        namespace   => "kskyamlmeta",
+        author      => "siliconfeces",
         version     => "0.001",
         description => "Collects metadata embedded into your archives as koushoku.yaml files.",
         icon =>
-          "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAABmJLR0QAAAAAAAD5Q7t/AAAACXBI\nWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4wYDFCYzptBwXAAAAB1pVFh0Q29tbWVudAAAAAAAQ3Jl\nYXRlZCB3aXRoIEdJTVBkLmUHAAAAjUlEQVQ4y82UwQ7AIAhDqeH/f7k7kRgmiozDPKppyisAkpTG\nM6T5vAQBCIAeQQBCUkiWRTV68KJZ1FuG5vY/oazYGdcWh7diy1Bml5We1yiMW4dmQr+W65mPjFjU\n5PMg2P9jKKvUdxWMU8neqYUW4cBpffnxi8TsXk/Qs8GkGGaWhmes1ZmNmr8kuMPwAJzzZSoHwxbF\nAAAAAElFTkSuQmCC",
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAANkSURBVDhPJZJpU5NXGIbf/9Ev0g+MM7Udp9WWDsVOsRYQKEVZQ4BsZnt9sy9shgShBbTYaTVCKY1B1pBEQggGFOogKEvYdOoXfszVQ/rhmTkz59zXc9/PeaRO12163DZCbgc+8y06HTJ+h5UOp4xLvoXdoOFBf5Auu4LS3obc0oJDp8VhNtLlcyN1uRWcZj13vS5cBi1+mwWPYiLY6cYjG+lxKoR8LgHpw9BQz+OBAbS1tch6DR1uO1Kox4dWVcfdDg9uswGnVSc66wn47QJmwtreTEPFVZxCoKosJ3hbRmlpRt8kNEIrdfscNN+o4tfeHhz6VhHBgqG1nsHeDpxGDV6zDkWjIvxLH25tK2+WUkzcG8JrNdJ/x4803NuJrr4G7Y/X8+UWIl1TDUGfgsfUjl2nwm/WMjrUh72tEXXFNYoKP+b74ks4FQOStuEnVNVlWBtv8kBYcmhVBJwWLOo6vKY2fvbaSD0ZxdnWxKWCj1CVXiEyPIBVuAz6bUiySc0dj0zAbsZtaM1fRH4fwm/RMDYYYCP2lNnfBsn89ZghxcIjMfmxng5GQ92ExIwkj6Kn5UYF6uofhMUG2mvLycYi7GaTnKwvk0vH+XctzXE6weupCFvRCP9MjLMx+Tfdulak4s8KqSr5kppvLmNT3WRQWN5Oz7ObibObnmMnMSXECxwtxdidi7L+Z5jlP0bYnJnEKX5PUpeVshqdINzl475dZnN+kqPsIocrApCa5fVchP3kDAeLc3nQ1vQTNqcjbCZncbQ3It1XZLLhR7wUtTMZZWd2Ugj+f3yYjpFLzbC/OM1BZoHcygJ7KeFEuHu7lsJmViN5G+o4jsd5+fAhKyMjecDJUoK9xDTH4uG753E+bCxxtJpkX5xzmQS5FyniU2MYNCKCsbo8b/84GWf7aZSt2Wi+81kdPU+wPj1OOOAhIHbi3Yu0GGqS07evqCv7llCXA+n6VxcpKTzHwsgwH1bTvBf0g7NOwu7J6jPGQn4iQ4H8XPZErNPNdYIWPZfPn6OvUwDUlVe59vknfHe+gLGAn9PtNQ7XnpHLJjgUdQZ6vy4iCMDxaiq/D8WFBXx9oZCA+DFJI3agougiVV9cyEOqij6l32UkFr6Xz7yfibG3PM/eSoLs1Di2+loaS0uovFIkFlDhPxYUixj0Cgg3AAAAAElFTkSuQmCC",
         parameters => [ { type => "bool", desc => "Save archive title" }, { type => "bool", desc => "Assume english" } ],
     );
 }

--- a/tests/LANraragi/Plugin/Metadata/Ksk.t
+++ b/tests/LANraragi/Plugin/Metadata/Ksk.t
@@ -1,0 +1,79 @@
+# LANraragi::Plugin::Metadata::Ksk
+use strict;
+use warnings;
+use utf8;
+use Data::Dumper;
+use File::Temp qw(tempfile);
+use File::Copy "cp";
+
+use Cwd qw( getcwd );
+
+use Test::Trap;
+use Test::More;
+use Test::Deep;
+
+my $cwd     = getcwd();
+my $SAMPLES = "$cwd/tests/samples";
+require "$cwd/tests/mocks.pl";
+
+use_ok('LANraragi::Plugin::Metadata::Ksk');
+
+note("test not fetching title or assuming language");
+{
+    my ( $fh, $filename ) = tempfile();
+    cp( $SAMPLES . "/ksk/fake.yaml", $fh );
+
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::Ksk::get_plugin_logger         = sub { return get_logger_mock(); };
+    local *LANraragi::Plugin::Metadata::Ksk::extract_file_from_archive = sub { $filename };
+    local *LANraragi::Plugin::Metadata::Ksk::is_file_in_archive        = sub { 1 };
+
+    my %dummyhash = ( file_path => "test" );
+
+    my %ko_tags = LANraragi::Plugin::Metadata::Ksk::get_tags( "", \%dummyhash, 0, 0 );
+    my $expected_tags =
+      "Harry Potter, Ebony Dark'ness Dementia Raven Way, Draco Malfoy, artist:xXMidnightEssenceXx, artist:bloodytearz666, series:Harry Potter, magazine:My Immortal - Genesis, source:https://www.fanfiction.net/s/6829556/1/My-Immortal";
+    is( $ko_tags{title}, undef,          "Title is not overwritten" );
+    is( $ko_tags{tags},  $expected_tags, "Language is missing" );
+
+}
+
+note("test fetching title, not assuming language");
+{
+    my ( $fh, $filename ) = tempfile();
+    cp( $SAMPLES . "/ksk/fake.yaml", $fh );
+
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::Ksk::get_plugin_logger         = sub { return get_logger_mock(); };
+    local *LANraragi::Plugin::Metadata::Ksk::extract_file_from_archive = sub { $filename };
+    local *LANraragi::Plugin::Metadata::Ksk::is_file_in_archive        = sub { 1 };
+
+    my %dummyhash = ( file_path => "test" );
+
+    my %ko_tags = LANraragi::Plugin::Metadata::Ksk::get_tags( "", \%dummyhash, 1, 0 );
+    my $expected_tags =
+      "Harry Potter, Ebony Dark'ness Dementia Raven Way, Draco Malfoy, artist:xXMidnightEssenceXx, artist:bloodytearz666, series:Harry Potter, magazine:My Immortal - Genesis, source:https://www.fanfiction.net/s/6829556/1/My-Immortal";
+    is( $ko_tags{title}, "My Immortal",  "Title is overwritten" );
+    is( $ko_tags{tags},  $expected_tags, "Language is missing" );
+}
+
+note("test fetching title, assuming language");
+{
+    my ( $fh, $filename ) = tempfile();
+    cp( $SAMPLES . "/ksk/fake.yaml", $fh );
+
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::Ksk::get_plugin_logger         = sub { return get_logger_mock(); };
+    local *LANraragi::Plugin::Metadata::Ksk::extract_file_from_archive = sub { $filename };
+    local *LANraragi::Plugin::Metadata::Ksk::is_file_in_archive        = sub { 1 };
+
+    my %dummyhash = ( file_path => "test" );
+
+    my %ko_tags = LANraragi::Plugin::Metadata::Ksk::get_tags( "", \%dummyhash, 1, 1 );
+    my $expected_tags =
+      "Harry Potter, Ebony Dark'ness Dementia Raven Way, Draco Malfoy, artist:xXMidnightEssenceXx, artist:bloodytearz666, series:Harry Potter, magazine:My Immortal - Genesis, language:english, source:https://www.fanfiction.net/s/6829556/1/My-Immortal";
+    is( $ko_tags{title}, "My Immortal",  "Title is overwritten" );
+    is( $ko_tags{tags},  $expected_tags, "Language is present" );
+}
+
+done_testing();

--- a/tests/modules.t
+++ b/tests/modules.t
@@ -43,7 +43,8 @@ my @modules = (
     "LANraragi::Plugin::Download::Koushoku",        "LANraragi::Plugin::Scripts::nHentaiSourceConverter",
     "LANraragi::Plugin::Scripts::BlacklistMigrate", "LANraragi::Plugin::Metadata::Hitomi",
     "LANraragi::Plugin::Metadata::Hentag",          "LANraragi::Plugin::Metadata::HentagOnline",
-    "LANraragi::Plugin::Metadata::ComicInfo",       "LANraragi::Plugin::Metadata::ChaikaFile"
+    "LANraragi::Plugin::Metadata::ComicInfo",       "LANraragi::Plugin::Metadata::ChaikaFile",
+    "LANraragi::Plugin::Metadata::Ksk",
 );
 
 # Test all modules load properly

--- a/tests/samples/ksk/fake.yaml
+++ b/tests/samples/ksk/fake.yaml
@@ -2,6 +2,7 @@ Artist:
 - xXMidnightEssenceXx
 - bloodytearz666
 Description: The legendary fanfic, now illustrated
+  with a line break
 Magazine:
 - My Immortal - Genesis
 Pages: 420

--- a/tests/samples/ksk/fake.yaml
+++ b/tests/samples/ksk/fake.yaml
@@ -1,0 +1,19 @@
+Artist:
+- xXMidnightEssenceXx
+- bloodytearz666
+Description: The legendary fanfic, now illustrated
+Magazine:
+- My Immortal - Genesis
+Pages: 420
+Parody:
+- Harry Potter
+Publisher:
+- FanFiction.net
+Released: Mon, 01 Jan 1990 11:30:01 GMT
+Tags:
+- Harry Potter
+- Ebony Dark'ness Dementia Raven Way
+- Draco Malfoy
+Thumb: https://placekitten.com/g/400/300
+Title: My Immortal
+URL: https://www.fanfiction.net/s/6829556/1/My-Immortal

--- a/tools/cpanfile
+++ b/tools/cpanfile
@@ -61,4 +61,4 @@ requires 'Module::Pluggable', 5.2;
 requires 'Time::Local', 1.30;
 
 # Ksk plugin
-requires 'YAML::Tiny', 1.73;
+requires 'YAML::Syck', 1.34;

--- a/tools/cpanfile
+++ b/tools/cpanfile
@@ -59,3 +59,6 @@ requires 'Module::Pluggable', 5.2;
 
 # Eze plugin
 requires 'Time::Local', 1.30;
+
+# Ksk plugin
+requires 'YAML::Tiny', 1.73;


### PR DESCRIPTION
This plugin parses the yaml files that exist in _some_ ksk archives. It requires an additional CPAN module, and I haven't tested it on any recent archive. It's a bit old and I've mostly just rebased the branch before opening the PR. At least the tests are green!

Since the metadata doesn't exist in all files, or even the most recent ones, I kind of gave up on this plugin. In other words, no hard feelings if you skip this PR.