### PR TITLE
Fix Redis password authentication

### DIFF
--- a/lib/LANraragi.pm
+++ b/lib/LANraragi.pm
@@ -138,8 +138,13 @@ sub startup {
     shutdown_from_pid( get_temp . "/minion.pid" );
 
     my $miniondb = $self->LRR_CONF->get_redisad . "/" . $self->LRR_CONF->get_miniondb;
+    my $redispassword = $self->LRR_CONF->get_redispassword;
+
+    # If the password is non-empty, add the required delimiters
+    if ($redispassword) { $redispassword = "x:" . $redispassword . "@"; }
+
     say "Minion will use the Redis database at $miniondb";
-    $self->plugin( 'Minion' => { Redis => "redis://$miniondb" } );
+    $self->plugin( 'Minion' => { Redis => "redis://$redispassword$miniondb" } );
     $self->LRR_LOGGER->info("Successfully connected to Minion database.");
     $self->minion->missing_after(5);    # Clean up older workers after 5 seconds of unavailability
 

--- a/lib/LANraragi/Model/Config.pm
+++ b/lib/LANraragi/Model/Config.pm
@@ -45,8 +45,8 @@ sub get_minion {
     my $miniondb = get_redisad . "/" . get_miniondb;
     my $password = get_redispassword;
 
-    # If the password is non-empty, add the required @
-    if ($password) { $password = $password . "@"; }
+    # If the password is non-empty, add the required delimiters
+    if ($password) { $password = "x:" . $password . "@"; }
 
     return Minion->new( Redis => "redis://$password$miniondb" );
 }


### PR DESCRIPTION
I was packaging the app for Nixpkgs (merged now, btw) when I realised that the Redis password wasn't working correctly.

I looked up the docs of the Minion Redis Backend (https://metacpan.org/pod/Minion::Backend::Redis), and it turns out you need an `x:` before the password (or atleast that's how it worked for me).

Also, there was another place (the main plugin registering part) where the password wasn't even trying to be passed over to Minion. This was the main source of the errors it was throwing.

This PR addresses this by prepending a `x:` to the password, when given, and also providing a password at the other location.