### PR TITLE
automatically add summary for archive upload and edits

### DIFF
--- a/lib/LANraragi/Model/Plugins.pm
+++ b/lib/LANraragi/Model/Plugins.pm
@@ -283,6 +283,12 @@ sub exec_metadata_plugin {
             $newtitle = trim($newtitle);
             $returnhash{title} = $newtitle;
         }
+
+        # Include updated summary data in response
+        if ( exists $newmetadata{summary} ) {
+            $returnhash{summary} = $newmetadata{summary};
+        }
+
         return %returnhash;
     }
     return ( error => "Plugin doesn't implement get_tags despite having a 'metadata' type." );

--- a/public/js/edit.js
+++ b/public/js/edit.js
@@ -174,6 +174,15 @@ Edit.getTags = function () {
                 });
             }
 
+            if (result.data.summary && result.data.summary !=="") {
+                $("#summary").val(result.data.summary);
+                LRR.toast({
+                    heading: "Archive summary changed to :",
+                    text: result.data.summary,
+                    icon: "info",
+                });
+            }
+
             if (result.data.new_tags !== "") {
                 result.data.new_tags.split(/,\s?/).forEach((tag) => {
                     // Remove trailing/leading spaces from tag before adding it

--- a/public/js/edit.js
+++ b/public/js/edit.js
@@ -177,8 +177,7 @@ Edit.getTags = function () {
             if (result.data.summary && result.data.summary !=="") {
                 $("#summary").val(result.data.summary);
                 LRR.toast({
-                    heading: "Archive summary changed to :",
-                    text: result.data.summary,
+                    heading: "Archive summary updated!",
                     icon: "info",
                 });
             }

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -125,7 +125,7 @@ Reader.initializeAll = function () {
 
             if (data.summary) {
                 $("#tagContainer").append(`<div class="archive-summary"/>`);
-                $(".archive-summary").html(data.summary);
+                $(".archive-summary").text(data.summary);
             }
 
             // Use localStorage progress value instead of the server one if needed

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -125,7 +125,7 @@ Reader.initializeAll = function () {
 
             if (data.summary) {
                 $("#tagContainer").append(`<div class="archive-summary"/>`);
-                $(".archive-summary").text(data.summary);
+                $(".archive-summary").html(data.summary);
             }
 
             // Use localStorage progress value instead of the server one if needed


### PR DESCRIPTION
Prior to PR, summary is not automatically added during archive file uploads (when metadata plugin is configured to run automatically) (addressed by Plugins.pm), and summary data is not automatically filled in to the summary box when editing an archive and calling metadata plugins (edit.js). This PR attempts to address that.

Contains edits (readme.js) from #968, a separate issue.

I'm not sure how do deal with rhombus git flows so I'm just keeping it linear now