### PR TITLE
Make stats page faster when file access is slow

### DIFF
--- a/lib/LANraragi/Model/Stats.pm
+++ b/lib/LANraragi/Model/Stats.pm
@@ -184,9 +184,17 @@ sub compute_content_size {
     my $redis_db = LANraragi::Model::Config->get_redis;
 
     my @keys = $redis_db->keys('????????????????????????????????????????');
-    my $size = 0;
+
+    $redis_db->multi;
     foreach my $id (@keys) {
-        $size = $size + LANraragi::Utils::Database::get_arcsize($id);
+        LANraragi::Utils::Database::get_arcsize($id, $redis_db);
+    }
+    my @result = $redis_db->exec;
+    $redis_db->quit;
+
+    my $size = 0;
+    foreach my $row (@result) {
+        $size = $size + $row;
     }
 
     return int( $size / 1073741824 * 100 ) / 100;

--- a/lib/LANraragi/Model/Stats.pm
+++ b/lib/LANraragi/Model/Stats.pm
@@ -181,12 +181,13 @@ sub build_tag_stats {
 }
 
 sub compute_content_size {
+    my $redis_db = LANraragi::Model::Config->get_redis;
 
-    #Get size of archive folder
-    my $dirname = LANraragi::Model::Config->get_userdir;
-    my $size    = 0;
-
-    find( sub { $size += -s if -f }, $dirname );
+    my @keys = $redis_db->keys('????????????????????????????????????????');
+    my $size = 0;
+    foreach my $id (@keys) {
+        $size = $size + LANraragi::Utils::Database::get_arcsize($id);
+    }
 
     return int( $size / 1073741824 * 100 ) / 100;
 }

--- a/lib/LANraragi/Model/Stats.pm
+++ b/lib/LANraragi/Model/Stats.pm
@@ -14,26 +14,8 @@ use LANraragi::Utils::Database qw(redis_decode redis_encode);
 use LANraragi::Utils::Logging qw(get_logger);
 
 sub get_archive_count {
-
-    #We can't trust the DB to contain the exact amount of files,
-    #As deleted files are still kept in store.
-    my $dirname = LANraragi::Model::Config->get_userdir;
-    my $count   = 0;
-
-    #Count files the old-fashioned way instead
-    find(
-        {   wanted => sub {
-                return if -d $_;    #Directories are excluded on the spot
-                if ( is_archive($_) ) {
-                    $count++;
-                }
-            },
-            no_chdir    => 1,
-            follow_fast => 1
-        },
-        $dirname
-    );
-    return $count;
+    my $redis  = LANraragi::Model::Config->get_redis_search;
+    return $redis->zcard("LRR_TITLES") + 0;    # Total number of archives (as int)
 }
 
 sub get_page_stat {

--- a/lib/LANraragi/Model/Stats.pm
+++ b/lib/LANraragi/Model/Stats.pm
@@ -187,7 +187,7 @@ sub compute_content_size {
 
     $redis_db->multi;
     foreach my $id (@keys) {
-        LANraragi::Utils::Database::get_arcsize($id, $redis_db);
+        LANraragi::Utils::Database::get_arcsize($redis_db, $id);
     }
     my @result = $redis_db->exec;
     $redis_db->quit;

--- a/lib/LANraragi/Model/Stats.pm
+++ b/lib/LANraragi/Model/Stats.pm
@@ -194,7 +194,9 @@ sub compute_content_size {
 
     my $size = 0;
     foreach my $row (@result) {
-        $size = $size + $row;
+        if (defined($row)) {
+            $size = $size + $row;
+        }
     }
 
     return int( $size / 1073741824 * 100 ) / 100;

--- a/lib/LANraragi/Model/Upload.pm
+++ b/lib/LANraragi/Model/Upload.pm
@@ -123,6 +123,7 @@ sub handle_incoming_file {
     # (The file being physically present is necessary in case last modified time is used)
     LANraragi::Utils::Database::add_timestamp_tag( $redis, $id );
     LANraragi::Utils::Database::add_pagecount( $redis, $id );
+    LANraragi::Utils::Database::add_arcsize( $id, $redis );
     $redis->quit();
     $redis_search->quit();
 

--- a/lib/LANraragi/Model/Upload.pm
+++ b/lib/LANraragi/Model/Upload.pm
@@ -123,7 +123,7 @@ sub handle_incoming_file {
     # (The file being physically present is necessary in case last modified time is used)
     LANraragi::Utils::Database::add_timestamp_tag( $redis, $id );
     LANraragi::Utils::Database::add_pagecount( $redis, $id );
-    LANraragi::Utils::Database::add_arcsize( $id, $redis );
+    LANraragi::Utils::Database::add_arcsize( $redis, $id );
     $redis->quit();
     $redis_search->quit();
 

--- a/lib/LANraragi/Utils/Database.pm
+++ b/lib/LANraragi/Utils/Database.pm
@@ -68,6 +68,9 @@ sub change_archive_id ( $old_id, $new_id ) {
     if ( $redis->exists($old_id) ) {
         $redis->rename( $old_id, $new_id );
     }
+
+    my $file = $redis->hget($new_id, "file");
+    set_arcsize($new_id, -s $file, $redis);
     $redis->quit;
 
     # We also need to update categories that contain the ID.

--- a/lib/LANraragi/Utils/Database.pm
+++ b/lib/LANraragi/Utils/Database.pm
@@ -600,8 +600,7 @@ sub set_arcsize( $id, $arcsize ) {
     $redis->hset( $id, "arcsize", $arcsize );
 }
 
-sub get_arcsize ( $id ) {
-    my $redis = LANraragi::Model::Config->get_redis;
+sub get_arcsize ( $id, $redis ) {
     return $redis->hget( $id, "arcsize" );
 }
 

--- a/lib/LANraragi/Utils/Database.pm
+++ b/lib/LANraragi/Utils/Database.pm
@@ -41,6 +41,7 @@ sub add_archive_to_redis ( $id, $file, $redis ) {
 
     $redis->hset( $id, "name", redis_encode($name) );
     $redis->hset( $id, "tags", "" );
+    set_arcsize( $id, -s $file );
 
     # Don't encode filenames.
     $redis->hset( $id, "file", $file );
@@ -585,6 +586,23 @@ sub get_tankoubons_by_file($arcid) {
 
     $redis->quit;
     return @tankoubons;
+}
+
+sub add_arcsize ( $id ) {
+    my $redis = LANraragi::Model::Config->get_redis;
+    my $file = $redis->hget( $id, "file" );
+    my $arcsize = -s $file;
+    set_arcsize( $id, $arcsize );
+}
+
+sub set_arcsize( $id, $arcsize ) {
+    my $redis = LANraragi::Model::Config->get_redis;
+    $redis->hset( $id, "arcsize", $arcsize );
+}
+
+sub get_arcsize ( $id ) {
+    my $redis = LANraragi::Model::Config->get_redis;
+    return $redis->hget( $id, "arcsize" );
 }
 
 1;

--- a/lib/LANraragi/Utils/Database.pm
+++ b/lib/LANraragi/Utils/Database.pm
@@ -41,7 +41,7 @@ sub add_archive_to_redis ( $id, $file, $redis ) {
 
     $redis->hset( $id, "name", redis_encode($name) );
     $redis->hset( $id, "tags", "" );
-    set_arcsize( $id, -s $file );
+    set_arcsize( $id, -s $file, $redis );
 
     # Don't encode filenames.
     $redis->hset( $id, "file", $file );
@@ -588,15 +588,13 @@ sub get_tankoubons_by_file($arcid) {
     return @tankoubons;
 }
 
-sub add_arcsize ( $id ) {
-    my $redis = LANraragi::Model::Config->get_redis;
+sub add_arcsize ( $id, $redis ) {
     my $file = $redis->hget( $id, "file" );
     my $arcsize = -s $file;
-    set_arcsize( $id, $arcsize );
+    set_arcsize( $id, $arcsize, $redis );
 }
 
-sub set_arcsize( $id, $arcsize ) {
-    my $redis = LANraragi::Model::Config->get_redis;
+sub set_arcsize( $id, $arcsize, $redis ) {
     $redis->hset( $id, "arcsize", $arcsize );
 }
 

--- a/lib/LANraragi/Utils/Database.pm
+++ b/lib/LANraragi/Utils/Database.pm
@@ -42,7 +42,7 @@ sub add_archive_to_redis ( $id, $file, $redis ) {
     $redis->hset( $id, "name", redis_encode($name) );
     $redis->hset( $id, "tags", "" );
     if (defined($file) && -e $file) {
-        set_arcsize($id, -s $file, $redis);
+        set_arcsize($redis, $id, -s $file);
     }
 
     # Don't encode filenames.
@@ -72,7 +72,7 @@ sub change_archive_id ( $old_id, $new_id ) {
     }
 
     my $file = $redis->hget($new_id, "file");
-    set_arcsize($new_id, -s $file, $redis);
+    set_arcsize($redis, $new_id, -s $file);
     $redis->quit;
 
     # We also need to update categories that contain the ID.
@@ -593,17 +593,17 @@ sub get_tankoubons_by_file($arcid) {
     return @tankoubons;
 }
 
-sub add_arcsize ( $id, $redis ) {
+sub add_arcsize ( $redis, $id ) {
     my $file = $redis->hget( $id, "file" );
     my $arcsize = -s $file;
-    set_arcsize( $id, $arcsize, $redis );
+    set_arcsize( $redis, $id, $arcsize );
 }
 
-sub set_arcsize( $id, $arcsize, $redis ) {
+sub set_arcsize( $redis, $id, $arcsize ) {
     $redis->hset( $id, "arcsize", $arcsize );
 }
 
-sub get_arcsize ( $id, $redis ) {
+sub get_arcsize ( $redis, $id ) {
     return $redis->hget( $id, "arcsize" );
 }
 

--- a/lib/LANraragi/Utils/Database.pm
+++ b/lib/LANraragi/Utils/Database.pm
@@ -41,7 +41,9 @@ sub add_archive_to_redis ( $id, $file, $redis ) {
 
     $redis->hset( $id, "name", redis_encode($name) );
     $redis->hset( $id, "tags", "" );
-    set_arcsize( $id, -s $file, $redis );
+    if (defined($file) && -e $file) {
+        set_arcsize($id, -s $file, $redis);
+    }
 
     # Don't encode filenames.
     $redis->hset( $id, "file", $file );

--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -260,7 +260,7 @@ sub add_to_filemap ( $redis_cfg, $file ) {
                 invalidate_cache();
             }
 
-            unless ( LANraragi::Utils::Database::get_arcsize( $id ) ) {
+            unless ( LANraragi::Utils::Database::get_arcsize( $id, $redis_arc ) ) {
                 $logger->debug("arcsize is not set for $id, storing now!");
                 LANraragi::Utils::Database::add_arcsize(  $id );
             }

--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -262,7 +262,7 @@ sub add_to_filemap ( $redis_cfg, $file ) {
 
             unless ( LANraragi::Utils::Database::get_arcsize( $id, $redis_arc ) ) {
                 $logger->debug("arcsize is not set for $id, storing now!");
-                LANraragi::Utils::Database::add_arcsize(  $id );
+                LANraragi::Utils::Database::add_arcsize(  $id, $redis_arc );
             }
 
             # Set pagecount in case it's not already there

--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -260,9 +260,9 @@ sub add_to_filemap ( $redis_cfg, $file ) {
                 invalidate_cache();
             }
 
-            unless ( LANraragi::Utils::Database::get_arcsize( $id, $redis_arc ) ) {
+            unless ( LANraragi::Utils::Database::get_arcsize( $redis_arc, $id ) ) {
                 $logger->debug("arcsize is not set for $id, storing now!");
-                LANraragi::Utils::Database::add_arcsize(  $id, $redis_arc );
+                LANraragi::Utils::Database::add_arcsize( $redis_arc, $id );
             }
 
             # Set pagecount in case it's not already there

--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -260,6 +260,11 @@ sub add_to_filemap ( $redis_cfg, $file ) {
                 invalidate_cache();
             }
 
+            unless ( LANraragi::Utils::Database::get_arcsize( $id ) ) {
+                $logger->debug("arcsize is not set for $id, storing now!");
+                LANraragi::Utils::Database::add_arcsize(  $id );
+            }
+
             # Set pagecount in case it's not already there
             unless ( $redis_arc->hget( $id, "pagecount" ) ) {
                 $logger->debug("Pagecount not calculated for $id, doing it now!");


### PR DESCRIPTION
This is my current attempt at making the stats page faster when using network drives or similar. I try to use redis rather than touching the FS, which is faster but has some issues of it's own.

First, total content size will only consider stuff that's known by LRR, and not the size of the actual directory. Also, you'll need to rescan to get that data into redis.

The archive count will now also show the same count as the default search view, which is a change compared to earlier where you got the actual count of archive files in the content dir.