### PR TITLE
Allow filtering on number of read pages

### DIFF
--- a/lib/LANraragi/Model/Search.pm
+++ b/lib/LANraragi/Model/Search.pm
@@ -175,7 +175,10 @@ sub search_uncached {
                 # Go through all IDs in @filtered and check if they have the right pagecount
                 # This could be sped up with an index, but it's probably not worth it.
                 foreach my $id (@filtered) {
-                    my $count = $redis_db->hget( $id, $col );
+
+                    # Default to 0 if null.
+                    my $count = $redis_db->hget( $id, $col ) || 0;
+
                     if (   ( $operator eq "=" && $count == $pagecount )
                         || ( $operator eq ">"  && $count > $pagecount )
                         || ( $operator eq ">=" && $count >= $pagecount )

--- a/tests/search.t
+++ b/tests/search.t
@@ -115,4 +115,12 @@ $search = qq(pages:>150);
 do_test_search();
 is( $ids[0], "e69e43e1355267f7d32a4f9b7f2fe108d2401ebg", qq(Pagecount search ($search)) );
 
+$search = qq(read:10);
+do_test_search();
+is( $ids[0], "e69e43e1355267f7d32a4f9b7f2fe108d2401ebf", qq(Read search ($search)) );
+
+$search = qq(read:<11, read:>9);
+do_test_search();
+is( $ids[0], "e69e43e1355267f7d32a4f9b7f2fe108d2401ebf", qq(Read search ($search)) );
+
 done_testing();

--- a/tools/Documentation/basic-operations/searching.md
+++ b/tools/Documentation/basic-operations/searching.md
@@ -7,6 +7,7 @@ The search bar in LANraragi tries to not be too dumb and will actively suggest t
 If you want to queue multiple terms/tags, you have to use **commas** to separate them, much like how tags are entered in the metadata field when editing an archive.  
 You can mix both tags and a specific title in a search if you want.  
 You can search for galleries with a specific number of pages with `pages:20`, or with a page range: `pages:>20, pages:<=30`.  
+You can also search for galleries with a specific number of pages read with similar syntax, `read:20`, or with a range: `read:>20, read:<=30`.  
 
 You can also use the following special characters in a search:
 


### PR DESCRIPTION
Would like to be able to search for not started (but not flagged as "new") and barely started galleries, this should allow that. Figured I would just extend the page number filtering since it can use the same logic.