### PR TITLE
(#943) Save japanese title from Chaika.moe metadata

### DIFF
--- a/tests/LANraragi/Plugin/Metadata/Chaika.t
+++ b/tests/LANraragi/Plugin/Metadata/Chaika.t
@@ -42,6 +42,21 @@ note ( 'testing retrieving tags by ID ...' );
     cmp_bag( [ split( ', ', $tags ) ] , \@tags_list, 'gallery tag list');
 }
 
+note ( 'testing retrieving tags with original title...' );
+{
+    my $json = decode_json( Mojo::File->new("$SAMPLES/chaika/001_gid_27240.json")->slurp );
+
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::Chaika::get_json_from_chaika = sub { return $json; };
+
+    my $jpntitle = 1;
+
+    my ( $tags, $title ) = LANraragi::Plugin::Metadata::Chaika::tags_from_chaika_id( "my-type", 123, 0, 0, '', $jpntitle );
+
+    is($title, $json->{title_jpn}, 'gallery original title');
+    cmp_bag( [ split( ', ', $tags ) ] , \@tags_list, 'gallery tag list');
+}
+
 note ( 'testing retrieving tags by SHA1 ...' );
 
 {


### PR DESCRIPTION
This PR adds option `Save the original title when available instead of the English or romanised title` in Chaika metadata plugin, as proposed in https://github.com/Difegue/LANraragi/issues/943:

### Screenshots

Settings page:
![Screenshot from 2024-04-17 16-35-11](https://github.com/Difegue/LANraragi/assets/57709309/6abc5622-2849-44fd-bda2-4b5cfdfd3923)

Before enabling the option:
![Screenshot from 2024-04-17 16-48-19](https://github.com/Difegue/LANraragi/assets/57709309/04349623-c4d1-477b-80b6-c44c1ba5dce9)

After enabling the option, I think it's working as intended (the first one has jp title and the second one does not):
![Screenshot from 2024-04-17 16-40-32](https://github.com/Difegue/LANraragi/assets/57709309/303d97e1-3602-46fa-8aff-bb9ee158c01d)

### Notes

This is my first time coding in perl, but I literally copied how EHentai plugin did <https://github.com/Difegue/LANraragi/blob/dev/lib/LANraragi/Plugin/Metadata/EHentai.pm> so it should be fine..?

Before commit, I ran `npm run critic` and the file I touched passed the lint:
![image](https://github.com/Difegue/LANraragi/assets/57709309/e44fa2ec-454b-4d63-a7a0-741bb4b54503)
