### PR TITLE
Add support for yet another version of info.yaml

### DIFF
--- a/lib/LANraragi/Plugin/Metadata/Ksk.pm
+++ b/lib/LANraragi/Plugin/Metadata/Ksk.pm
@@ -80,6 +80,19 @@ sub tags_from_ksk_yaml {
     handle_tag_yaml( "series:",   $parody,   \@found_tags );
     handle_tag_yaml( "magazine:", $magazine, \@found_tags );
 
+    # Koharu-version tags. Uses namespaces, and keys are lowercase
+    if (!defined($title)) {
+        $title = $hash->{"title"};
+    }
+    handle_tag_yaml( "",          $hash->{"general"},  \@found_tags );
+    handle_tag_yaml( "male:",     $hash->{"male"},     \@found_tags );
+    handle_tag_yaml( "female:",   $hash->{"female"},   \@found_tags );
+    handle_tag_yaml( "mixed:",    $hash->{"mixed"},    \@found_tags );
+    handle_tag_yaml( "other:",    $hash->{"other"},    \@found_tags );
+    handle_tag_yaml( "artist:",   $hash->{"artist"},   \@found_tags );
+    handle_tag_yaml( "language:", $hash->{"language"}, \@found_tags );
+    handle_tag_yaml( "source:",   $hash->{"source"},   \@found_tags );
+
     if ($assume_english) {
         push( @found_tags, "language:english" );
     }
@@ -104,7 +117,7 @@ sub handle_tag_yaml {
         foreach my $tag (@$yamldata) {
             push( @{ $_[2] }, "$namespace$tag" );
         }
-    } else {
+    } elsif ( defined($yamldata) ) {
         push( @{ $_[2] }, "$namespace$yamldata" );
     }
 

--- a/tests/LANraragi/Plugin/Metadata/Ksk.t
+++ b/tests/LANraragi/Plugin/Metadata/Ksk.t
@@ -72,4 +72,24 @@ note("test support for info.yaml");
     is( $ko_tags{title}, "My Immortal", "Loads data from info.yaml" );
 }
 
+note("test support for koharu info.yaml");
+{
+    my ( $fh, $filename ) = tempfile();
+    cp( $SAMPLES . "/ksk/fake_koharu.yaml", $fh );
+
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::Ksk::get_plugin_logger         = sub { return get_logger_mock(); };
+    local *LANraragi::Plugin::Metadata::Ksk::extract_file_from_archive = sub { $filename };
+    local *LANraragi::Plugin::Metadata::Ksk::is_file_in_archive        = sub { my $fn = $_[1]; return $fn eq "info.yaml"; };
+
+    my %dummyhash = ( file_path => "test" );
+
+    my %ko_tags = LANraragi::Plugin::Metadata::Ksk::get_tags( "", \%dummyhash, 0 );
+    is( $ko_tags{title}, "[Marcus Aurelius] Meditations", "Didn't handle title" );
+
+    my $expected_tags =
+        "first, second, third, male:emperor, male:philosopher, male:stoic, female:ass, female:titties, mixed:group, other:philosophy, artist:marcus aurelius, language:greek, source:SchaleNetwork:/g/1337/b00b1e5";
+    is( $ko_tags{tags}, $expected_tags, "Didn't handle tags" );
+}
+
 done_testing();

--- a/tests/samples/ksk/fake_koharu.yaml
+++ b/tests/samples/ksk/fake_koharu.yaml
@@ -1,0 +1,21 @@
+source: SchaleNetwork:/g/1337/b00b1e5
+title: '[Marcus Aurelius] Meditations'
+general:
+  - first
+  - second
+  - third
+artist:
+  - marcus aurelius
+male:
+  - emperor
+  - philosopher
+  - stoic
+female:
+  - ass
+  - titties
+mixed:
+  - group
+language:
+  - greek
+other:
+  - philosophy


### PR DESCRIPTION
New site has different data in the info.yaml file. This adds support for that, and fixes an issue where missing data in info.yaml could make tags ugly (empty namespaced tags, etc).