### PR TITLE
Remove loading='lazy' to fix firefox scroll-to-start bug

### DIFF
--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -273,7 +273,6 @@ Reader.initInfiniteScrollView = function () {
     Reader.pages.slice(1).forEach((source) => {
         const img = new Image();
         img.id = `page-${Reader.pages.indexOf(source)}`;
-        img.loading = "lazy";
         img.height = 800;
         img.width = 600;
         img.src = source;


### PR DESCRIPTION
When using infinite scroll in firefox, you can sometimes automatically scroll back to the beginning when you reach the end of an archive for the first time . This happens because of a conflict between firefox's lazy loading behavior and progress tracking.

Firefox is pretty aggressive when it comes to lazy loading, and thus only loads images when they hit the viewport (or is at least very close). Also, LRR waits until the browser has loaded all images before jumping to the current page (according to progress tracking). Therefore, in firefox, the "jump to the correct page" only fires when you reach the end of the archive.

Chrome doesn't really suffer from this, as chrome's interpretation of lazy loading is basically "lol no" and tends to just load everything eagerly.