### PR TITLE
Avoid ARRAY garbage tags for unexpected koromo info.json files

### DIFF
--- a/lib/LANraragi/Plugin/Metadata/Koromo.pm
+++ b/lib/LANraragi/Plugin/Metadata/Koromo.pm
@@ -110,47 +110,37 @@ sub tags_from_koromo_json {
     my $type       = $hash->{"Types"};
     my $url        = $hash->{"URL"};
 
-    foreach my $tag (@$tags) {
-        push( @found_tags, $tag );
-    }
+    handle_tag_yaml("", $tags, \@found_tags);
+    handle_tag_yaml("character:", $characters, \@found_tags);
+    handle_tag_yaml("series:", $series, \@found_tags);
+    handle_tag_yaml("group:", $groups);
+    handle_tag_yaml("artist:", $artists, \@found_tags);
 
-    foreach my $tag (@$characters) {
-        push( @found_tags, "character:" . $tag );
-    }
-
-    foreach my $tag (@$series) {
-        push( @found_tags, "series:" . $tag );
-    }
-
-    foreach my $tag (@$groups) {
-        push( @found_tags, "group:" . $tag );
-    }
-
-    foreach my $tag (@$artists) {
-        push( @found_tags, "artist:" . $tag );
-    }
-
-    push( @found_tags, "series:" . $parody ) unless !$parody;
-
-    # Don't add bogus artist:ARRAYblabla if artist is an array
-    if ($artist) {
-        if ( ref $artist eq 'ARRAY' ) {
-            foreach my $tag (@$artist) {
-                push( @found_tags, "artist:" . $tag );
-            }
-        } else {
-            push( @found_tags, "artist:" . $artist ) unless !$artist;
-        }
-    }
-
-    push( @found_tags, "magazine:" . $magazine ) unless !$magazine;
-    push( @found_tags, "language:" . $language ) unless !$language;
-    push( @found_tags, "category:" . $type )     unless !$type;
-    push( @found_tags, "source:" . $url )        unless !$url;
+    handle_tag_yaml("series:", $parody, \@found_tags);
+    handle_tag_yaml("artist:", $artist, \@found_tags);
+    handle_tag_yaml("magazine:", $magazine, \@found_tags );
+    handle_tag_yaml("language:", $language, \@found_tags );
+    handle_tag_yaml("category:", $type, \@found_tags );
+    handle_tag_yaml("source:", $url, \@found_tags );
 
     #Done-o
     my $concat_tags = join( ", ", @found_tags );
     return ( $concat_tags, $title );
+
+}
+
+sub handle_tag_yaml {
+    my $namespace = $_[0];
+    my $yamldata  = $_[1];
+
+    # Check if array or string, don't iterate if string
+    if ( ref $yamldata eq 'ARRAY' ) {
+        foreach my $tag (@$yamldata) {
+            push( @{ $_[2] }, "$namespace$tag" );
+        }
+    } elsif ( defined($yamldata) ) {
+        push( @{ $_[2] }, "$namespace$yamldata" );
+    }
 
 }
 

--- a/tests/LANraragi/Plugin/Metadata/Koromo.t
+++ b/tests/LANraragi/Plugin/Metadata/Koromo.t
@@ -68,4 +68,27 @@ note("multiple artists json");
     is( $ko_tags{tags},  $expected_tags, "Koromo parsing test 2/2" );
 }
 
+note("multiple magazines");
+{
+    # Copy the koromo sample json to a temporary directory as it's deleted once parsed
+    my ( $fh, $filename ) = tempfile();
+    cp( $SAMPLES . "/koromo/koromo_multimag.json", $fh );
+
+    # Mock LANraragi::Utils::Archive's subs to return the temporary sample JSON
+    # Since we're using exports, the methods are under the plugin's namespace.
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::Koromo::get_plugin_logger         = sub { return get_logger_mock(); };
+    local *LANraragi::Plugin::Metadata::Koromo::extract_file_from_archive = sub { $filename };
+    local *LANraragi::Plugin::Metadata::Koromo::is_file_in_archive        = sub { 1 };
+
+    my %dummyhash = ( something => 22, file_path => "test" );
+
+    # Since this is calling the sub directly and not in an object context,
+    # we pass a dummy string as first parameter to replace the object.
+    my %ko_tags = trap { LANraragi::Plugin::Metadata::Koromo::get_tags( "", \%dummyhash, 1 ); };
+
+    my $expected_tags = "magazine:Comic Koromo #1, magazine:Comic Koromo #2";
+    is( $ko_tags{tags}, $expected_tags, "Handle magazine being an array" );
+}
+
 done_testing();

--- a/tests/samples/koromo/koromo_multimag.json
+++ b/tests/samples/koromo/koromo_multimag.json
@@ -1,0 +1,6 @@
+{
+    "Magazine": [
+        "Comic Koromo #1",
+        "Comic Koromo #2"
+    ]
+}


### PR DESCRIPTION
Encountered koromo'ish info.json files with multiple magazines, which caused good ol' `magazine:ARRAY(0xbadb00b13)` tags. This PR fixes that, and ensures the same shit doesn't happen to other tags.