### PR TITLE
Reuse generate_archive_list to make code more DRY

### DIFF
--- a/lib/LANraragi/Controller/Category.pm
+++ b/lib/LANraragi/Controller/Category.pm
@@ -21,25 +21,18 @@ sub index {
 
     $redis->quit();
 
-    #Then complete it with the rest from the database.
-    #40-character long keys only => Archive IDs
-    my @keys = $redis->keys('????????????????????????????????????????');
-
+    my @idlist = LANraragi::Model::Archive::generate_archive_list;
     #Parse the archive list and build <li> elements accordingly.
     my $arclist = "";
 
     #Only show IDs that still have their files present.
-    foreach my $id (@keys) {
-        my $zipfile = $redis->hget( $id, "file" );
-        my $title   = $redis->hget( $id, "title" );
-        $title = redis_decode($title);
-        $title = xml_escape($title);
+    foreach my $arc (@idlist) {
+        my $title = xml_escape($arc->{title});
+        my $id = xml_escape($arc->{arcid});
 
-        if ( -e $zipfile ) {
-            $arclist .=
-              "<li><input type='checkbox' name='archive' id='$id' class='archive' onchange='Category.updateArchiveInCategory(this.id, this.checked)'>";
-            $arclist .= "<label for='$id'> $title</label></li>";
-        }
+        $arclist .=
+          "<li><input type='checkbox' name='archive' id='$id' class='archive' onchange='Category.updateArchiveInCategory(this.id, this.checked)'>";
+        $arclist .= "<label for='$id'> $title</label></li>";
     }
 
     $redis->quit();


### PR DESCRIPTION
The "Modify Categories" page was rolling some custom code for listing all archives. This PR changes that to reuse the same function as in "Batch Operations", which has the nice side effect of being faster as well.