### PR TITLE
Fix #975 Preload image size asynchronously

### DIFF
--- a/public/js/common.js
+++ b/public/js/common.js
@@ -317,6 +317,14 @@ LRR.getImgSize = function (target) {
     return imgSize;
 };
 
+LRR.getImgSizeAsync = function (target) {
+    return $.ajax({
+        url: target,
+        cache: true,
+        type: "HEAD",
+    });
+};
+
 /**
  * Show a generic toast with a given header and message.
  * This is a compatibility layer to migrate jquery-toast-plugin to react-toastify.


### PR DESCRIPTION
Was a pretty low hanging fruit so tried to do it in the simplest way possible. Adds an async version of the `getImageSize` function and calls it in `Reader.loadImage`. Other line changes are formatting stuff done by the autoformatter specified in `devcontainer.json`.