### PR TITLE
Use password directly when connecting to Redis

### DIFF
--- a/lib/LANraragi/Model/Config.pm
+++ b/lib/LANraragi/Model/Config.pm
@@ -69,16 +69,13 @@ sub get_redis_internal {
 
     # Default redis server location is localhost:6379.
     # Auto-reconnect on, one attempt every 2ms up to 3 seconds. Die after that.
+    # Auth if password is set
     my $redis = Redis->new(
         server    => &get_redisad,
         debug     => $ENV{LRR_DEVSERVER} ? "1" : "0",
-        reconnect => 3
+        reconnect => 3,
+        &get_redispassword ? (password => &get_redispassword) : ()
     );
-
-    # Auth if password is set
-    if ( &get_redispassword ne "" ) {
-        $redis->auth(&get_redispassword);
-    }
 
     # Switch to specced database
     $redis->select($db);


### PR DESCRIPTION
It turns out I didn't find every issue with using Redis with a password in a previous PR.
I found that it would sometimes throw `NOAUTH` errors, but only when finishing a Minion job(??) The main thing is that file upload and downloaders were not working at all because of this.
After a little more time than I dare to admit, I found a solution: don't use `auth`, just use the `password` key in the constructor.
I don't know a lot of Perl, so after a bit of searching, I found a way to do conditional key-value pairs. If there's a better way, please do tell me.