### PR TITLE
Make permission fixing optional (but default)

### DIFF
--- a/tools/build/docker/Dockerfile
+++ b/tools/build/docker/Dockerfile
@@ -35,7 +35,9 @@ ENV LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 \
     # Enable automatic http proxy detection for mojo
     MOJO_PROXY=1 \
     # Allow Mojo to automatically pick up the X-Forwarded-For and X-Forwarded-Proto headers
-    MOJO_REVERSE_PROXY=1
+    MOJO_REVERSE_PROXY=1 \
+    # Attempt to fix file permissions automatically
+    LRR_AUTOFIX_PERMISSIONS=1
 
 RUN \
   if [ $(getent group ${LRR_GID}) ]; then \

--- a/tools/build/docker/s6/cont-init.d/01-lrr-setup
+++ b/tools/build/docker/s6/cont-init.d/01-lrr-setup
@@ -2,6 +2,7 @@
 
 USER_ID=${LRR_UID}
 GROUP_ID=${LRR_GID}
+FIX_PERMS=${LRR_AUTOFIX_PERMISSIONS:-1}
 
 echo "Starting LANraragi with UID/GID : $USER_ID/$GROUP_ID"
 
@@ -9,10 +10,7 @@ echo "Starting LANraragi with UID/GID : $USER_ID/$GROUP_ID"
 #This solves permission problems on the content folder if the Docker user sets the same uid as the owner of the folder.
 usermod -o -u $USER_ID koyomi
 groupmod -o -g $GROUP_ID koyomi
-
-#Ensure LRR folder is writable
 chown koyomi /home/koyomi/lanraragi
-chmod u+rwx /home/koyomi/lanraragi
 
 #Crash with an error if content folder doesn't exist
 if [ ! -d "/home/koyomi/lanraragi/content" ]; then
@@ -24,10 +22,19 @@ fi
 chown -R koyomi /home/koyomi/lanraragi/database
 chmod -R u+rwx /home/koyomi/lanraragi/database
 
-#Ensure thumbnail folder is writable
-chown -R koyomi /home/koyomi/lanraragi/content/thumb
-find /home/koyomi/lanraragi/content/thumb -type f -exec chmod u+rw  {} \;
-find /home/koyomi/lanraragi/content/thumb -type d -exec chmod u+rwx {} \;
+if [ "$FIX_PERMS" -eq 1 ]; then
+  echo "Fixing permissions, hold on!"
+  #Ensure thumbnail folder is writable
+  chown -R koyomi /home/koyomi/lanraragi/content/thumb
+  find /home/koyomi/lanraragi/content/thumb -type f -exec chmod u+rw  {} \;
+  find /home/koyomi/lanraragi/content/thumb -type d -exec chmod u+rwx {} \;
+
+  # Ensure the rest of the content folder is at least readable
+  find /home/koyomi/lanraragi/content -name thumb -prune -o -type f -exec chmod u+r  {} \;
+  find /home/koyomi/lanraragi/content -name thumb -prune -o -type d -exec chmod u+rx {} \;
+else
+    echo "Not touching permissions"
+fi
 
 #Ensure log folder is writable
 mkdir /home/koyomi/lanraragi/log


### PR DESCRIPTION
This PR makes it possible to skip most of the chmod/chown fuckery going on when starting the docker version. This can make startup way faster if the content is accessed through NFS. I didn't quite figure out where to document it so I didn't. Permissions is still fixed for redis etc, this ONLY affects the content directory,

The default action is to use the previous behavior.

tl;dr, `-e LRR_AUTOFIX_PERMISSIONS=0` makes startup go wroom wroom.