### PR TITLE
(chore): ajax cache to reduce server load

### DIFF
--- a/public/js/common.js
+++ b/public/js/common.js
@@ -308,6 +308,7 @@ LRR.getImgSize = function (target) {
     $.ajax({
         async: false,
         url: target,
+        cache: true,
         type: "HEAD",
         success: (data, textStatus, request) => {
             imgSize = parseInt(request.getResponseHeader("Content-Length") / 1024, 10);

--- a/public/js/index_datatables.js
+++ b/public/js/index_datatables.js
@@ -50,7 +50,10 @@ IndexTable.initializeAll = function () {
     IndexTable.dataTable = $(".datatables").DataTable({
         serverSide: true,
         processing: true,
-        ajax: "search",
+        ajax: {
+        url: "search",
+        cache: true,
+        },
         deferRender: true,
         lengthChange: false,
         pageLength: Index.pageSize,


### PR DESCRIPTION
normal, ajax will add timestamp at the end of request. this config remove it