### PR TITLE
Avoid puking out warning when calling trim_crlf with undef

### DIFF
--- a/lib/LANraragi/Utils/String.pm
+++ b/lib/LANraragi/Utils/String.pm
@@ -41,8 +41,11 @@ sub trim ($s) {
 
 # Remove all newlines in a string
 sub trim_CRLF ($s) {
-    $s =~ s/\R//g;
-    return $s;
+    if (defined($s)) {
+        $s =~ s/\R//g;
+        return $s;
+    }
+    return;
 }
 
 # Fixes up a URL string for use in the DL system.

--- a/tests/LANraragi/Utils/String.t
+++ b/tests/LANraragi/Utils/String.t
@@ -49,5 +49,11 @@ note('testing string similarity detection...');
     is( LANraragi::Utils::String::most_similar( "orange", () ),                           undef, "Empty set" );
 }
 
+note('testing trim_crlf...');
+{
+    is( LANraragi::Utils::String::trim_CRLF( undef ), undef, "Undef should return undef");
+    is( LANraragi::Utils::String::trim_CRLF( "a\nb" ), "ab", "newline should go bye");
+}
+
 done_testing();
 


### PR DESCRIPTION
I got a bunch of `Use of uninitialized value $s in substitution (s///) at /home/koyomi/lanraragi/script/../lib/LANraragi/Utils/String.pm line 44.` in my logs, this should fix that.