### PR TITLE
added hentag-login plugin

### DIFF
--- a/lib/LANraragi/Plugin/Login/Hentag.pm
+++ b/lib/LANraragi/Plugin/Login/Hentag.pm
@@ -1,4 +1,4 @@
-package LANraragi::Plugin::Login::EHentai;
+package LANraragi::Plugin::Login::Hentag;
 
 use strict;
 use warnings;
@@ -38,7 +38,7 @@ sub do_login {
 }
 
 # get_user_agent(ipb cookies)
-# Try crafting a Mojo::UserAgent object that can access E-Hentai.
+# Try crafting a Mojo::UserAgent object that can access Hentag.
 # Returns the UA object created.
 sub get_user_agent {
 
@@ -51,7 +51,6 @@ sub get_user_agent {
         $logger->info("Cookies provided ($hx $hu)!");
 
         #Setup the needed cookies with both domains
-        #They should translate to exhentai cookies with the igneous value generated
         $ua->cookie_jar->add(
             Mojo::Cookie::Response->new(
                 name   => 'hx',

--- a/lib/LANraragi/Plugin/Login/hentag.pm
+++ b/lib/LANraragi/Plugin/Login/hentag.pm
@@ -1,0 +1,81 @@
+package LANraragi::Plugin::Login::EHentai;
+
+use strict;
+use warnings;
+no warnings 'uninitialized';
+
+use Mojo::UserAgent;
+use LANraragi::Utils::Logging qw(get_logger);
+
+#Meta-information about your plugin.
+sub plugin_info {
+
+    return (
+        #Standard metadata
+        name      => "Hentag",
+        type      => "login",
+        namespace => "hentaglogin",
+        author    => "Moort",
+        version   => "1.0",
+        description =>
+          "Handles login to Hentag. If you have an account with contraversial content enabled, hentag online lookup can parse more archives",
+        parameters => [
+            { type => "int",    desc => "hx cookie value" },
+            { type => "string", desc => "hu cookie value" },
+        ]
+    );
+
+}
+
+# Mandatory function to be implemented by your login plugin
+# Returns a Mojo::UserAgent object only!
+sub do_login {
+
+    # Login plugins only receive the parameters entered by the user.
+    shift;
+    my ( $hx, $hu ) = @_;
+    return get_user_agent( $hx, $hu );
+}
+
+# get_user_agent(ipb cookies)
+# Try crafting a Mojo::UserAgent object that can access E-Hentai.
+# Returns the UA object created.
+sub get_user_agent {
+
+    my ( $hx, $hu ) = @_;
+
+    my $logger = get_logger( "Hentag Login", "plugins" );
+    my $ua     = Mojo::UserAgent->new;
+
+    if ( $hx ne "" && $hu ne "" ) {
+        $logger->info("Cookies provided ($hx $hu)!");
+
+        #Setup the needed cookies with both domains
+        #They should translate to exhentai cookies with the igneous value generated
+        $ua->cookie_jar->add(
+            Mojo::Cookie::Response->new(
+                name   => 'hx',
+                value  => $hx,
+                domain => 'hentag.com',
+                path   => '/'
+            )
+        );
+
+        $ua->cookie_jar->add(
+            Mojo::Cookie::Response->new(
+                name   => 'hu',
+                value  => $hu,
+                domain => 'hentag.com',
+                path   => '/'
+            )
+        );
+
+    } else {
+        $logger->info("No cookies provided, returning blank UserAgent.");
+    }
+
+    return $ua;
+
+}
+
+1;

--- a/lib/LANraragi/Plugin/Metadata/HentagOnline.pm
+++ b/lib/LANraragi/Plugin/Metadata/HentagOnline.pm
@@ -23,8 +23,9 @@ sub plugin_info {
         name        => "Hentag Online Lookups",
         type        => "metadata",
         namespace   => "hentagonlineplugin",
-        author      => "siliconfeces",
-        version     => "0.1",
+        author      => "siliconfeces & Moort",
+        version     => "0.2",
+        login_from  => "hentaglogin"
         description => "Searches hentag.com for tags matching your archive",
         parameters  => [
             { type => "bool", desc => "Save archive title" },

--- a/tests/modules.t
+++ b/tests/modules.t
@@ -38,13 +38,13 @@ my @modules = (
     "LANraragi::Plugin::Metadata::nHentai",         "LANraragi::Plugin::Metadata::RegexParse",
     "LANraragi::Plugin::Metadata::Fakku",           "LANraragi::Plugin::Metadata::Koushoku",
     "LANraragi::Plugin::Login::EHentai",            "LANraragi::Plugin::Login::Fakku",
-    "LANraragi::Plugin::Scripts::SourceFinder",     "LANraragi::Plugin::Scripts::FolderToCat",
-    "LANraragi::Plugin::Download::EHentai",         "LANraragi::Plugin::Download::Chaika",
-    "LANraragi::Plugin::Download::Koushoku",        "LANraragi::Plugin::Scripts::nHentaiSourceConverter",
-    "LANraragi::Plugin::Scripts::BlacklistMigrate", "LANraragi::Plugin::Metadata::Hitomi",
+    "LANraragi::Plugin::Login::Hentag",             "LANraragi::Plugin::Scripts::SourceFinder",
+    "LANraragi::Plugin::Scripts::FolderToCat",      "LANraragi::Plugin::Download::EHentai",
+    "LANraragi::Plugin::Download::Chaika",          "LANraragi::Plugin::Download::Koushoku",
+    "LANraragi::Plugin::Scripts::BlacklistMigrate", "LANraragi::Plugin::Scripts::nHentaiSourceConverter",
+    "LANraragi::Plugin::Metadata::Hitomi",          "LANraragi::Plugin::Metadata::Ksk",
     "LANraragi::Plugin::Metadata::Hentag",          "LANraragi::Plugin::Metadata::HentagOnline",
-    "LANraragi::Plugin::Metadata::ComicInfo",       "LANraragi::Plugin::Metadata::ChaikaFile",
-    "LANraragi::Plugin::Metadata::Ksk",
+    "LANraragi::Plugin::Metadata::ComicInfo",       "LANraragi::Plugin::Metadata::ChaikaFile"
 );
 
 # Test all modules load properly


### PR DESCRIPTION
Hentag has content that is invisible till you make an account and turn on a setting.
So for making that available I made the hentag-login plugin

At least, it's not available through the website, I don't know if the same applies for the api, but I at least don't get all results even though they are there when the setting is turned on

I have 0 perl experience, so please check if it works before merging