### PR TITLE
Ignore source tag when building untagged index

### DIFF
--- a/lib/LANraragi/Model/Stats.pm
+++ b/lib/LANraragi/Model/Stats.pm
@@ -8,13 +8,13 @@ use Redis;
 use File::Find;
 use Mojo::JSON qw(encode_json);
 
-use LANraragi::Utils::Generic qw(is_archive);
-use LANraragi::Utils::String qw(trim trim_CRLF trim_url);
+use LANraragi::Utils::Generic  qw(is_archive);
+use LANraragi::Utils::String   qw(trim trim_CRLF trim_url);
 use LANraragi::Utils::Database qw(redis_decode redis_encode);
-use LANraragi::Utils::Logging qw(get_logger);
+use LANraragi::Utils::Logging  qw(get_logger);
 
 sub get_archive_count {
-    my $redis  = LANraragi::Model::Config->get_redis_search;
+    my $redis = LANraragi::Model::Config->get_redis_search;
     return $redis->zcard("LRR_TITLES") + 0;    # Total number of archives (as int)
 }
 
@@ -74,7 +74,7 @@ sub build_stat_hashes {
                 $t = trim_CRLF($t);
 
                 # The following are basic and therefore don't count as "tagged"
-                $has_tags = 1 unless $t =~ /(artist|parody|series|language|event|group|date_added|timestamp):.*/;
+                $has_tags = 1 unless $t =~ /(artist|parody|series|language|event|group|date_added|timestamp|source):.*/;
 
                 # If the tag is a source: tag, add it to the URL index
                 if ( $t =~ /source:(.*)/i ) {
@@ -187,14 +187,14 @@ sub compute_content_size {
 
     $redis_db->multi;
     foreach my $id (@keys) {
-        LANraragi::Utils::Database::get_arcsize($redis_db, $id);
+        LANraragi::Utils::Database::get_arcsize( $redis_db, $id );
     }
     my @result = $redis_db->exec;
     $redis_db->quit;
 
     my $size = 0;
     foreach my $row (@result) {
-        if (defined($row)) {
+        if ( defined($row) ) {
             $size = $size + $row;
         }
     }

--- a/lib/LANraragi/Utils/Database.pm
+++ b/lib/LANraragi/Utils/Database.pm
@@ -39,8 +39,8 @@ sub add_archive_to_redis ( $id, $file, $redis ) {
     $logger->debug("File Name: $name");
     $logger->debug("Filesystem Path: $file");
 
-    $redis->hset( $id, "name", redis_encode($name) );
-    $redis->hset( $id, "tags", "" );
+    $redis->hset( $id, "name",    redis_encode($name) );
+    $redis->hset( $id, "tags",    "" );
     $redis->hset( $id, "summary", "" );
 
     if ( defined($file) && -e $file ) {
@@ -376,7 +376,7 @@ sub set_tags ( $id, $newtags, $append = 0 ) {
     invalidate_cache();
 }
 
-sub set_summary ($id, $summary) {
+sub set_summary ( $id, $summary ) {
 
     my $redis = LANraragi::Model::Config->get_redis;
     $redis->hset( $id, "summary", redis_encode($summary) );
@@ -432,7 +432,7 @@ sub update_indexes ( $id, $oldtags, $newtags ) {
     foreach my $tag (@newtags) {
 
         # The following are basic and therefore don't count as "tagged"
-        $has_tags = 1 unless $tag =~ /(artist|parody|series|language|event|group|date_added|timestamp):.*/;
+        $has_tags = 1 unless $tag =~ /(artist|parody|series|language|event|group|date_added|timestamp|source):.*/;
 
         # If the tag is a source: tag, add it to the URL index
         if ( $tag =~ /source:(.*)/i ) {


### PR DESCRIPTION
When a metadata plugin fails, tags are not added to an archive. However, since the `source:` tag is still attached to the archive, it isn't automatically detected as an untagged archive, which makes it difficult to batch tag later on. All this PR does is to add `source` to the list of ignored tags (other changes are the auto-formatter).