### PR TITLE
Fix eH login script so that downloader can download galleries hidden behind a warning

### DIFF
--- a/lib/LANraragi/Plugin/Login/EHentai.pm
+++ b/lib/LANraragi/Plugin/Login/EHentai.pm
@@ -145,6 +145,16 @@ sub get_user_agent {
             )
         );
 
+        $ua->cookie_jar->add(
+            Mojo::Cookie::Response->new(
+                name   => 'nw',
+                value  => '1',
+                domain => 'e-hentai.org',
+                path   => '/'
+            )
+        );
+
+
     } else {
         $logger->info("No cookies provided, returning blank UserAgent.");
     }

--- a/lib/LANraragi/Plugin/Login/EHentai.pm
+++ b/lib/LANraragi/Plugin/Login/EHentai.pm
@@ -134,6 +134,17 @@ sub get_user_agent {
                 path   => '/'
             )
         );
+
+        #Skips the "offensive warning" screen so that such galleries archive gIDs can be easily retrieved by Download script.
+        $ua->cookie_jar->add(
+            Mojo::Cookie::Response->new(
+                name   => 'nw',
+                value  => '1',
+                domain => 'exhentai.org',
+                path   => '/'
+            )
+        );
+
     } else {
         $logger->info("No cookies provided, returning blank UserAgent.");
     }


### PR DESCRIPTION
Add nw=1 cookie to skip offensive warning screen