### PR TITLE
Add web app manifest

### DIFF
--- a/public/app.webappmanifest
+++ b/public/app.webappmanifest
@@ -1,0 +1,14 @@
+{
+  "name": "LANraragi",
+  "short_name": "LANraragi",
+  "start_url": "/",
+  "display": "standalone",
+  "description": "Web application for archival and reading of manga/doujinshi.",
+  "icons": [
+    {
+      "src": "favicon.ico",
+      "type": "image/png",
+      "sizes": "256x256"
+    }
+  ]
+}

--- a/templates/backup.html.tt2
+++ b/templates/backup.html.tt2
@@ -10,6 +10,7 @@
 	<meta name="apple-mobile-web-app-capable" content="yes" />
 
 	<link type="image/png" rel="icon" href="favicon.ico" />
+	<link rel="manifest" href="app.webmanifest" />
 	<link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version%]" />
 
 	<link rel="stylesheet" type="text/css" href="/css/vendor/fontawesome-all.min.css" />

--- a/templates/batch.html.tt2
+++ b/templates/batch.html.tt2
@@ -12,6 +12,7 @@
 	<meta name="apple-mobile-web-app-capable" content="yes" />
 
 	<link type="image/png" rel="icon" href="favicon.ico" />
+	<link rel="manifest" href="app.webmanifest" />
 	<link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version%]" />
 	<link rel="stylesheet" type="text/css" href="/css/vendor/fontawesome-all.min.css" />
 	<link rel="stylesheet" type="text/css" href="/css/vendor/ReactToastify.min.css" />

--- a/templates/category.html.tt2
+++ b/templates/category.html.tt2
@@ -12,6 +12,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
 
     <link type="image/png" rel="icon" href="/favicon.ico" />
+    <link rel="manifest" href="app.webmanifest" />
     <link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version%]" />
     <link rel="stylesheet" type="text/css" href="/css/vendor/fontawesome-all.min.css" />
     <link rel="stylesheet" type="text/css" href="/css/vendor/ReactToastify.min.css" />

--- a/templates/config.html.tt2
+++ b/templates/config.html.tt2
@@ -10,6 +10,7 @@
 	<meta name="apple-mobile-web-app-capable" content="yes" />
 
 	<link type="image/png" rel="icon" href="favicon.ico" />
+	<link rel="manifest" href="app.webmanifest" />
 	<link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version%]" />
 	<link rel="stylesheet" type="text/css" href="/css/config.css" />
 

--- a/templates/edit.html.tt2
+++ b/templates/edit.html.tt2
@@ -10,6 +10,7 @@
 	<meta name="apple-mobile-web-app-capable" content="yes" />
 
 	<link type="image/png" rel="icon" href="favicon.ico" />
+	<link rel="manifest" href="app.webmanifest" />
 	<link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version%]" />
 	<link rel="stylesheet" type="text/css" href="/css/config.css" />
 

--- a/templates/exception.production.html.ep
+++ b/templates/exception.production.html.ep
@@ -10,6 +10,7 @@
 <meta name="apple-mobile-web-app-capable" content="yes" />
 
 	<link type="image/png" rel="icon" href="favicon.ico" />
+	<link rel="manifest" href="app.webmanifest" />
 </head>
 
 <body style='background: none repeat scroll 0% 0% brown; color: white; font-family: sans-serif; text-align: center'>

--- a/templates/index.html.tt2
+++ b/templates/index.html.tt2
@@ -10,6 +10,7 @@
 	<meta name="apple-mobile-web-app-capable" content="yes" />
 
 	<link type="image/png" rel="icon" href="favicon.ico" />
+	<link rel="manifest" href="app.webmanifest" />
 	<link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version %]" />
 
 	<link rel="stylesheet" type="text/css" href="/css/vendor/fontawesome-all.min.css" />

--- a/templates/login.html.tt2
+++ b/templates/login.html.tt2
@@ -10,6 +10,7 @@
 	<meta name="apple-mobile-web-app-capable" content="yes" />
 
 	<link type="image/png" rel="icon" href="favicon.ico" />
+	<link rel="manifest" href="app.webmanifest" />
 	<link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version%]" />
 
 	<link rel="stylesheet" type="text/css" href="./css/vendor/fontawesome-all.min.css" />

--- a/templates/logs.html.tt2
+++ b/templates/logs.html.tt2
@@ -10,6 +10,7 @@
 	<meta name="apple-mobile-web-app-capable" content="yes" />
 
 	<link type="image/png" rel="icon" href="favicon.ico" />
+	<link rel="manifest" href="app.webmanifest" />
 	<link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version%]" />
 
 	<link rel="stylesheet" type="text/css" href="./css/vendor/fontawesome-all.min.css" />

--- a/templates/not_found.production.html.ep
+++ b/templates/not_found.production.html.ep
@@ -10,6 +10,7 @@
 <meta name="apple-mobile-web-app-capable" content="yes" />
 
 	<link type="image/png" rel="icon" href="favicon.ico" />
+	<link rel="manifest" href="app.webmanifest" />
 </head>
 
 <body style=' text-align: center'>

--- a/templates/plugins.html.tt2
+++ b/templates/plugins.html.tt2
@@ -10,6 +10,7 @@
 	<meta name="apple-mobile-web-app-capable" content="yes" />
 
 	<link type="image/png" rel="icon" href="/favicon.ico" />
+	<link rel="manifest" href="app.webmanifest" />
 	<link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version%]" />
 	<link rel="stylesheet" type="text/css" href="/css/config.css" />
 

--- a/templates/reader.html.tt2
+++ b/templates/reader.html.tt2
@@ -10,6 +10,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
 
     <link type="image/png" rel="icon" href="favicon.ico" />
+    <link rel="manifest" href="app.webmanifest" />
     <link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version %]" />
     <link rel="stylesheet" type="text/css" href="/css/config.css?[% version %]" />
 

--- a/templates/stats.html.tt2
+++ b/templates/stats.html.tt2
@@ -10,6 +10,7 @@
 	<meta name="apple-mobile-web-app-capable" content="yes" />
 
 	<link type="image/png" rel="icon" href="favicon.ico" />
+	<link rel="manifest" href="app.webmanifest" />
 	<link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version%]" />
 
 	<link rel="stylesheet" type="text/css" href="./css/vendor/fontawesome-all.min.css" />

--- a/templates/upload.html.tt2
+++ b/templates/upload.html.tt2
@@ -10,6 +10,7 @@
 	<meta name="apple-mobile-web-app-capable" content="yes" />
 
 	<link type="image/png" rel="icon" href="favicon.ico" />
+	<link rel="manifest" href="app.webmanifest" />
 	<link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version%]" />
 
 	<link rel="stylesheet" type="text/css" href="./css/vendor/jquery.fileupload.css" />


### PR DESCRIPTION
This allows installing the website as a progressive web app (PWA) on mobile devices and certain web browsers. That's useful to be able to use the app without having the URL bar/tab bar getting in the way.

Relevant docs:
- Mozilla: https://developer.mozilla.org/en-US/docs/Web/Manifest 
- Google: https://web.dev/learn/pwa/web-app-manifest

I've tested this on two Android devices (Android 9 and 14).