### PR TITLE
Updated the FAKKU plugin to add summary support and source tag lookup.

### DIFF
--- a/lib/LANraragi/Plugin/Metadata/Fakku.pm
+++ b/lib/LANraragi/Plugin/Metadata/Fakku.pm
@@ -235,7 +235,7 @@ sub get_tags_from_fakku {
 
     # If the Summary DIV doesn't exist, return a blank string.
     if ( defined $summ_div ) {
-        $summary = $summ_div->text;
+        $summary = $summ_div->all_text;
     } else {
         $summary = "";
     }

--- a/lib/LANraragi/Plugin/Metadata/Fakku.pm
+++ b/lib/LANraragi/Plugin/Metadata/Fakku.pm
@@ -25,7 +25,7 @@ sub plugin_info {
         namespace   => "fakkumetadata",
         login_from  => "fakkulogin",
         author      => "Difegue, Nodja, Nixis198",
-        version     => "0.96",
+        version     => "0.97",
         description =>
           "Searches FAKKU for tags matching your archive. If you have an account, don't forget to enter the matching cookie in the login plugin to be able to access controversial content. <br/><br/>  
            <i class='fa fa-exclamation-circle'></i> <b>This plugin can and will return invalid results depending on what you're searching for!</b> <br/>The FAKKU search API isn't very precise and I recommend you use the Chaika.moe plugin when possible.",

--- a/lib/LANraragi/Plugin/Metadata/Fakku.pm
+++ b/lib/LANraragi/Plugin/Metadata/Fakku.pm
@@ -95,12 +95,11 @@ sub get_tags {
     # We could stand to pre-check it to see if it really is a FAKKU URL but meh
     if ( $lrr_info->{oneshot_param} ) {
         $fakku_URL = $lrr_info->{oneshot_param};
-    } else {
-        if ( $fakku_URL eq "" ) {
+    }
+    if ( $fakku_URL eq "" ) {
 
-            # Search for a FAKKU URL if the user didn't specify one or none found in the tags.
-            $fakku_URL = search_for_fakku_url( $lrr_info->{archive_title}, $ua );
-        }
+        # Search for a FAKKU URL if the user didn't specify one or none found in the tags.
+        $fakku_URL = search_for_fakku_url( $lrr_info->{archive_title}, $ua );
     }
 
     # Do we have a URL to grab data from?
@@ -297,7 +296,10 @@ sub get_tags_from_fakku {
     }
 
     # Adds the source tag is enabled.
-    push( @tags, "source:" . $url ) unless !$add_url;
+    if ($add_url) {
+        $url =~ s{^https://www\.}{}i;
+        push( @tags, "source:" . $url );
+    }
 
     return ( join( ', ', @tags ), $title, $summary );
 

--- a/lib/LANraragi/Plugin/Metadata/Fakku.pm
+++ b/lib/LANraragi/Plugin/Metadata/Fakku.pm
@@ -25,14 +25,14 @@ sub plugin_info {
         namespace   => "fakkumetadata",
         login_from  => "fakkulogin",
         author      => "Difegue, Nodja, Nixis198",
-        version     => "0.94",
+        version     => "0.96",
         description =>
           "Searches FAKKU for tags matching your archive. If you have an account, don't forget to enter the matching cookie in the login plugin to be able to access controversial content. <br/><br/>  
            <i class='fa fa-exclamation-circle'></i> <b>This plugin can and will return invalid results depending on what you're searching for!</b> <br/>The FAKKU search API isn't very precise and I recommend you use the Chaika.moe plugin when possible.",
         icon =>
           "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAACZSURBVDhPlY+xDYQwDEWvZgRGYA22Y4frqJDSZhFugiuuo4cqPGT0iTjAYL3C+fGzktc3hEcsQvJq6HtjE2Jdv4viH4a4pWnL8q4A6g+ET9P8YhS2/kqwIZXWnwqChDxPfCFfD76wOzJ2IOR/0DSwnuRKYAKUW3gq2OsJTYM0jr7QVRVwlabJEaw3ARYBcmFXeomxphIeEMIMmh3lOLQR+QQAAAAASUVORK5CYII=",
-        parameters  => [],
-        oneshot_arg => "FAKKU Gallery URL (Will attach tags matching this exact gallery to your archive)"
+        oneshot_arg => "FAKKU Gallery URL (Will attach tags matching this exact gallery to your archive)",
+        parameters  => [ { type => "bool", desc => "Add 'Source' tag" } ]
     );
 
 }
@@ -41,8 +41,9 @@ sub plugin_info {
 sub get_tags {
 
     shift;
-    my $lrr_info = shift;                     # Global info hash
-    my $ua       = $lrr_info->{user_agent};
+    my $lrr_info     = shift;                     # Global info hash
+    my $ua           = $lrr_info->{user_agent};
+    my ($add_source) = @_;
 
     my $logger = get_plugin_logger();
 
@@ -77,14 +78,29 @@ sub get_tags {
 
     my $fakku_URL = "";
 
+    # Looks for the "source:" in the existing tags.
+    my @oldTags = split( ',', $lrr_info->{existing_tags} );
+    my $pattern = qr/^source:(.+)$/;
+
+    foreach my $oldtag (@oldTags) {
+        if ( $oldtag =~ $pattern ) {
+            my $foundURL = $1;
+            if ( $foundURL =~ /fakku\.net/ ) {    #Makes sure the found url is a fakku.net url.
+                $fakku_URL = $foundURL;
+            }
+        }
+    }
+
     # If the user specified a oneshot argument, use it as-is.
     # We could stand to pre-check it to see if it really is a FAKKU URL but meh
     if ( $lrr_info->{oneshot_param} ) {
         $fakku_URL = $lrr_info->{oneshot_param};
     } else {
+        if ( $fakku_URL eq "" ) {
 
-        # Search for a FAKKU URL if the user didn't specify one
-        $fakku_URL = search_for_fakku_url( $lrr_info->{archive_title}, $ua );
+            # Search for a FAKKU URL if the user didn't specify one or none found in the tags.
+            $fakku_URL = search_for_fakku_url( $lrr_info->{archive_title}, $ua );
+        }
     }
 
     # Do we have a URL to grab data from?
@@ -95,8 +111,8 @@ sub get_tags {
         return ( error => "No matching FAKKU Gallery Found!" );
     }
 
-    my ( $newtags, $newtitle );
-    eval { ( $newtags, $newtitle ) = get_tags_from_fakku( $fakku_URL, $ua ); };
+    my ( $newtags, $newtitle, $newSummary );
+    eval { ( $newtags, $newtitle, $newSummary ) = get_tags_from_fakku( $fakku_URL, $ua, $add_source ); };
 
     if ($@) {
         return ( error => $@ );
@@ -105,7 +121,7 @@ sub get_tags {
     $logger->info("Sending the following tags to LRR: $newtags");
 
     #Return a hash containing the new metadata - it will be integrated in LRR.
-    return ( tags => $newtags, title => $newtitle );
+    return ( tags => $newtags, title => $newtitle, summary => $newSummary );
 }
 
 ######
@@ -192,7 +208,7 @@ sub get_dom_from_fakku {
 # Parses a FAKKU URL for tags.
 sub get_tags_from_fakku {
 
-    my ( $url, $ua ) = @_;
+    my ( $url, $ua, $add_url ) = @_;
 
     my $logger = get_plugin_logger();
 
@@ -210,6 +226,24 @@ sub get_tags_from_fakku {
     $logger->debug("Parsed title: $title");
 
     my @tags = ();
+
+    # Finds the DIV for the Summary.
+    my $summ_selector =
+      '.table-cell.w-full.align-top.text-left.space-y-2.leading-relaxed.link\:text-blue-700.dark\:link\:text-white';
+    my $summ_div = $dom->at($summ_selector);
+    my $summary;
+
+    # If the Summary DIV doesn't exist, return a blank string.
+    if ( defined $summ_div ) {
+        $summary = $summ_div->text;
+    } else {
+        $summary = "";
+    }
+
+    # If no FAKKU description exists, just keep it blank.
+    if ( $summary eq "No description has been written." ) {
+        $summary = "";
+    }
 
     # We can grab some namespaced tags from the first few div.
     my @namespaces = $metadata_parent->children('div')->each;
@@ -262,7 +296,10 @@ sub get_tags_from_fakku {
         }
     }
 
-    return ( join( ', ', @tags ), $title );
+    # Adds the source tag is enabled.
+    push( @tags, "source:" . $url ) unless !$add_url;
+
+    return ( join( ', ', @tags ), $title, $summary );
 
 }
 

--- a/tests/LANraragi/Plugin/Metadata/Fakku.t
+++ b/tests/LANraragi/Plugin/Metadata/Fakku.t
@@ -3,7 +3,7 @@ use warnings;
 use utf8;
 use Data::Dumper;
 
-use Cwd qw( getcwd );
+use Cwd        qw( getcwd );
 use Mojo::JSON qw(decode_json encode_json);
 use Mojo::File;
 
@@ -14,12 +14,18 @@ my $cwd     = getcwd();
 my $SAMPLES = "$cwd/tests/samples";
 require "$cwd/tests/mocks.pl";
 
-my @tags_list_from_gallery = (
+my @tags_list_from_gallery_no_source = (
     'Artist:Hamao',
     'Parody:Original Work',
     'Magazine:Comic Kairakuten 2020-04',
-    'Publisher:FAKKU', 'color', 'schoolgirl outfit',
-    'osananajimi', 'unlimited', 'non-h', 'illustration'
+    'Publisher:FAKKU', 'color',     'schoolgirl outfit',
+    'osananajimi',     'unlimited', 'non-h', 'illustration'
+);
+
+my @tags_list_from_gallery_with_source = (
+    'Artist:Hamao', 'Parody:Original Work', 'Magazine:Comic Kairakuten 2020-04', 'Publisher:FAKKU',
+    'color',        'schoolgirl outfit',    'osananajimi',                       'unlimited',
+    'non-h',        'illustration',         'source:https://url/to/my/page.html'
 );
 
 use_ok('LANraragi::Plugin::Metadata::Fakku');
@@ -36,7 +42,7 @@ note("testing searching URL by title ...");
     is( $url, "https://www.fakku.net/hentai/kairakuten-cover-girls-episode-009-hamao-english", "url check" );
 }
 
-note("testing parsing gallery front page ...");
+note("testing parsing gallery front page no source tag...");
 
 {
     my $html = ( Mojo::File->new("$SAMPLES/fakku/002_gallery_front.html")->slurp );
@@ -44,9 +50,25 @@ note("testing parsing gallery front page ...");
     local *LANraragi::Plugin::Metadata::Fakku::get_dom_from_fakku = sub { return Mojo::DOM->new($html); };
     local *LANraragi::Plugin::Metadata::Fakku::get_plugin_logger  = sub { return get_logger_mock(); };
 
-    my ( $tags, $title ) = LANraragi::Plugin::Metadata::Fakku::get_tags_from_fakku("https://url/to/my/page.html");
-    cmp_bag( [ split( ', ', $tags ) ], \@tags_list_from_gallery, "tag check" );
-    is( $title, 'Kairakuten Cover Girl\'s Episode 009: Hamao', "title check" );
+    my ( $tags, $title, $summary ) = LANraragi::Plugin::Metadata::Fakku::get_tags_from_fakku("https://url/to/my/page.html");
+    cmp_bag( [ split( ', ', $tags ) ], \@tags_list_from_gallery_no_source, "tag check" );
+    is( $title,   'Kairakuten Cover Girl\'s Episode 009: Hamao', "title check" );
+    is( $summary, 'This is a test summary. Hi mom.',             "summary check" );
+}
+
+note("testing parsing gallery front page with source tag...");
+
+{
+    my $html = ( Mojo::File->new("$SAMPLES/fakku/002_gallery_front.html")->slurp );
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::Fakku::get_dom_from_fakku = sub { return Mojo::DOM->new($html); };
+    local *LANraragi::Plugin::Metadata::Fakku::get_plugin_logger  = sub { return get_logger_mock(); };
+
+    my ( $tags, $title, $summary ) =
+      LANraragi::Plugin::Metadata::Fakku::get_tags_from_fakku( "https://url/to/my/page.html", "", 1 );
+    cmp_bag( [ split( ', ', $tags ) ], \@tags_list_from_gallery_with_source, "tag check" );
+    is( $title,   'Kairakuten Cover Girl\'s Episode 009: Hamao', "title check" );
+    is( $summary, 'This is a test summary. Hi mom.',             "summary check" );
 }
 
 done_testing();

--- a/tests/LANraragi/Plugin/Metadata/Fakku.t
+++ b/tests/LANraragi/Plugin/Metadata/Fakku.t
@@ -52,8 +52,8 @@ note("testing parsing gallery front page no source tag...");
 
     my ( $tags, $title, $summary ) = LANraragi::Plugin::Metadata::Fakku::get_tags_from_fakku("https://url/to/my/page.html");
     cmp_bag( [ split( ', ', $tags ) ], \@tags_list_from_gallery_no_source, "tag check" );
-    is( $title,   'Kairakuten Cover Girl\'s Episode 009: Hamao', "title check" );
-    is( $summary, 'This is a test summary. Hi mom.',             "summary check" );
+    is( $title,   'Kairakuten Cover Girl\'s Episode 009: Hamao',     "title check" );
+    is( $summary, 'Bold baby bold. This is a test summary. Hi mom.', "summary check" );
 }
 
 note("testing parsing gallery front page with source tag...");
@@ -67,8 +67,8 @@ note("testing parsing gallery front page with source tag...");
     my ( $tags, $title, $summary ) =
       LANraragi::Plugin::Metadata::Fakku::get_tags_from_fakku( "https://url/to/my/page.html", "", 1 );
     cmp_bag( [ split( ', ', $tags ) ], \@tags_list_from_gallery_with_source, "tag check" );
-    is( $title,   'Kairakuten Cover Girl\'s Episode 009: Hamao', "title check" );
-    is( $summary, 'This is a test summary. Hi mom.',             "summary check" );
+    is( $title,   'Kairakuten Cover Girl\'s Episode 009: Hamao',     "title check" );
+    is( $summary, 'Bold baby bold. This is a test summary. Hi mom.', "summary check" );
 }
 
 done_testing();

--- a/tests/samples/fakku/002_gallery_front.html
+++ b/tests/samples/fakku/002_gallery_front.html
@@ -323,7 +323,7 @@
                         </div>
                         <div class="table text-sm w-full">
                             <div
-                                class="table-cell w-full align-top text-left space-y-2 leading-relaxed link:text-blue-700 dark:link:text-white">This is a test summary. Hi mom.</div>
+                                class="table-cell w-full align-top text-left space-y-2 leading-relaxed link:text-blue-700 dark:link:text-white"><b>Bold baby bold. </b>This is a test summary. Hi mom.</div>
                         </div>
 
 

--- a/tests/samples/fakku/002_gallery_front.html
+++ b/tests/samples/fakku/002_gallery_front.html
@@ -278,7 +278,8 @@
                             <div
                                 class="table-cell w-full align-top text-left space-y-2 link:text-blue-700 dark:link:text-white">
                                 <a title="Hamao Hentai" href="https://www.fakku.net/artists/hamao" class=" ">
-                                    Hamao</a></div>
+                                    Hamao</a>
+                            </div>
                         </div>
 
 
@@ -288,7 +289,8 @@
                                 class="table-cell w-full align-top text-left space-y-2 link:text-blue-700 dark:link:text-white">
                                 <a title="Original Work Hentai" href="https://www.fakku.net/series/original-work"
                                     class=" ">
-                                    Original Work</a></div>
+                                    Original Work</a>
+                            </div>
                         </div>
 
 
@@ -298,7 +300,8 @@
                                 class="table-cell w-full align-top text-left space-y-2 link:text-blue-700 dark:link:text-white">
                                 <a title="Comic Kairakuten 2020-04 Hentai"
                                     href="https://www.fakku.net/magazines/comic-kairakuten-2020-04" class=" ">
-                                    Comic Kairakuten 2020-04</a></div>
+                                    Comic Kairakuten 2020-04</a>
+                            </div>
                         </div>
 
 
@@ -307,7 +310,8 @@
                             <div
                                 class="table-cell w-full align-top text-left space-y-2 link:text-blue-700 dark:link:text-white">
                                 <a title="FAKKU Hentai" href="https://www.fakku.net/publishers/fakku" class=" ">
-                                    FAKKU</a></div>
+                                    FAKKU</a>
+                            </div>
                         </div>
 
 
@@ -317,7 +321,10 @@
                                 class="table-cell w-full align-top text-left space-y-2 link:text-blue-700 dark:link:text-white">
                                 1 page</div>
                         </div>
-
+                        <div class="table text-sm w-full">
+                            <div
+                                class="table-cell w-full align-top text-left space-y-2 leading-relaxed link:text-blue-700 dark:link:text-white">This is a test summary. Hi mom.</div>
+                        </div>
 
 
 
@@ -1590,7 +1597,8 @@
                                             $12.95</div>
                                         <div
                                             class="table-cell rounded rounded-l-none font-bold text-base text-white px-3 pr-4 py-2 bg-green-600">
-                                            <i class="fas fa-cart-plus fa-sm"></i></div>
+                                            <i class="fas fa-cart-plus fa-sm"></i>
+                                        </div>
                                     </div>
 
                                 </div>
@@ -2352,7 +2360,8 @@
                     <div class="flex-1 align-top text-lg text-left font-bold py-2 pr-2" id="overlay-title"></div>
                     <div
                         class="flex-none align-top text-gray-900 z-40 text-right cursor-pointer dark:text-white text-lg js-overlay-close">
-                        <i class="fas fa-times hover:bg-gray-100 p-2 rounded"></i></div>
+                        <i class="fas fa-times hover:bg-gray-100 p-2 rounded"></i>
+                    </div>
                 </div>
 
                 <div class="space-y-4" id="overlay-content"></div>


### PR DESCRIPTION
With the latest version adding summaries, the FAKKU plugin now grabs the summary as well. It now also adds the option to include the given URL as a source tag. It does need to be enabled in the plugin settings.

Also if a source tag is already in to tags, the plugin will detect it and use that if no URL is provided by the user.
This is useful for updating galleries to now add the summary.