### PR TITLE
adds plugin CopyArchiveTags

### DIFF
--- a/lib/LANraragi/Plugin/Metadata/CopyArchiveTags.pm
+++ b/lib/LANraragi/Plugin/Metadata/CopyArchiveTags.pm
@@ -25,7 +25,7 @@ sub plugin_info {
                 desc => "Enable to also copy the date (but it's up to you to remove the old one)"
             }
         ],
-        oneshot_arg => "LRR Gallery URI or ID:"
+        oneshot_arg => "LRR Gallery URL or ID:"
     );
 
 }

--- a/lib/LANraragi/Plugin/Metadata/CopyArchiveTags.pm
+++ b/lib/LANraragi/Plugin/Metadata/CopyArchiveTags.pm
@@ -4,16 +4,17 @@ use strict;
 use warnings;
 
 use LANraragi::Model::Plugins;
-use LANraragi::Utils::Database qw(get_archive_tags);
-use LANraragi::Utils::Logging  qw(get_plugin_logger);
-use LANraragi::Utils::Tags     qw(join_tags_to_string);
+use LANraragi::Utils::Database;
+use LANraragi::Utils::Logging qw(get_plugin_logger);
+use LANraragi::Utils::Tags    qw(join_tags_to_string split_tags_to_array);
+use LANraragi::Utils::String  qw(trim);
 
 #Meta-information about your plugin.
 sub plugin_info {
 
     return (
         #Standard metadata
-        name        => "CopyArchiveTags",
+        name        => "Copy Archive Tags",
         type        => "metadata",
         namespace   => "copy-archive-tags",
         author      => "IceBreeze",
@@ -48,8 +49,10 @@ sub get_tags {
 sub internal_get_tags {
     my ( $logger, $params ) = @_;
 
-    my $lrr_gid = $params->{'oneshot'};
-    $lrr_gid =~ s/^.*id=//i;    # extract the ID from the URI if necessary
+    my $lrr_gid = extract_archive_id( $params->{'oneshot'} );
+    if ( !$lrr_gid ) {
+        die "oneshot_param doesn't contain a valid archive ID\n";
+    }
 
     if ( $lrr_gid eq $params->{'lrr_info'}{'archive_id'} ) {
         die "You are using the current archive ID\n";
@@ -57,17 +60,25 @@ sub internal_get_tags {
 
     $logger->info("Copying tags from archive \"${lrr_gid}\"");
 
-    my $tags;
-    if ( $params->{'copy_date_added'} ) {
-        $tags = get_archive_tags($lrr_gid);
-    } else {
-        my @tags = get_archive_tags($lrr_gid);
+    my $tags = LANraragi::Utils::Database::get_tags($lrr_gid);
+
+    if ( !$params->{'copy_date_added'} ) {
+        my @tags = split_tags_to_array($tags);
         $tags = join_tags_to_string( grep( !m/date_added/, @tags ) );
     }
 
     my %hashdata = ( tags => $tags );
 
     return %hashdata;
+}
+
+sub extract_archive_id {
+    my ($oneshot) = @_;
+    return if ( !$oneshot || length($oneshot) < 40 );
+    if ( ( lc $oneshot ) =~ m/([0-9a-f]{40,})/ ) {
+        return $1 if length($1) == 40;
+    }
+    return;
 }
 
 sub read_params {

--- a/lib/LANraragi/Plugin/Metadata/CopyArchiveTags.pm
+++ b/lib/LANraragi/Plugin/Metadata/CopyArchiveTags.pm
@@ -1,5 +1,8 @@
 package LANraragi::Plugin::Metadata::CopyArchiveTags;
 
+use v5.36;
+use experimental 'try';
+
 use strict;
 use warnings;
 
@@ -36,10 +39,12 @@ sub get_tags {
     my $logger = get_plugin_logger();
 
     # should be handled in the caller
-    my %hashdata = eval { internal_get_tags( $logger, $params ); };
-    if ($@) {
-        $logger->error($@);
-        return ( error => $@ );
+    my %hashdata;
+    try {
+        %hashdata = internal_get_tags( $logger, $params );
+    } catch ($e) {
+        $logger->error($e);
+        return ( error => $e );
     }
 
     $logger->info( "Sending the following tags to LRR: " . ( $hashdata{tags} || '-' ) );

--- a/lib/LANraragi/Plugin/Metadata/CopyArchiveTags.pm
+++ b/lib/LANraragi/Plugin/Metadata/CopyArchiveTags.pm
@@ -1,0 +1,88 @@
+package LANraragi::Plugin::Metadata::CopyArchiveTags;
+
+use strict;
+use warnings;
+
+use LANraragi::Model::Plugins;
+use LANraragi::Utils::Database qw(get_archive_tags);
+use LANraragi::Utils::Logging  qw(get_plugin_logger);
+use LANraragi::Utils::Tags     qw(join_tags_to_string);
+
+#Meta-information about your plugin.
+sub plugin_info {
+
+    return (
+        #Standard metadata
+        name        => "CopyArchiveTags",
+        type        => "metadata",
+        namespace   => "copy-archive-tags",
+        author      => "IceBreeze",
+        version     => "1.0",
+        description => "Copy tags from another LRR archive given either the URI or the ID.",
+        parameters  => [
+            {   type => "bool",
+                name => 'copy_date_added',
+                desc => "Enable to also copy the date (but it's up to you to remove the old one)"
+            }
+        ],
+        oneshot_arg => "LRR Gallery URI or ID:"
+    );
+
+}
+
+sub get_tags {
+    my $params = read_params(@_);
+    my $logger = get_plugin_logger();
+
+    # should be handled in the caller
+    my %hashdata = eval { internal_get_tags( $logger, $params ); };
+    if ($@) {
+        $logger->error($@);
+        return ( error => $@ );
+    }
+
+    $logger->info( "Sending the following tags to LRR: " . ( $hashdata{tags} || '-' ) );
+    return %hashdata;
+}
+
+sub internal_get_tags {
+    my ( $logger, $params ) = @_;
+
+    my $lrr_gid = $params->{'oneshot'};
+    $lrr_gid =~ s/^.*id=//i;    # extract the ID from the URI if necessary
+
+    if ( $lrr_gid eq $params->{'lrr_info'}{'archive_id'} ) {
+        die "You are using the current archive ID\n";
+    }
+
+    $logger->info("Copying tags from archive \"${lrr_gid}\"");
+
+    my $tags;
+    if ( $params->{'copy_date_added'} ) {
+        $tags = get_archive_tags($lrr_gid);
+    } else {
+        my @tags = get_archive_tags($lrr_gid);
+        $tags = join_tags_to_string( grep( !m/date_added/, @tags ) );
+    }
+
+    my %hashdata = ( tags => $tags );
+
+    return %hashdata;
+}
+
+sub read_params {
+    my %plugin_info = plugin_info();
+    my $lrr_info    = $_[1];
+    my @param_cfg   = @{ $plugin_info{parameters} };
+
+    my %params;
+    $params{lrr_info} = $lrr_info;
+    $params{oneshot}  = $lrr_info->{oneshot_param};
+    for ( my $i = 0; $i < scalar @param_cfg; $i++ ) {
+        my $value = $_[ $i + 2 ] || $param_cfg[$i]->{default};
+        $params{ $param_cfg[$i]->{name} } = $value;
+    }
+    return \%params;
+}
+
+1;

--- a/lib/LANraragi/Utils/Database.pm
+++ b/lib/LANraragi/Utils/Database.pm
@@ -190,7 +190,7 @@ sub get_archive_json_multi (@ids) {
     return @archives;
 }
 
-sub get_archive_tags ($id) {
+sub get_tags ($id) {
     my %archive_info = get_archive($id);
     return undef if ( !%archive_info );
     return wantarray

--- a/lib/LANraragi/Utils/Database.pm
+++ b/lib/LANraragi/Utils/Database.pm
@@ -26,7 +26,7 @@ use LANraragi::Utils::Logging qw(get_logger);
 use Exporter 'import';
 our @EXPORT_OK = qw(
   redis_encode redis_decode invalidate_cache compute_id change_archive_id set_tags set_title set_summary set_isnew get_computed_tagrules save_computed_tagrules get_tankoubons_by_file
-  get_archive get_archive_json get_archive_json_multi get_archive_tags);
+  get_archive get_archive_json get_archive_json_multi get_tags);
 
 # Creates a DB entry for a file path with the given ID.
 # This function doesn't actually require the file to exist at its given location.
@@ -193,9 +193,7 @@ sub get_archive_json_multi (@ids) {
 sub get_tags ($id) {
     my %archive_info = get_archive($id);
     return undef if ( !%archive_info );
-    return wantarray
-      ? split_tags_to_array( $archive_info{tags} )
-      : $archive_info{tags};
+    return $archive_info{tags};
 }
 
 # Internal function for building an archive JSON.

--- a/tests/LANraragi/Plugin/Metadata/CopyArchiveTags.t
+++ b/tests/LANraragi/Plugin/Metadata/CopyArchiveTags.t
@@ -79,6 +79,121 @@ note('testing get_tags returning a list of tags ...');
     cmp_deeply( \@log_messages, [ [ 'info', ignore, 'Sending the following tags to LRR: one, two' ] ], 'log messages' );
 }
 
+note('extract_archive_id returns undef if param doesn\'t contain a valid archive ID ...');
+{
+    is( LANraragi::Plugin::Metadata::CopyArchiveTags::extract_archive_id(undef), undef, 'param was undef' );
+
+    is( LANraragi::Plugin::Metadata::CopyArchiveTags::extract_archive_id(''), undef, 'param was empty' );
+
+    my $short_hex = substr( _random_archive_id(), 1 );
+
+    is( LANraragi::Plugin::Metadata::CopyArchiveTags::extract_archive_id("http://127.0.0.1:3000/reader?id=${short_hex}"),
+        undef, 'invalid id: too short hex number' );
+
+    my $long_hex = 'fff' . _random_archive_id();
+
+    is( LANraragi::Plugin::Metadata::CopyArchiveTags::extract_archive_id("http://127.0.0.1:3000/reader?id=${long_hex}"),
+        undef, 'invalid id: too long hex number' );
+
+}
+
+note('extract_archive_id returns the ID in lowercase ...');
+{
+    my $archive_id = uc _random_archive_id();
+
+    is( LANraragi::Plugin::Metadata::CopyArchiveTags::extract_archive_id("http://127.0.0.1:3000/reader?id=${archive_id}"),
+        lc $archive_id,
+        'lowercase ID'
+    );
+}
+
+note('extract_archive_id parses oneshot_param ...');
+{
+
+    my $archive_id = _random_archive_id();
+    is( LANraragi::Plugin::Metadata::CopyArchiveTags::extract_archive_id($archive_id), $archive_id, 'simple ID input' );
+
+    $archive_id = _random_archive_id();
+    is( LANraragi::Plugin::Metadata::CopyArchiveTags::extract_archive_id("   ${archive_id}    "), $archive_id, 'dirty input 1' );
+
+    $archive_id = _random_archive_id();
+    is( LANraragi::Plugin::Metadata::CopyArchiveTags::extract_archive_id("d=${archive_id}    "), $archive_id, 'dirty input 2' );
+
+    $archive_id = _random_archive_id();
+    is( LANraragi::Plugin::Metadata::CopyArchiveTags::extract_archive_id("http://127.0.0.1:3000/reader?id=${archive_id}"),
+        $archive_id, 'reader URL - localhost' );
+
+    $archive_id = _random_archive_id();
+    is( LANraragi::Plugin::Metadata::CopyArchiveTags::extract_archive_id("http://127.0.0.1:3000/edit?id=${archive_id}"),
+        $archive_id, 'editor URL - localhost' );
+
+    $archive_id = _random_archive_id();
+    is( LANraragi::Plugin::Metadata::CopyArchiveTags::extract_archive_id("http://lanraragi.pizza/reader?id=${archive_id}"),
+        $archive_id, 'reader URL - hostname' );
+
+    $archive_id = _random_archive_id();
+    is( LANraragi::Plugin::Metadata::CopyArchiveTags::extract_archive_id("http://lanraragi.geek/edit?id=${archive_id}"),
+        $archive_id, 'editor URL - hostname' );
+
+}
+
+note('internal_get_tags dies when oneshot_param is undefined ...');
+{
+
+    my $log_mock = get_logger_mock();
+    my $params   = {
+        'oneshot'         => undef,
+        'copy_date_added' => undef,
+        'lrr_info'        => { 'archive_id' => 'dummy' }
+    };
+
+    # Act
+    trap { LANraragi::Plugin::Metadata::CopyArchiveTags::internal_get_tags( $log_mock, $params ); };
+
+    is( $trap->exit,   undef, 'no exit code' );
+    is( $trap->stdout, '',    'no STDOUT' );
+    is( $trap->stderr, '',    'no STDERR' );
+    like( $trap->die, qr/^oneshot_param doesn't contain a valid archive ID/, 'die message' );
+}
+
+note('internal_get_tags dies when oneshot_param is empty ...');
+{
+
+    my $log_mock = get_logger_mock();
+    my $params   = {
+        'oneshot'         => '',
+        'copy_date_added' => undef,
+        'lrr_info'        => { 'archive_id' => 'dummy' }
+    };
+
+    # Act
+    trap { LANraragi::Plugin::Metadata::CopyArchiveTags::internal_get_tags( $log_mock, $params ); };
+
+    is( $trap->exit,   undef, 'no exit code' );
+    is( $trap->stdout, '',    'no STDOUT' );
+    is( $trap->stderr, '',    'no STDERR' );
+    like( $trap->die, qr/^oneshot_param doesn't contain a valid archive ID/, 'die message' );
+}
+
+note('internal_get_tags dies when oneshot_param doesn\'t contain a valid archive ID ...');
+{
+
+    my $log_mock = get_logger_mock();
+    my $params   = {
+        'oneshot'         => 'xpto',
+        'copy_date_added' => undef,
+        'lrr_info'        => { 'archive_id' => 'dummy' }
+    };
+
+    # Act
+    trap { LANraragi::Plugin::Metadata::CopyArchiveTags::internal_get_tags( $log_mock, $params ); };
+
+    is( $trap->exit,   undef, 'no exit code' );
+    is( $trap->stdout, '',    'no STDOUT' );
+    is( $trap->stderr, '',    'no STDERR' );
+    like( $trap->die, qr/^oneshot_param doesn't contain a valid archive ID/, 'die message' );
+}
+
 note('internal_get_tags dies when search ID matches the current archive ID ...');
 {
 
@@ -99,77 +214,6 @@ note('internal_get_tags dies when search ID matches the current archive ID ...')
     like( $trap->die, qr/^You are using the current archive ID/, 'die message' );
 }
 
-note('internal_get_tags parses oneshot_param ...');
-{
-    my @log_messages;
-    my $log_mock = get_logger_mock( \@log_messages );
-    my $params   = { 'lrr_info' => { 'archive_id' => 'dummy' } };
-
-    no warnings 'once', 'redefine';
-    local *LANraragi::Plugin::Metadata::CopyArchiveTags::get_archive_tags = sub { return 'dummy'; };
-
-    # passing explicit ID
-    my $user_input_key = _random_archive_id();
-    $params->{'oneshot'} = $user_input_key;
-
-    LANraragi::Plugin::Metadata::CopyArchiveTags::internal_get_tags( $log_mock, $params );
-
-    cmp_deeply( \@log_messages, [ [ 'info', ignore, "Copying tags from archive \"$user_input_key\"" ] ], 'used explicit ID' );
-
-    ### passing localhost reader uri
-    @log_messages        = ();
-    $user_input_key      = _random_archive_id();
-    $params->{'oneshot'} = 'http://127.0.0.1:3000/reader?id=' . $user_input_key;
-
-    LANraragi::Plugin::Metadata::CopyArchiveTags::internal_get_tags( $log_mock, $params );
-
-    cmp_deeply(
-        \@log_messages,
-        [ [ 'info', ignore, "Copying tags from archive \"$user_input_key\"" ] ],
-        'extracted from localhost reader URI'
-    );
-
-    ### passing localhost edit uri
-    @log_messages        = ();
-    $user_input_key      = _random_archive_id();
-    $params->{'oneshot'} = 'http://127.0.0.1:3000/edit?id=' . $user_input_key;
-
-    LANraragi::Plugin::Metadata::CopyArchiveTags::internal_get_tags( $log_mock, $params );
-
-    cmp_deeply(
-        \@log_messages,
-        [ [ 'info', ignore, "Copying tags from archive \"$user_input_key\"" ] ],
-        'extracted from localhost edit URI'
-    );
-
-    ### passing remote reader uri
-    @log_messages        = ();
-    $user_input_key      = _random_archive_id();
-    $params->{'oneshot'} = 'http://lanraragi.pizza/reader?id=' . $user_input_key;
-
-    LANraragi::Plugin::Metadata::CopyArchiveTags::internal_get_tags( $log_mock, $params );
-
-    cmp_deeply(
-        \@log_messages,
-        [ [ 'info', ignore, "Copying tags from archive \"$user_input_key\"" ] ],
-        'extracted from remote reader URI'
-    );
-
-    ### passing remote edit uri
-    @log_messages        = ();
-    $user_input_key      = _random_archive_id();
-    $params->{'oneshot'} = 'http://lanraragi.geek/edit?id=' . $user_input_key;
-
-    LANraragi::Plugin::Metadata::CopyArchiveTags::internal_get_tags( $log_mock, $params );
-
-    cmp_deeply(
-        \@log_messages,
-        [ [ 'info', ignore, "Copying tags from archive \"$user_input_key\"" ] ],
-        'extracted from remote edit URI'
-    );
-
-}
-
 note('internal_get_tags does not return date_added by default ...');
 {
     my @log_messages;
@@ -179,12 +223,10 @@ note('internal_get_tags does not return date_added by default ...');
         'oneshot'  => $input_id,
         'lrr_info' => { 'archive_id' => _random_archive_id() }
     };
-    my @tags_ok = ( 'date_added:123', 'tag1', 'tag2' );
-    my $tags_ko = 'date_added:000,wrong1,wrong2';
 
     no warnings 'once', 'redefine';
-    local *LANraragi::Plugin::Metadata::CopyArchiveTags::get_archive_tags = sub {
-        return wantarray ? @tags_ok : $tags_ko;
+    local *LANraragi::Utils::Database::get_tags = sub {
+        return 'date_added:123,tag1,tag2';
     };
 
     # Act
@@ -205,12 +247,10 @@ note('internal_get_tags returns date_added if asked ...');
         'copy_date_added' => 1,
         'lrr_info'        => { 'archive_id' => _random_archive_id() }
     };
-    my @tags_ko = ( 'date_added:000', 'wrong3', 'wrong4' );
-    my $tags_ok = 'date_added:321,tag3,tag4';
 
     no warnings 'once', 'redefine';
-    local *LANraragi::Plugin::Metadata::CopyArchiveTags::get_archive_tags = sub {
-        return wantarray ? @tags_ko : $tags_ok;
+    local *LANraragi::Utils::Database::get_tags = sub {
+        return 'date_added:321,tag3,tag4';
     };
 
     # Act

--- a/tests/LANraragi/Plugin/Metadata/CopyArchiveTags.t
+++ b/tests/LANraragi/Plugin/Metadata/CopyArchiveTags.t
@@ -1,0 +1,224 @@
+use strict;
+use warnings;
+use utf8;
+use Data::Dumper;
+
+use Cwd qw( getcwd );
+
+use Test::More;
+use Test::Deep;
+use Test::Trap;
+
+my $cwd = getcwd();
+require "$cwd/tests/mocks.pl";
+
+use_ok('LANraragi::Plugin::Metadata::CopyArchiveTags');
+
+sub _random_archive_id {
+    my $rnd = '';
+    $rnd .= sprintf( "%x", rand 16 ) for 1 .. 40;
+    return $rnd;
+}
+
+note('testing that get_tags doesn\'t die ...');
+{
+
+    my $lrr_info = { 'oneshot_param' => _random_archive_id() };
+    my @log_messages;
+    my $log_mock = get_logger_mock( \@log_messages );
+
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::CopyArchiveTags::get_plugin_logger = sub { return $log_mock };
+    local *LANraragi::Plugin::Metadata::CopyArchiveTags::internal_get_tags = sub { die "Eep!\n"; };
+
+    # Act
+    my @error = LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, 'dummy', 0, 'dummy' );
+
+    cmp_deeply( \@error, [ 'error', "Eep!\n" ], 'returned error' );
+
+    cmp_deeply( \@log_messages, [ [ 'error', $log_mock, "Eep!\n" ] ], 'log messages' );
+
+}
+
+note('testing get_tags returning an empty tag list ...');
+{
+
+    my $lrr_info = { 'oneshot_param' => _random_archive_id() };
+    my @log_messages;
+
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::CopyArchiveTags::get_plugin_logger = sub { return get_logger_mock( \@log_messages ) };
+    local *LANraragi::Plugin::Metadata::CopyArchiveTags::internal_get_tags = sub { return (); };
+    local *LANraragi::Plugin::Metadata::CopyArchiveTags::read_params       = sub { return {}; };
+
+    # Act
+    my @rdata = LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, 'dummy', 0, 'dummy' );
+
+    cmp_deeply( \@rdata, [], 'returned data' );
+
+    cmp_deeply( \@log_messages, [ [ 'info', ignore, 'Sending the following tags to LRR: -' ] ], 'log messages' );
+
+}
+
+note('testing get_tags returning a list of tags ...');
+{
+
+    my $lrr_info = { 'oneshot_param' => _random_archive_id() };
+    my @log_messages;
+
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::CopyArchiveTags::get_plugin_logger = sub { return get_logger_mock( \@log_messages ) };
+    local *LANraragi::Plugin::Metadata::CopyArchiveTags::internal_get_tags = sub { return ( 'tags' => 'one, two' ); };
+    local *LANraragi::Plugin::Metadata::CopyArchiveTags::read_params       = sub { return {}; };
+
+    # Act
+    my @rdata = LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, 'dummy', 0, 'dummy' );
+
+    cmp_deeply( \@rdata, [ tags => 'one, two' ], 'returned data' );
+
+    cmp_deeply( \@log_messages, [ [ 'info', ignore, 'Sending the following tags to LRR: one, two' ] ], 'log messages' );
+}
+
+note('internal_get_tags dies when search ID matches the current archive ID ...');
+{
+
+    my $log_mock    = get_logger_mock();
+    my $the_only_id = _random_archive_id();
+    my $params      = {
+        'oneshot'         => $the_only_id,
+        'copy_date_added' => undef,
+        'lrr_info'        => { 'archive_id' => $the_only_id }
+    };
+
+    # Act
+    trap { LANraragi::Plugin::Metadata::CopyArchiveTags::internal_get_tags( $log_mock, $params ); };
+
+    is( $trap->exit,   undef, 'no exit code' );
+    is( $trap->stdout, '',    'no STDOUT' );
+    is( $trap->stderr, '',    'no STDERR' );
+    like( $trap->die, qr/^You are using the current archive ID/, 'die message' );
+}
+
+note('internal_get_tags parses oneshot_param ...');
+{
+    my @log_messages;
+    my $log_mock = get_logger_mock( \@log_messages );
+    my $params   = { 'lrr_info' => { 'archive_id' => 'dummy' } };
+
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::CopyArchiveTags::get_archive_tags = sub { return 'dummy'; };
+
+    # passing explicit ID
+    my $user_input_key = _random_archive_id();
+    $params->{'oneshot'} = $user_input_key;
+
+    LANraragi::Plugin::Metadata::CopyArchiveTags::internal_get_tags( $log_mock, $params );
+
+    cmp_deeply( \@log_messages, [ [ 'info', ignore, "Copying tags from archive \"$user_input_key\"" ] ], 'used explicit ID' );
+
+    ### passing localhost reader uri
+    @log_messages        = ();
+    $user_input_key      = _random_archive_id();
+    $params->{'oneshot'} = 'http://127.0.0.1:3000/reader?id=' . $user_input_key;
+
+    LANraragi::Plugin::Metadata::CopyArchiveTags::internal_get_tags( $log_mock, $params );
+
+    cmp_deeply(
+        \@log_messages,
+        [ [ 'info', ignore, "Copying tags from archive \"$user_input_key\"" ] ],
+        'extracted from localhost reader URI'
+    );
+
+    ### passing localhost edit uri
+    @log_messages        = ();
+    $user_input_key      = _random_archive_id();
+    $params->{'oneshot'} = 'http://127.0.0.1:3000/edit?id=' . $user_input_key;
+
+    LANraragi::Plugin::Metadata::CopyArchiveTags::internal_get_tags( $log_mock, $params );
+
+    cmp_deeply(
+        \@log_messages,
+        [ [ 'info', ignore, "Copying tags from archive \"$user_input_key\"" ] ],
+        'extracted from localhost edit URI'
+    );
+
+    ### passing remote reader uri
+    @log_messages        = ();
+    $user_input_key      = _random_archive_id();
+    $params->{'oneshot'} = 'http://lanraragi.pizza/reader?id=' . $user_input_key;
+
+    LANraragi::Plugin::Metadata::CopyArchiveTags::internal_get_tags( $log_mock, $params );
+
+    cmp_deeply(
+        \@log_messages,
+        [ [ 'info', ignore, "Copying tags from archive \"$user_input_key\"" ] ],
+        'extracted from remote reader URI'
+    );
+
+    ### passing remote edit uri
+    @log_messages        = ();
+    $user_input_key      = _random_archive_id();
+    $params->{'oneshot'} = 'http://lanraragi.geek/edit?id=' . $user_input_key;
+
+    LANraragi::Plugin::Metadata::CopyArchiveTags::internal_get_tags( $log_mock, $params );
+
+    cmp_deeply(
+        \@log_messages,
+        [ [ 'info', ignore, "Copying tags from archive \"$user_input_key\"" ] ],
+        'extracted from remote edit URI'
+    );
+
+}
+
+note('internal_get_tags does not return date_added by default ...');
+{
+    my @log_messages;
+    my $log_mock = get_logger_mock( \@log_messages );
+    my $input_id = _random_archive_id();
+    my $params   = {
+        'oneshot'  => $input_id,
+        'lrr_info' => { 'archive_id' => _random_archive_id() }
+    };
+    my @tags_ok = ( 'date_added:123', 'tag1', 'tag2' );
+    my $tags_ko = 'date_added:000,wrong1,wrong2';
+
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::CopyArchiveTags::get_archive_tags = sub {
+        return wantarray ? @tags_ok : $tags_ko;
+    };
+
+    # Act
+    my %data = LANraragi::Plugin::Metadata::CopyArchiveTags::internal_get_tags( $log_mock, $params );
+
+    cmp_deeply( \%data, { 'tags' => 'tag1,tag2' }, 'returned tags list' );
+
+    cmp_deeply( \@log_messages, [ [ 'info', ignore, "Copying tags from archive \"${input_id}\"" ] ], 'log messages' );
+}
+
+note('internal_get_tags returns date_added if asked ...');
+{
+    my @log_messages;
+    my $log_mock = get_logger_mock( \@log_messages );
+    my $input_id = _random_archive_id();
+    my $params   = {
+        'oneshot'         => $input_id,
+        'copy_date_added' => 1,
+        'lrr_info'        => { 'archive_id' => _random_archive_id() }
+    };
+    my @tags_ko = ( 'date_added:000', 'wrong3', 'wrong4' );
+    my $tags_ok = 'date_added:321,tag3,tag4';
+
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::CopyArchiveTags::get_archive_tags = sub {
+        return wantarray ? @tags_ko : $tags_ok;
+    };
+
+    # Act
+    my %data = LANraragi::Plugin::Metadata::CopyArchiveTags::internal_get_tags( $log_mock, $params );
+
+    cmp_deeply( \%data, { 'tags' => 'date_added:321,tag3,tag4' }, 'returned tags list' );
+
+    cmp_deeply( \@log_messages, [ [ 'info', ignore, "Copying tags from archive \"${input_id}\"" ] ], 'log messages' );
+}
+
+done_testing();

--- a/tests/mocks.pl
+++ b/tests/mocks.pl
@@ -307,8 +307,14 @@ sub setup_redis_mock {
 }
 
 sub get_logger_mock {
+    my ($args) = @_;
     my $mock = Test::MockObject->new();
-    $mock->mock( 'debug', sub { }, 'info', sub { }, 'trace', sub { } );
+    $mock->mock(
+        'error', sub { push( @{$args}, [ 'error', @_ ] ) if ($args); },
+        'info',  sub { push( @{$args}, [ 'info',  @_ ] ) if ($args); },
+        'debug', sub { push( @{$args}, [ 'debug', @_ ] ) if ($args); },
+        'trace', sub { push( @{$args}, [ 'trace', @_ ] ) if ($args); }
+    );
     return $mock;
 }
 

--- a/tests/modules.t
+++ b/tests/modules.t
@@ -43,7 +43,7 @@ my @modules = (
     "LANraragi::Plugin::Metadata::Hitomi",       "LANraragi::Plugin::Metadata::Hentag",
     "LANraragi::Plugin::Metadata::HentagOnline", "LANraragi::Plugin::Metadata::ComicInfo",
     "LANraragi::Plugin::Metadata::ChaikaFile",   "LANraragi::Plugin::Metadata::Ksk",
-    "LANraragi::Plugin::Metadata::HatH",
+    "LANraragi::Plugin::Metadata::HatH",         "LANraragi::Plugin::Metadata::CopyArchiveTags",
     "LANraragi::Plugin::Login::Pixiv",           "LANraragi::Plugin::Metadata::Pixiv",
 );
 


### PR DESCRIPTION
I took advantage of the issue #966 to try some suggestions like:
- exception handling for the plugins
- named parameters

They are implemented inside the plugin because I think they are too invasive to be put elsewhere at the moment.

Also I added a little helper method to retrieve the tags from an archive and I slightly reworked various `get_archive*` methods internally, but I couldn't come up with a better name for `h_get_archive` for the one that needs the Redis instance to be passed. 
