### PR TITLE
Set missing ghostscript device value

### DIFF
--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -223,7 +223,7 @@ sub get_filelist($archive) {
 
         # For pdfs, extraction returns images from 1.jpg to x.jpg, where x is the pdf pagecount.
         # Using -dNOSAFER or --permit-file-read is required since GS 9.50, see https://github.com/doxygen/doxygen/issues/7290
-        my $pages = `gs -q -dNOSAFER -c "($archive) (r) file runpdfbegin pdfpagecount = quit"`;
+        my $pages = `gs -q -dNOSAFER -sDEVICE=jpeg -c "($archive) (r) file runpdfbegin pdfpagecount = quit"`;
         for my $num ( 1 .. $pages ) {
             push @files, "$num.jpg";
             push @sizes, 0;


### PR DESCRIPTION
I was testing out pdf conversion on WSL (running NixOS), and ghostscript was complaining that the xserver wasn't running. I found that one line in the pdf info querying code was missing an explicitly specified device, so I'm guessing the xserver was the fallback, which WSL didn't have.

Also tested it on Linux, when I viewed the pdf on the website, the server's monitor started opening many pdf-viewer windows just for a split second, which, because I am using `i3`, was continuously messing up the window layout.

This simple change should fix both of these issues.

I didn't notice any quality regressions (the quality was not that great before and after the fix, but maybe that's just NixOS)