### PR TITLE
Use alpine 3.20 (again!)

### DIFF
--- a/tools/build/docker/Dockerfile
+++ b/tools/build/docker/Dockerfile
@@ -1,5 +1,5 @@
 # DOCKER-VERSION 0.3.4
-FROM        alpine:3.18
+FROM        alpine:3.20
 LABEL       git="https://github.com/Difegue/LANraragi"
 ARG INSTALL_PARAMETER
 

--- a/tools/build/docker/Dockerfile-dev
+++ b/tools/build/docker/Dockerfile-dev
@@ -1,5 +1,5 @@
 # DOCKER-VERSION 0.3.4
-FROM        alpine:3.18
+FROM        alpine:3.20
 
 #Default mojo server port
 EXPOSE 3000

--- a/tools/build/docker/install-everything.sh
+++ b/tools/build/docker/install-everything.sh
@@ -23,7 +23,7 @@ done
 apk update
 apk add tzdata
 apk add perl perl-io-socket-ssl perl-dev redis libarchive-dev libbz2 openssl-dev zlib-dev linux-headers
-apk add imagemagick imagemagick-perlmagick libwebp-tools libheif ghostscript
+apk add imagemagick imagemagick-perlmagick libwebp-tools libheif
 apk add g++ make pkgconf gnupg wget curl file
 apk add shadow s6 s6-portable-utils 
 

--- a/tools/install.pl
+++ b/tools/install.pl
@@ -105,11 +105,9 @@ say("OK!");
 
 #Check for GhostScript
 say("Checking for GhostScript...");
-if ( can_run('gs') ) {
-    say("OK!");
-} else {
-    warn 'NOT FOUND! PDF support will not work properly. Please install the "gs" tool.';
-}
+can_run('gs')
+  or warn 'NOT FOUND! PDF support will not work properly. Please install the "gs" tool.';
+say("OK!");
 
 #Check for libarchive
 say("Checking for libarchive...");


### PR DESCRIPTION
Alpine 3.20.1 contains the imagemagick INC fix and it Works On My Machine. You might need to re-pull if you have the old busted 3.20 image in your docker cache, but it's either that or locking down to 3.20.1 (and update Dockerfiles once 3.20.2 hits).

(This is just a revert of the revert).