### PR TITLE
Change YAML::Syck to YAML::PP

### DIFF
--- a/lib/LANraragi/Plugin/Metadata/Ksk.pm
+++ b/lib/LANraragi/Plugin/Metadata/Ksk.pm
@@ -7,7 +7,7 @@ use LANraragi::Model::Plugins;
 use LANraragi::Utils::Logging qw(get_plugin_logger);
 use LANraragi::Utils::Archive qw(is_file_in_archive extract_file_from_archive);
 
-use YAML::Syck qw(LoadFile);
+use YAML::PP qw(LoadFile);
 
 sub plugin_info {
 

--- a/tools/cpanfile
+++ b/tools/cpanfile
@@ -63,7 +63,7 @@ requires 'Module::Pluggable', 5.2;
 requires 'Time::Local', 1.30;
 
 # Ksk plugin/YAML Support
-requires 'YAML::Syck', 1.34;
+requires 'YAML::PP', 0.38.0;
 
 # Hentag plugin
 requires 'String::Similarity', 1.04


### PR DESCRIPTION
This parser handles the longer \u unicode sequences without any changes to existing LANraragi code.  It is a literal drop in swap.