### PR TITLE
Enable EH script to handle source tag with https prefix

### DIFF
--- a/lib/LANraragi/Plugin/Metadata/EHentai.pm
+++ b/lib/LANraragi/Plugin/Metadata/EHentai.pm
@@ -70,7 +70,7 @@ sub get_tags {
         $gID    = $1;
         $gToken = $2;
         $logger->debug("Skipping search and using gallery $gID / $gToken from oneshot args");
-    } elsif ( $lrr_info->{existing_tags} =~ /.*source:\s*e(?:x|-)hentai\.org\/g\/([0-9]*)\/([0-z]*)\/*.*/gi ) {
+    } elsif ( $lrr_info->{existing_tags} =~ /.*source:\s*(?:https?:\/\/)?e(?:x|-)hentai\.org\/g\/([0-9]*)\/([0-z]*)\/*.*/gi ) {
         $gID    = $1;
         $gToken = $2;
         $hasSrc = 1;


### PR DESCRIPTION
When pasting links directly into the downloader, the links are often prefixed with `https://` or potentially `http://`. The `source:` tag is attached to the archive with the URL containing the https prefix, but can't be picked up by the current EH metadata script because the regex does not handle it. Here I add the non-capture group `(?:https?:\/\/)?` to the regex to allow these links to be used by the script.