### PR TITLE
Make install script die on any error

### DIFF
--- a/tools/build/docker/install-everything.sh
+++ b/tools/build/docker/install-everything.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 usage() { echo "Usage: $0 [-d (devmode) -w (wsl cpan packages)]" 1>&2; exit 1; }
 
 DEV=0


### PR DESCRIPTION
install-everything.sh will happily chug along if, for instance, the alpine CDN is down or currently not  accessible. The end result is a broken install, which isn't very cash money.

Rather than adding a bunch of fancy error handling, this PR just makes the script die if anything in it fails.