### PR TITLE
Smarter hentag titles

### DIFF
--- a/lib/LANraragi/Plugin/Metadata/HentagOnline.pm
+++ b/lib/LANraragi/Plugin/Metadata/HentagOnline.pm
@@ -247,24 +247,14 @@ sub pick_best_hit($title_hint, @hits) {
     if (!defined($title_hint)) {
         return $hits[0];
     }
-    $title_hint = LANraragi::Utils::String::clean_title($title_hint);
-    my $best_similarity = 0.0;
-    my $best_row = $hits[0];
-    foreach my $row (@hits) {
-        my ($tags, $title) = LANraragi::Plugin::Metadata::Hentag::tags_from_hentag_json($row);
-        $title = LANraragi::Utils::String::clean_title($title);
-        # Automatically accept identical hits (after cleanup)
-        if (lc($title_hint) eq lc($title)) {
-            return $row;
-        }
-        # If no perfect match is found, use the most similar hit
-        my $similarity = similarity($title, $title_hint);
-        if ($similarity > $best_similarity) {
-            $best_similarity = $similarity;
-            $best_row = $row;
-        }
+    $title_hint = lc(LANraragi::Utils::String::clean_title($title_hint));
+
+    my @titles;
+    while (my ($index, $elem) = each @hits) {
+        my ($tags, $title) = LANraragi::Plugin::Metadata::Hentag::tags_from_hentag_json($elem);
+        $titles[$index] = lc(LANraragi::Utils::String::clean_title($title));
     }
-    return $best_row;
+    return $hits[LANraragi::Utils::String::most_similar($title_hint, @titles)];
 }
 
 1;

--- a/lib/LANraragi/Utils/String.pm
+++ b/lib/LANraragi/Utils/String.pm
@@ -7,6 +7,8 @@ use feature "switch";
 no warnings 'experimental';
 use feature qw(signatures);
 
+use String::Similarity;
+
 # Remove "junk" from titles, turning something like "(c12) [poop (butt)] hardcore handholding [monogolian] [recensored]" into "hardcore handholding"
 sub clean_title($title) {
     $title = trim($title);
@@ -24,6 +26,26 @@ sub clean_title($title) {
 sub trim($s) {
     $s =~ s/^\s+|\s+$//g;
     return $s
+}
+
+# Finds the index of the string in @values that is most similar to $tested_string. Returns undef if @values is empty.
+# If multiple rows score "first place", the first one is returned
+sub most_similar($tested_string, @values) {
+    if (!@values) {
+        return;
+    }
+
+    my $best_similarity = 0.0;
+    my $best_index = undef;
+
+    while (my ($index, $elem) = each @values) {
+        my $similarity = similarity($tested_string, $elem);
+        if (!defined($best_index) || $similarity > $best_similarity) {
+            $best_similarity = $similarity;
+            $best_index = $index;
+        }
+    }
+    return $best_index;
 }
 
 1;

--- a/lib/LANraragi/Utils/String.pm
+++ b/lib/LANraragi/Utils/String.pm
@@ -1,0 +1,29 @@
+package LANraragi::Utils::String;
+
+use strict;
+use warnings;
+use utf8;
+use feature "switch";
+no warnings 'experimental';
+use feature qw(signatures);
+
+# Remove "junk" from titles, turning something like "(c12) [poop (butt)] hardcore handholding [monogolian] [recensored]" into "hardcore handholding"
+sub clean_title($title) {
+    $title = trim($title);
+    # Remove leading "(c12)"
+    $title =~ s/^\([^)]*\)?\s?//g;
+    # Remove leading "[poop (butt)]"
+    $title =~ s/^\[[^]]*\]?\s?//g;
+
+    # Remove trailing [mongolian] [recensored]"
+    $title =~ s/\s?\[[^]]*\]$//g;
+    $title =~ s/\s?\[[^]]*\]$//g;
+    return $title;
+}
+
+sub trim($s) {
+    $s =~ s/^\s+|\s+$//g;
+    return $s
+}
+
+1;

--- a/tests/LANraragi/Plugin/Metadata/HentagOnline.t
+++ b/tests/LANraragi/Plugin/Metadata/HentagOnline.t
@@ -206,4 +206,26 @@ note("08 - multiple hits in same language");
     is( $response{tags},  $expected_tags,  "correct tags" );
 }
 
+note("08 - multiple hits, pick the best hit");
+{
+    my $archive_title = "some series 1";
+    my $received_title;
+    my $mock_json = Mojo::File->new("$SAMPLES/hentag/05_search_response_multiple_similar_titles.json")->slurp;
+
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::HentagOnline::get_plugin_logger = sub { return get_logger_mock(); };
+    local *LANraragi::Plugin::Metadata::HentagOnline::get_json_by_title = sub {
+        my ( $ua, $our_archive_title ) = @_;
+        $received_title = $our_archive_title;
+        return $mock_json;
+    };
+
+    my %get_tags_params = ( archive_title => $archive_title);
+
+    my %response = LANraragi::Plugin::Metadata::HentagOnline::get_tags( "", \%get_tags_params, 1 );
+
+    my $expected_title = "(c20) [auth (circ)] some series 1 [peepee] [poopoo]";
+    is( $response{title}, $expected_title, "correct title" );
+}
+
 done_testing();

--- a/tests/LANraragi/Plugin/Metadata/HentagOnline.t
+++ b/tests/LANraragi/Plugin/Metadata/HentagOnline.t
@@ -228,4 +228,26 @@ note("08 - multiple hits, pick the best hit");
     is( $response{title}, $expected_title, "correct title" );
 }
 
+note("09 - multiple hits, pick the best hit, by similarity");
+{
+    my $archive_title = "some seris 1";
+    my $received_title;
+    my $mock_json = Mojo::File->new("$SAMPLES/hentag/05_search_response_multiple_similar_titles.json")->slurp;
+
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::HentagOnline::get_plugin_logger = sub { return get_logger_mock(); };
+    local *LANraragi::Plugin::Metadata::HentagOnline::get_json_by_title = sub {
+        my ( $ua, $our_archive_title ) = @_;
+        $received_title = $our_archive_title;
+        return $mock_json;
+    };
+
+    my %get_tags_params = ( archive_title => $archive_title);
+
+    my %response = LANraragi::Plugin::Metadata::HentagOnline::get_tags( "", \%get_tags_params, 1 );
+
+    my $expected_title = "(c20) [auth (circ)] some series 1 [peepee] [poopoo]";
+    is( $response{title}, $expected_title, "correct title" );
+}
+
 done_testing();

--- a/tests/LANraragi/Utils/String.t
+++ b/tests/LANraragi/Utils/String.t
@@ -1,0 +1,48 @@
+use strict;
+use warnings;
+use utf8;
+use Data::Dumper;
+
+use Test::More;
+use Test::Deep;
+
+BEGIN { use_ok('LANraragi::Utils::String'); }
+
+
+note('testing trim...');
+{
+    my $input = "";
+    my $expected = "";
+    my $result = LANraragi::Utils::String::trim($input);
+
+    is($result, $expected, "Empty string should result in empty string");
+}
+
+{
+    my $input = "already trimmed";
+    my $expected = "already trimmed";
+    my $result = LANraragi::Utils::String::trim($input);
+
+    is($result, $expected, "Pre-trimmed should do nothing");
+}
+
+{
+    my $input = " trim everything   ";
+    my $expected = "trim everything";
+    my $result = LANraragi::Utils::String::trim($input);
+
+    is($result, $expected, "Trim should trim");
+}
+
+
+note('testing title cleanup...');
+{
+    my $input = "(C83) [Tetsubou Shounen (Natsushi)] So hold my hand one more time [English] [Yuri-ism Project]";
+    my $expected = "So hold my hand one more time";
+    my $result = LANraragi::Utils::String::clean_title($input);
+
+    is($result, $expected, "Remove leading/trailing junk");
+}
+
+done_testing();
+

--- a/tests/LANraragi/Utils/String.t
+++ b/tests/LANraragi/Utils/String.t
@@ -44,5 +44,11 @@ note('testing title cleanup...');
     is($result, $expected, "Remove leading/trailing junk");
 }
 
+note('testing string similarity detection...');
+{
+    is(LANraragi::Utils::String::most_similar("orange", ("door hinge", "sporange")), 1, "Simple case");
+    is(LANraragi::Utils::String::most_similar("orange", ()), undef, "Empty set");
+}
+
 done_testing();
 

--- a/tests/samples/hentag/05_search_response_multiple_similar_titles.json
+++ b/tests/samples/hentag/05_search_response_multiple_similar_titles.json
@@ -1,0 +1,47 @@
+[
+  {
+    "title": "(c20) [auth (circ)] some series 3 [peepee] [poopoo]",
+    "artists": [
+      "plop"
+    ],
+    "femaleTags": [
+      "bilbul"
+    ],
+    "language": "english",
+    "category": "manga",
+    "createdAt": 1255081730000,
+    "locations": [
+      "whatever"
+    ]
+  },
+  {
+    "title": "(c20) [auth (circ)] some series 1 [peepee] [poopoo]",
+    "artists": [
+      "the artist"
+    ],
+    "femaleTags": [
+      "penis"
+    ],
+    "language": "english",
+    "category": "manga",
+    "createdAt": 1255081730000,
+    "locations": [
+      "whatever 2"
+    ]
+  },
+  {
+    "title": "(c20) [auth (circ)] some series 2 [peepee] [poopoo]",
+    "artists": [
+      "the artist"
+    ],
+    "femaleTags": [
+      "penis"
+    ],
+    "language": "english",
+    "category": "manga",
+    "createdAt": 1255081730000,
+    "locations": [
+      "whatever 2"
+    ]
+  }
+]

--- a/tools/cpanfile
+++ b/tools/cpanfile
@@ -62,3 +62,6 @@ requires 'Time::Local', 1.30;
 
 # Ksk plugin/YAML Support
 requires 'YAML::Syck', 1.34;
+
+# Hentag plugin
+requires 'String::Similarity', 1.04


### PR DESCRIPTION
This PR improves the success rate of the hentag plugin, when searching by title.

Before this PR, the plugin just picks the first search result if there's multiple. This usually works fine, but for entries in a series this can result in the wrong result being picked.

To solve this, this PR checks which hit seems to be most similar to the requested title. Still not 100% perfect, of course, but a notable improvement. Also, the magic sauce is added as a reusable function as other plugin makers might find it useful.