### PR TITLE
Use string-based comparison (cmp) rather than numeric <=> for IDs

### DIFF
--- a/lib/LANraragi/Model/Tankoubon.pm
+++ b/lib/LANraragi/Model/Tankoubon.pm
@@ -131,7 +131,7 @@ sub get_tankoubon ( $tank_id, $fulldata = 0, $page = 0 ) {
     }
 
     # Sort and add IDs to archives array
-    foreach my $i ( sort { $tankoubon{$a} <=> $tankoubon{$b} } keys %tankoubon ) {
+    foreach my $i ( sort { $tankoubon{$a} cmp $tankoubon{$b} } keys %tankoubon ) {
         push( @archives, $i );
     }
 


### PR DESCRIPTION
IDs are strings, so should use cmp instead of spaceship operator (caused a warning).