### PR TITLE
Add base URL feature

### DIFF
--- a/lib/LANraragi.pm
+++ b/lib/LANraragi.pm
@@ -196,6 +196,9 @@ sub startup {
                     $c->req->url->base->path($prefix);
                 }
             }
+            # SameSite=Lax is the default behavior here; I set it
+            # explicitly to get rid of a warning in the browser
+            $c->cookie("lrr_baseurl" => $prefix, { samesite => "lax" });
         }
     );
 

--- a/lib/LANraragi.pm
+++ b/lib/LANraragi.pm
@@ -191,6 +191,8 @@ sub startup {
             if ($prefix) {
                 if (!$prefix =~ m|^/[^"]*[^/"]$|) {
                     say "Warning: configured URL prefix '$prefix' invalid, ignoring";
+                    # if prefix is invalid, then set it to empty for the cookie
+                    $prefix = "";
                 }
                 else {
                     $c->req->url->base->path($prefix);

--- a/lib/LANraragi.pm
+++ b/lib/LANraragi.pm
@@ -187,7 +187,7 @@ sub startup {
             my $c = shift;
             state $unused = add_sigint_handler();
 
-            my $prefix = $self->LRR_CONF->get_baseurl;
+            my $prefix = $self->LRR_BASEURL;
             if ($prefix) {
                 if (!$prefix =~ m|^/[^"]*[^/"]$|) {
                     say "Warning: configured URL prefix '$prefix' invalid, ignoring";

--- a/lib/LANraragi.pm
+++ b/lib/LANraragi.pm
@@ -179,7 +179,18 @@ sub startup {
     # (https://stackoverflow.com/questions/60814220/how-to-manage-myself-sigint-and-sigterm-signals)
     $self->hook(
         before_dispatch => sub {
+            my $c = shift;
             state $unused = add_sigint_handler();
+
+            my $prefix = $self->LRR_CONF->get_baseurl;
+            if ($prefix) {
+                if (!$prefix =~ m|^/.*[^/]$|) {
+                    say "Warning: configured URL prefix '$prefix' invalid, ignoring";
+                }
+                else {
+                    $c->req->url->base->path($prefix);
+                }
+            }
         }
     );
 

--- a/lib/LANraragi.pm
+++ b/lib/LANraragi.pm
@@ -72,6 +72,11 @@ sub startup {
         }
     );
 
+    # for some reason I can't call the one under LRR_CONF from the
+    # templates, so create a separate helper here
+    my $prefix = $self->LRR_CONF->get_baseurl();
+    $self->helper( LRR_BASEURL => sub { return $prefix } );
+
     #Check if a Redis server is running on the provided address/port
     eval { $self->LRR_CONF->get_redis->ping(); };
     if ($@) {
@@ -184,7 +189,7 @@ sub startup {
 
             my $prefix = $self->LRR_CONF->get_baseurl;
             if ($prefix) {
-                if (!$prefix =~ m|^/.*[^/]$|) {
+                if (!$prefix =~ m|^/[^"]*[^/"]$|) {
                     say "Warning: configured URL prefix '$prefix' invalid, ignoring";
                 }
                 else {

--- a/lib/LANraragi/Model/Config.pm
+++ b/lib/LANraragi/Model/Config.pm
@@ -41,6 +41,9 @@ sub get_configdb { return $config->{redis_database_config} }
 # Database used to store search index and cache
 sub get_searchdb { return $config->{redis_database_search} }
 
+# Base URL for deployment under a path prefix
+sub get_baseurl { return "$config->{base_url_path}" }
+
 # Create a Minion object connected to the Minion database.
 sub get_minion {
     my $miniondb = get_redisad . "/" . get_miniondb;

--- a/lib/LANraragi/Model/Reader.pm
+++ b/lib/LANraragi/Model/Reader.pm
@@ -92,7 +92,7 @@ sub build_reader_JSON {
         $imgpath =~ s!%2F!/!g;
 
         # Bundle this path into an API call which will be used by the browser
-        push @images_browser, "./api/archives/$id/page?path=$imgpath";
+        push @images_browser, $self->url_for("/api/archives/$id/page?path=$imgpath")->path_query;
     }
 
     # Update pagecount and sizes

--- a/lib/LANraragi/Utils/Generic.pm
+++ b/lib/LANraragi/Utils/Generic.pm
@@ -196,16 +196,17 @@ sub generate_themes_header {
 
         my $css_file = $css[$i];
         my ( $css_name, $css_color ) = css_default_data($css_file);
+        my $css_url = $self->url_for("/themes/$css_file?$version");
 
         # If this is the default sheet, set it up as so.
         if ( $css[$i] eq LANraragi::Model::Config->get_style ) {
 
-            $html .= qq(<link rel="stylesheet" type="text/css" title="$css_name" href="/themes/$css_file?$version">);
+            $html .= qq(<link rel="stylesheet" type="text/css" title="$css_name" href="$css_url">);
 
             # Add the main color as a them-color meta tag
             $html .= qq(<meta name="theme-color" content="$css_color">);
         } else {
-            $html .= qq(<link rel="alternate stylesheet" type="text/css" title="$css_name" href="/themes/$css_file?$version">);
+            $html .= qq(<link rel="alternate stylesheet" type="text/css" title="$css_name" href="$css_url">);
         }
     }
 

--- a/lrr.conf
+++ b/lrr.conf
@@ -5,4 +5,5 @@
   redis_database_minion => "1",
   redis_database_config => "2",
   redis_database_search => "3",
+  base_url_path => "",
 }

--- a/public/js/backup.js
+++ b/public/js/backup.js
@@ -5,7 +5,7 @@ const Backup = {};
 
 Backup.initializeAll = function () {
     // bind events to DOM
-    $(document).on("click.return", "#return", () => { window.location.href = "/"; });
+    $(document).on("click.return", "#return", () => { window.location.href = new LRR.apiURL("/"); });
     $(document).on("click.do-backup", "#do-backup", () => { window.open("./backup?dobackup=1", "_blank"); });
 
     // Handler for file uploading.

--- a/public/js/batch.js
+++ b/public/js/batch.js
@@ -18,8 +18,8 @@ Batch.initializeAll = function () {
     $(document).on("click.start-batch", "#start-batch", Batch.startBatchCheck);
     $(document).on("click.restart-job", "#restart-job", Batch.restartBatchUI);
     $(document).on("click.cancel-job", "#cancel-job", Batch.cancelBatch);
-    $(document).on("click.server-config", "#server-config", () => LRR.openInNewTab("./config"));
-    $(document).on("click.plugin-config", "#plugin-config", () => LRR.openInNewTab("./config/plugins"));
+    $(document).on("click.server-config", "#server-config", () => LRR.openInNewTab(new LRR.apiURL("/config")));
+    $(document).on("click.plugin-config", "#plugin-config", () => LRR.openInNewTab(new LRR.apiURL("/config/plugins")));
     $(document).on("click.return", "#return", () => { window.location.href = new LRR.apiURL("/"); });
 
     Batch.selectOperation();

--- a/public/js/batch.js
+++ b/public/js/batch.js
@@ -20,7 +20,7 @@ Batch.initializeAll = function () {
     $(document).on("click.cancel-job", "#cancel-job", Batch.cancelBatch);
     $(document).on("click.server-config", "#server-config", () => LRR.openInNewTab("./config"));
     $(document).on("click.plugin-config", "#plugin-config", () => LRR.openInNewTab("./config/plugins"));
-    $(document).on("click.return", "#return", () => { window.location.href = "/"; });
+    $(document).on("click.return", "#return", () => { window.location.href = new LRR.apiURL("/"); });
 
     Batch.selectOperation();
     Batch.showOverride();
@@ -75,7 +75,7 @@ Batch.showOverride = function () {
  * Check untagged archives, using the matching API endpoint.
  */
 Batch.checkUntagged = function () {
-    Server.callAPI("api/archives/untagged", "GET", null, "Error getting untagged archives!",
+    Server.callAPI("/api/archives/untagged", "GET", null, "Error getting untagged archives!",
         (data) => {
             // Check untagged archives
             data.forEach((id) => {
@@ -292,7 +292,7 @@ Batch.endBatch = function (event) {
     });
 
     // Delete the search cache after a finished session
-    Server.callAPI("api/search/cache", "DELETE", null, "Error while deleting cache! Check Logs.", null);
+    Server.callAPI("/api/search/cache", "DELETE", null, "Error while deleting cache! Check Logs.", null);
 
     $("#cancel-job").hide();
 

--- a/public/js/batch.js
+++ b/public/js/batch.js
@@ -167,7 +167,8 @@ Batch.startBatch = function () {
 
     let wsProto = "ws://";
     if (document.location.protocol === "https:") wsProto = "wss://";
-    Batch.socket = new WebSocket(`${wsProto + window.location.host}/batch/socket`);
+    let socket_path = new LRR.apiURL("/batch/socket");
+    Batch.socket = new WebSocket(`${wsProto + window.location.host}${socket_path}`);
 
     Batch.socket.onopen = function () {
         const command = commandBase;

--- a/public/js/category.js
+++ b/public/js/category.js
@@ -15,7 +15,7 @@ Category.initializeAll = function () {
     $(document).on("click.new-dynamic", "#new-dynamic", () => Category.addNewCategory(true));
     $(document).on("click.predicate-help", "#predicate-help", Category.predicateHelp);
     $(document).on("click.delete", "#delete", Category.deleteSelectedCategory);
-    $(document).on("click.return", "#return", () => { window.location.href = "/"; });
+    $(document).on("click.return", "#return", () => { window.location.href = new LRR.apiURL("/"); });
 
     Category.loadCategories();
 };
@@ -53,7 +53,7 @@ Category.addNewCategory = function (isDynamic) {
 };
 
 Category.loadCategories = function (selectedID) {
-    fetch("/api/categories")
+    fetch(new LRR.apiURL("/api/categories"))
         .then((response) => response.json())
         .then((data) => {
             // Save data clientside for reference in later functions

--- a/public/js/common.js
+++ b/public/js/common.js
@@ -251,7 +251,7 @@ LRR.buildThumbnailDiv = function (data, tagTooltip = true) {
     const thumbCss = (localStorage.cropthumbs === "true") ? "id3" : "id3 nocrop";
     // The ID can be in a different field depending on the archive object...
     const id = data.arcid || data.id;
-    let reader_url = new LRR.apiURL(`reader?id=${id}`);
+    let reader_url = new LRR.apiURL(`/reader?id=${id}`);
 
     return `<div class="id1 context-menu swiper-slide" id="${id}">
                 <div class="id2">

--- a/public/js/common.js
+++ b/public/js/common.js
@@ -3,6 +3,16 @@
  */
 const LRR = {};
 
+function _get_baseurl_cookie() {
+    let cookies = document.cookie;
+    val = cookies.split('; ').find((r) => r.startsWith("lrr_baseurl="))?.split("=")[1];
+    if (val === undefined) {
+        console.warn("lrr_baseurl cookie undefined, must be set by backend");
+        val = "";
+    }
+    return val;
+}
+
 // This class is used to wrap URLs that point into the app, including
 // API endpoints and browser targets. It reads the configured base URL
 // from the template, then prepends it to the provided URL in the
@@ -13,6 +23,8 @@ const LRR = {};
 // URL, and can be wrapped around another instance of itself without a
 // change.
 LRR.apiURL = class {
+    static base_url = _get_baseurl_cookie();
+
     constructor(load_url) {
         // accept instances of self as well, to make wrapping
         // idempotent
@@ -29,12 +41,7 @@ LRR.apiURL = class {
     toString() {
         // in the default case, this will be empty string and will
         // leave the load URL unchanged
-        let base_url = window.LRR_BASEURL;
-        if (base_url === undefined) {
-            console.trace("LRR_BASEURL undefined, template must set this variable");
-            base_url = "";
-        }
-        return base_url + this.load_url;
+        return LRR.apiURL.base_url + this.load_url;
     }
 };
 

--- a/public/js/common.js
+++ b/public/js/common.js
@@ -3,6 +3,41 @@
  */
 const LRR = {};
 
+// This class is used to wrap URLs that point into the app, including
+// API endpoints and browser targets. It reads the configured base URL
+// from the template, then prepends it to the provided URL in the
+// toString() method.
+
+// Every operation involving an app-internal URL should be wrapped in
+// this class before use. It can be passed to any API that expects a
+// URL, and can be wrapped around another instance of itself without a
+// change.
+LRR.apiURL = class {
+    constructor(load_url) {
+        // accept instances of self as well, to make wrapping
+        // idempotent
+        if (load_url instanceof LRR.apiURL) {
+            load_url = load_url.load_url;
+        }
+        this.load_url = load_url;
+        if (!this.load_url.startsWith("/")) {
+            console.trace("passed non-absolute URL to apiURL");
+            this.load_url = "/" + this.load_url;
+        }
+    }
+
+    toString() {
+        // in the default case, this will be empty string and will
+        // leave the load URL unchanged
+        let base_url = window.LRR_BASEURL;
+        if (base_url === undefined) {
+            console.trace("LRR_BASEURL undefined, template must set this variable");
+            base_url = "";
+        }
+        return base_url + this.load_url;
+    }
+};
+
 /**
  * Quick HTML encoding function.
  * @param {*} r The HTML to encode
@@ -51,7 +86,7 @@ LRR.isNullOrWhitespace = function (input) {
 LRR.getTagSearchURL = function (namespace, tag) {
     const namespacedTag = this.buildNamespacedTag(namespace, tag);
     if (namespace !== "source") {
-        return `/?q=${encodeURIComponent(namespacedTag)}`;
+        return new LRR.apiURL(`/?q=${encodeURIComponent(namespacedTag)}`);
     } else if (/https?:\/\//.test(tag)) {
         return `${tag}`;
     } else {
@@ -216,19 +251,20 @@ LRR.buildThumbnailDiv = function (data, tagTooltip = true) {
     const thumbCss = (localStorage.cropthumbs === "true") ? "id3" : "id3 nocrop";
     // The ID can be in a different field depending on the archive object...
     const id = data.arcid || data.id;
+    let reader_url = new LRR.apiURL(`reader?id=${id}`);
 
     return `<div class="id1 context-menu swiper-slide" id="${id}">
                 <div class="id2">
                     ${LRR.buildProgressDiv(data)}
-                    <a href="reader?id=${id}" title="${LRR.encodeHTML(data.title)}">${LRR.encodeHTML(data.title)}</a>
+                    <a href="${reader_url}" title="${LRR.encodeHTML(data.title)}">${LRR.encodeHTML(data.title)}</a>
                 </div>
                 <div class="${thumbCss}">
-                    <a href="reader?id=${id}" title="${LRR.encodeHTML(data.title)}">
-                        <img style="position:relative;" id="${id}_thumb" src="./img/wait_warmly.jpg"/>
+                    <a href="${reader_url}" title="${LRR.encodeHTML(data.title)}">
+                        <img style="position:relative;" id="${id}_thumb" src="${new LRR.apiURL('/img/wait_warmly.jpg')}"/>
                         <i id="${id}_spinner" class="fa fa-4x fa-cog fa-spin ttspinner"></i>
-                        <img src="./api/archives/${id}/thumbnail" 
+                        <img src="${new LRR.apiURL(`/api/archives/${id}/thumbnail`)}" 
                                 onload="$('#${id}_thumb').remove(); $('#${id}_spinner').remove();" 
-                                onerror="this.src='./img/noThumb.png'"/>
+                                onerror="this.src='${new LRR.apiURL("/img/noThumb.png")}'"/>
                     </a>
                 </div>
                 <div class="id4">

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -22,7 +22,7 @@ Config.initializeAll = function () {
     $(document).on("click.drop-db", "#drop-db", Server.dropDatabase);
 
     $(document).on("click.restart-button", "#restart-button", Config.rebootShinobu);
-    $(document).on("click.open-minion", "#open-minion", () => LRR.openInNewTab("/minion"));
+    $(document).on("click.open-minion", "#open-minion", () => LRR.openInNewTab(new LRR.apiURL("/minion")));
 
     $(document).on("click.genthumb-button", "#genthumb-button", () => Server.regenerateThumbnails(false));
     $(document).on("click.forcethumb-button", "#forcethumb-button", () => Server.regenerateThumbnails(true));

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -6,9 +6,9 @@ const Config = {};
 Config.initializeAll = function () {
     // bind events to DOM
     $(document).on("click.save", "#save", () => { Server.saveFormData("#editConfigForm"); });
-    $(document).on("click.plugin-config", "#plugin-config", () => { window.location.href = "/config/plugins"; });
-    $(document).on("click.backup", "#backup", () => { window.location.href = "/backup"; });
-    $(document).on("click.return", "#return", () => { window.location.href = "/"; });
+    $(document).on("click.plugin-config", "#plugin-config", () => { window.location.href = new LRR.apiURL("/config/plugins"); });
+    $(document).on("click.backup", "#backup", () => { window.location.href = new LRR.apiURL("/backup"); });
+    $(document).on("click.return", "#return", () => { window.location.href = new LRR.apiURL("/"); });
     $(document).on("click.enablepass", "#enablepass", Config.enable_pass);
     $(document).on("click.enableresize", "#enableresize", Config.enable_resize);
     $(document).on("click.usedateadded", "#usedateadded", Config.enable_timemodified);

--- a/public/js/edit.js
+++ b/public/js/edit.js
@@ -15,7 +15,7 @@ Edit.initializeAll = function () {
     $(document).on("click.save-metadata", "#save-metadata", Edit.saveMetadata);
     $(document).on("click.delete-archive", "#delete-archive", Edit.deleteArchive);
     $(document).on("click.tagger", ".tagger", Edit.focusTagInput);
-    $(document).on("click.goback", "#goback", () => { window.location.href = "/"; });
+    $(document).on("click.goback", "#goback", () => { window.location.href = new LRR.apiURL("/"); });
     $(document).on("paste.tagger", ".tagger-new", Edit.handlePaste);
 
     Edit.updateOneShotArg();
@@ -123,7 +123,7 @@ Edit.saveMetadata = function () {
     formData.append("title", $("#title").val());
     formData.append("summary", $("#summary").val());
 
-    return fetch(`api/archives/${id}/metadata`, { method: "PUT", body: formData })
+    return fetch(new LRR.apiURL(`/api/archives/${id}/metadata`), { method: "PUT", body: formData })
         .then((response) => (response.ok ? response.json() : { success: 0, error: "Response was not OK" }))
         .then((data) => {
             if (data.success) {
@@ -163,7 +163,7 @@ Edit.getTags = function () {
     const pluginID = $("select#plugin option:checked").val();
     const archivID = $("#archiveID").val();
     const pluginArg = $("#arg").val();
-    Server.callAPI(`../api/plugins/use?plugin=${pluginID}&id=${archivID}&arg=${pluginArg}`, "POST", null, "Error while fetching tags :",
+    Server.callAPI(`/api/plugins/use?plugin=${pluginID}&id=${archivID}&arg=${pluginArg}`, "POST", null, "Error while fetching tags :",
         (result) => {
             if (result.data.title && result.data.title !== "") {
                 $("#title").val(result.data.title);

--- a/public/js/edit.js
+++ b/public/js/edit.js
@@ -47,7 +47,7 @@ Edit.initializeAll = function () {
                     completion: {
                         list: Edit.suggestions,
                     },
-                    link: (name) => `/?q=${name}`,
+                    link: (name) => new LRR.apiURL(`/?q=${name}`),
                 });
             }
         });

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -533,7 +533,7 @@ Index.loadContextMenuCategories = (catList, id) => Server.callAPI(`/api/archives
 Index.handleContextMenu = function (option, id) {
     switch (option) {
     case "edit":
-        LRR.openInNewTab(`./edit?id=${id}`);
+        LRR.openInNewTab(new LRR.apiURL(`/edit?id=${id}`));
         break;
     case "delete":
         LRR.showPopUp({
@@ -551,10 +551,10 @@ Index.handleContextMenu = function (option, id) {
         });
         break;
     case "read":
-        LRR.openInNewTab(new LRR.apiURL(`/reader?id=${id}`).toString());
+        LRR.openInNewTab(new LRR.apiURL(`/reader?id=${id}`));
         break;
     case "download":
-        LRR.openInNewTab(new LRR.apiURL(`/api/archives/${id}/download`).toString());
+        LRR.openInNewTab(new LRR.apiURL(`/api/archives/${id}/download`));
         break;
     default:
         break;

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -109,7 +109,7 @@ Index.initializeAll = function () {
             } else {
                 LRR.toast({
                     heading: "<i class=\"fas fa-bug\"></i> You're running in Debug Mode!",
-                    text: "Advanced server statistics can be viewed <a href=\"./debug\">here.</a>",
+                    text: `Advanced server statistics can be viewed <a href="${new LRR.apiURL("/debug")}">here.</a>`,
                     icon: "warning",
                 });
             }
@@ -551,10 +551,10 @@ Index.handleContextMenu = function (option, id) {
         });
         break;
     case "read":
-        LRR.openInNewTab(`./reader?id=${id}`);
+        LRR.openInNewTab(new LRR.apiURL(`/reader?id=${id}`).toString());
         break;
     case "download":
-        LRR.openInNewTab(`./api/archives/${id}/download`);
+        LRR.openInNewTab(new LRR.apiURL(`/api/archives/${id}/download`).toString());
         break;
     default:
         break;
@@ -680,7 +680,7 @@ Index.migrateProgress = function () {
         localProgressKeys.forEach((id) => {
             const progress = localStorage.getItem(`${id}-reader`);
 
-            promises.push(fetch(`api/archives/${id}/metadata`, { method: "GET" })
+            promises.push(fetch(new LRR.apiURL(`api/archives/${id}/metadata`), { method: "GET" })
                 .then((response) => response.json())
                 .then((data) => {
                     // Don't migrate if the server progress is already further

--- a/public/js/index_datatables.js
+++ b/public/js/index_datatables.js
@@ -61,7 +61,7 @@ IndexTable.initializeAll = function () {
         dom: "<\"top\"ip>rt<\"bottom\"p><\"clear\">",
         language: {
             info: "Showing _START_ to _END_ of _TOTAL_ ancient chinese lithographies.",
-            infoEmpty: "<h1><br/><i class=\"fas fa-4x fa-toilet-paper-slash\"></i><br/><br/>No archives to show you! Try <a href=\"upload\">uploading some</a>?</h1><br/>",
+            infoEmpty: `<h1><br/><i class=\"fas fa-4x fa-toilet-paper-slash\"></i><br/><br/>No archives to show you! Try <a href="${new LRR.apiURL("/upload")}">uploading some</a>?</h1><br/>`,
             processing: "<div id=\"progress\" class=\"indeterminate\"\"><div class=\"bar-container\"><div class=\"bar\" style=\" width: 80%; \"></div></div></div>",
         },
         preDrawCallback: IndexTable.initializeThumbView, // callbacks for thumbnail view
@@ -158,11 +158,11 @@ IndexTable.renderColumn = function (namespace, type, data) {
 IndexTable.renderTitle = function (data, type) {
     if (type === "display") {
         return `${LRR.buildProgressDiv(data)} 
-                <a class="context-menu" id="${data.arcid}" onmouseover="IndexTable.buildImageTooltip(this)" href="reader?id=${data.arcid}"> 
+                <a class="context-menu" id="${data.arcid}" onmouseover="IndexTable.buildImageTooltip(this)" href="${new LRR.apiURL(`reader?id=${data.arcid}`)}"> 
                     ${LRR.encodeHTML(data.title)}
                 </a>
                 <div class="caption" style="display: none;">
-                    <img style="height:300px" src="./api/archives/${data.arcid}/thumbnail" onerror="this.src='./img/noThumb.png'">
+                    <img style="height:300px" src="${new LRR.apiURL(`/api/archives/${data.arcid}/thumbnail`)}" onerror="this.src='${new LRR.apiURL('/img/noThumb.png')}'">
                 </div>`;
     }
 

--- a/public/js/index_datatables.js
+++ b/public/js/index_datatables.js
@@ -158,7 +158,7 @@ IndexTable.renderColumn = function (namespace, type, data) {
 IndexTable.renderTitle = function (data, type) {
     if (type === "display") {
         return `${LRR.buildProgressDiv(data)} 
-                <a class="context-menu" id="${data.arcid}" onmouseover="IndexTable.buildImageTooltip(this)" href="${new LRR.apiURL(`reader?id=${data.arcid}`)}"> 
+                <a class="context-menu" id="${data.arcid}" onmouseover="IndexTable.buildImageTooltip(this)" href="${new LRR.apiURL(`/reader?id=${data.arcid}`)}"> 
                     ${LRR.encodeHTML(data.title)}
                 </a>
                 <div class="caption" style="display: none;">

--- a/public/js/logs.js
+++ b/public/js/logs.js
@@ -14,7 +14,7 @@ Logs.initializeAll = function () {
     $(document).on("click.show-plugins", "#show-plugins", () => Logs.showLog("plugins"));
     $(document).on("click.show-mojo", "#show-mojo", () => Logs.showLog("mojo"));
     $(document).on("click.show-redis", "#show-redis", () => Logs.showLog("redis"));
-    $(document).on("click.return", "#return", () => { window.location.href = "/"; });
+    $(document).on("click.return", "#return", () => { window.location.href = new LRR.apiURL("/"); });
 
     Logs.showLog("general");
 };

--- a/public/js/plugins.js
+++ b/public/js/plugins.js
@@ -6,7 +6,7 @@ const Plugins = {};
 Plugins.initializeAll = function () {
     // bind events to DOM
     $(document).on("click.save", "#save", () => Server.saveFormData("#editPluginForm"));
-    $(document).on("click.return", "#return", () => { window.location.href = "/"; });
+    $(document).on("click.return", "#return", () => { window.location.href = new LRR.apiURL("/"); });
 
     // Handler for file uploading.
     $("#fileupload").fileupload({

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -40,7 +40,7 @@ Reader.initializeAll = function () {
     $(document).on("click.toggle-settings-overlay", "#toggle-settings-overlay", Reader.toggleSettingsOverlay);
     $(document).on("click.toggle-help", "#toggle-help", Reader.toggleHelp);
     $(document).on("click.regenerate-archive-cache", "#regenerate-cache", () => {
-        window.location.href = `./reader?id=${Reader.id}&force_reload`;
+        window.location.href = new LRR.apiURL(`/reader?id=${Reader.id}&force_reload`);
     });
     $(document).on("click.edit-metadata", "#edit-archive", () => LRR.openInNewTab(`./edit?id=${Reader.id}`));
     $(document).on("click.delete-archive", "#delete-archive", () => {
@@ -62,9 +62,10 @@ Reader.initializeAll = function () {
     $(document).on("click.add-category", "#add-category", () => {
         if ($("#category").val() === "" || $(`#archive-categories a[data-id="${$("#category").val()}"]`).length !== 0) { return; }
         Server.addArchiveToCategory(Reader.id, $("#category").val());
-
+        let url = new LRR.apiURL(`/?c=${$("#category").val()}`);
+        
         const html = `<div class="gt" style="font-size:14px; padding:4px">
-            <a href="/?c=${$("#category").val()}">
+            <a href="${url}">
             <span class="label">${$("#category option:selected").text()}</span>
             <a href="#" class="remove-category" data-id="${$("#category").val()}"
                 style="margin-left:4px; margin-right:2px">×</a>
@@ -190,7 +191,7 @@ Reader.loadImages = function () {
         },
     ).finally(() => {
         if (Reader.pages === undefined) {
-            $("#img").attr("src", "img/flubbed.gif");
+            $("#img").attr("src", new LRR.apiURL("/img/flubbed.gif").toString());
             $("#display").append("<h2>I flubbed it while trying to open the archive.</h2>");
         }
     });
@@ -352,7 +353,7 @@ Reader.handleShortcuts = function (e) {
         break;
     case 82: // r
         if (e.ctrlKey || e.shiftKey || e.metaKey) { break; }
-        document.location.href = "/random";
+        document.location.href = new LRR.apiURL("/random");
         break;
     default:
         break;
@@ -524,7 +525,7 @@ Reader.updateProgress = function () {
     if (Reader.trackProgressLocally) {
         localStorage.setItem(`${Reader.id}-reader`, Reader.currentPage + 1);
     } else {
-        Server.callAPI(`api/archives/${Reader.id}/progress/${Reader.currentPage + 1}`, "PUT", null, "Error updating reading progress!", null);
+        Server.callAPI(`/api/archives/${Reader.id}/progress/${Reader.currentPage + 1}`, "PUT", null, "Error updating reading progress!", null);
     }
 };
 
@@ -716,7 +717,7 @@ Reader.initializeArchiveOverlay = function () {
         const page = index + 1;
 
         const thumbCss = (localStorage.cropthumbs === "true") ? "id3" : "id3 nocrop";
-        const thumbnailUrl = `./api/archives/${Reader.id}/thumbnail?page=${page}`;
+        const thumbnailUrl = new LRR.apiURL(`/api/archives/${Reader.id}/thumbnail?page=${page}`);
         const thumbnail = `
             <div class='${thumbCss} quick-thumbnail' page='${index}' style='display: inline-block; cursor: pointer'>
                 <span class='page-number'>Page ${page}</span>
@@ -736,7 +737,7 @@ Reader.initializeArchiveOverlay = function () {
             // If the spinner is still visible, update the thumbnail
             if ($(`#${index}_spinner`).attr("loaded") !== "true") {
                 // Set image source to the thumbnail
-                const thumbnailUrl = `./api/archives/${Reader.id}/thumbnail?page=${page}&cachebust=${Date.now()}`;
+                const thumbnailUrl = new LRR.apiURL(`/api/archives/${Reader.id}/thumbnail?page=${page}&cachebust=${Date.now()}`);
                 $(`#${index}_thumb`).attr("src", thumbnailUrl);
                 $(`#${index}_spinner`).attr("loaded", true);
                 $(`#${index}_spinner`).hide();
@@ -744,7 +745,7 @@ Reader.initializeArchiveOverlay = function () {
         }
     };
 
-    fetch(`/api/archives/${Reader.id}/files/thumbnails`, { method: "POST" })
+    fetch(new LRR.apiURL(`/api/archives/${Reader.id}/files/thumbnails`), { method: "POST" })
         .then((response) => {
             if (response.status === 200) {
                 // Thumbnails are already generated, there's nothing to do. Very nice!

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -42,7 +42,7 @@ Reader.initializeAll = function () {
     $(document).on("click.regenerate-archive-cache", "#regenerate-cache", () => {
         window.location.href = new LRR.apiURL(`/reader?id=${Reader.id}&force_reload`);
     });
-    $(document).on("click.edit-metadata", "#edit-archive", () => LRR.openInNewTab(`./edit?id=${Reader.id}`));
+    $(document).on("click.edit-metadata", "#edit-archive", () => LRR.openInNewTab(new LRR.apiURL(`/edit?id=${Reader.id}`)));
     $(document).on("click.delete-archive", "#delete-archive", () => {
         LRR.closeOverlay();
         LRR.showPopUp({

--- a/public/js/server.js
+++ b/public/js/server.js
@@ -16,6 +16,7 @@ Server.isScriptRunning = false;
  * @returns The result of the callback, or NULL.
  */
 Server.callAPI = function (endpoint, method, successMessage, errorMessage, successCallback) {
+    endpoint = new LRR.apiURL(endpoint);
     return fetch(endpoint, { method })
         .then((response) => (response.ok ? response.json() : { success: 0, error: "Response was not OK" }))
         .then((data) => {
@@ -43,6 +44,7 @@ Server.callAPI = function (endpoint, method, successMessage, errorMessage, succe
 };
 
 Server.callAPIBody = function (endpoint, method, body, successMessage, errorMessage, successCallback) {
+    endpoint = new LRR.apiURL(endpoint);
     return fetch(endpoint, { method, body })
         .then((response) => (response.ok ? response.json() : { success: 0, error: "Response was not OK" }))
         .then((data) => {
@@ -79,7 +81,8 @@ Server.callAPIBody = function (endpoint, method, body, successMessage, errorMess
  * @param {*} progressCallback Execute a callback if the job reports progress. (aka, if there's anything in notes)
  */
 Server.checkJobStatus = function (jobId, useDetail, callback, failureCallback, progressCallback = null) {
-    fetch(useDetail ? `/api/minion/${jobId}/detail` : `/api/minion/${jobId}`, { method: "GET" })
+    let endpoint = new LRR.apiURL(useDetail ? `/api/minion/${jobId}/detail` : `/api/minion/${jobId}`);
+    fetch(endpoint, { method: "GET" })
         .then((response) => (response.ok ? response.json() : { success: 0, error: "Response was not OK" }))
         .then((data) => {
             if (data.error) throw new Error(data.error);
@@ -297,7 +300,8 @@ Server.removeArchiveFromCategory = function (arcId, catId) {
  * @param {*} callback Callback to execute once the archive is deleted (usually a redirection)
  */
 Server.deleteArchive = function (arcId, callback) {
-    fetch(`/api/archives/${arcId}`, { method: "DELETE" })
+    let endpoint = new LRR.apiURL(`/api/archives/${arcId}`);
+    fetch(endpoint, { method: "DELETE" })
         .then((response) => (response.ok ? response.json() : { success: 0, error: "Response was not OK" }))
         .then((data) => {
             if (!data.success) {

--- a/public/js/stats.js
+++ b/public/js/stats.js
@@ -26,6 +26,7 @@ Stats.initializeAll = function () {
                     return;
                 const namespacedTag = LRR.buildNamespacedTag(tag.namespace, tag.text);
                 const url = LRR.getTagSearchURL(tag.namespace, tag.text);
+                
 
                 const ocss = "max-width: 95%; display: flex;";
                 const icss = "text-overflow: ellipsis; white-space: nowrap; overflow: hidden; min-width: 0; max-width: 100%;";

--- a/public/js/stats.js
+++ b/public/js/stats.js
@@ -26,7 +26,6 @@ Stats.initializeAll = function () {
                     return;
                 const namespacedTag = LRR.buildNamespacedTag(tag.namespace, tag.text);
                 const url = LRR.getTagSearchURL(tag.namespace, tag.text);
-                
 
                 const ocss = "max-width: 95%; display: flex;";
                 const icss = "text-overflow: ellipsis; white-space: nowrap; overflow: hidden; min-width: 0; max-width: 100%;";

--- a/public/js/upload.js
+++ b/public/js/upload.js
@@ -10,7 +10,7 @@ let totalUploads = 0;
 Upload.initializeAll = function () {
     // bind events to DOM
     $(document).on("click.download-url", "#download-url", Upload.downloadUrl);
-    $(document).on("click.return", "#return", () => { window.location.href = "/"; });
+    $(document).on("click.return", "#return", () => { window.location.href = new LRR.apiURL("/"); });
 
     $("#fileupload").fileupload({
         dataType: "json",
@@ -94,8 +94,8 @@ Upload.handleCompletedUpload = function (jobID, d) {
     $(`#${jobID}-name`).html(d.result.title);
 
     if (d.result.id) {
-        $(`#${jobID}-name`).attr("href", `reader?id=${d.result.id}`);
-        $(`#${jobID}-link`).attr("href", `edit?id=${d.result.id}`);
+        $(`#${jobID}-name`).attr("href", new LRR.apiURL(`/reader?id=${d.result.id}`));
+        $(`#${jobID}-link`).attr("href", new LRR.apiURL(`/edit?id=${d.result.id}`));
     }
 
     if (d.result.success) {
@@ -136,7 +136,7 @@ Upload.downloadUrl = function () {
             formData.append("catid", categoryID);
         }
 
-        fetch("/api/download_url", {
+        fetch(new LRR.apiURL("/api/download_url"), {
             method: "POST",
             body: formData,
         })

--- a/templates/backup.html.tt2
+++ b/templates/backup.html.tt2
@@ -30,6 +30,7 @@
 	<script src="[% c.url_for("/js/vendor/react-toastify.umd.js") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
+        <script>window.LRR_BASEURL = "[% c.LRR_BASEURL %]";</script>
 	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/backup.js?$version") %]" type="text/JAVASCRIPT"></script>

--- a/templates/backup.html.tt2
+++ b/templates/backup.html.tt2
@@ -30,7 +30,6 @@
 	<script src="[% c.url_for("/js/vendor/react-toastify.umd.js") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
-        <script>window.LRR_BASEURL = "[% c.LRR_BASEURL %]";</script>
 	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/backup.js?$version") %]" type="text/JAVASCRIPT"></script>

--- a/templates/backup.html.tt2
+++ b/templates/backup.html.tt2
@@ -11,28 +11,28 @@
 
 	<link type="image/png" rel="icon" href="favicon.ico" />
 	<link rel="manifest" href="app.webappmanifest" />
-	<link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version%]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/lrr.css?$version") %]" />
 
-	<link rel="stylesheet" type="text/css" href="/css/vendor/fontawesome-all.min.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/jquery.fileupload.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/ReactToastify.min.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/sweetalert2.min.css" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/fontawesome-all.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/jquery.fileupload.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/ReactToastify.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/sweetalert2.min.css") %]" />
 	[% csshead %]
 
-	<script src="/js/vendor/jquery.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/jquery.ui.widget.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/jquery.fileupload.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/preact.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/hooks.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/compat.umd.js" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/jquery.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/jquery.ui.widget.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/jquery.fileupload.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/preact.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/hooks.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/compat.umd.js") %]" type="text/JAVASCRIPT"></script>
 	<script>window.React = window.preactCompat; window.react = window.preactCompat;</script>
-	<script src="/js/vendor/clsx.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/react-toastify.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/sweetalert2.min.js" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/clsx.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/react-toastify.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
-	<script src="/js/common.js?[% version%]" type="text/JAVASCRIPT"></script>
-	<script src="/js/server.js?[% version%]" type="text/JAVASCRIPT"></script>
-	<script src="/js/backup.js?[% version%]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/backup.js?$version") %]" type="text/JAVASCRIPT"></script>
 
 </head>
 

--- a/templates/batch.html.tt2
+++ b/templates/batch.html.tt2
@@ -28,7 +28,6 @@
 	<script src="[% c.url_for("/js/vendor/react-toastify.umd.js") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
-        <script>window.LRR_BASEURL = "[% c.LRR_BASEURL %]";</script>
 	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/batch.js?$version") %]" type="text/JAVASCRIPT"></script>

--- a/templates/batch.html.tt2
+++ b/templates/batch.html.tt2
@@ -28,6 +28,7 @@
 	<script src="[% c.url_for("/js/vendor/react-toastify.umd.js") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
+        <script>window.LRR_BASEURL = "[% c.LRR_BASEURL %]";</script>
 	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/batch.js?$version") %]" type="text/JAVASCRIPT"></script>

--- a/templates/batch.html.tt2
+++ b/templates/batch.html.tt2
@@ -13,24 +13,24 @@
 
 	<link type="image/png" rel="icon" href="favicon.ico" />
 	<link rel="manifest" href="app.webappmanifest" />
-	<link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version%]" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/fontawesome-all.min.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/ReactToastify.min.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/sweetalert2.min.css" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/lrr.css?$version") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/fontawesome-all.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/ReactToastify.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/sweetalert2.min.css") %]" />
 	[% csshead %]
 
-	<script src="/js/vendor/jquery.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/preact.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/hooks.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/compat.umd.js" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/jquery.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/preact.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/hooks.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/compat.umd.js") %]" type="text/JAVASCRIPT"></script>
 	<script>window.React = window.preactCompat; window.react = window.preactCompat;</script>
-	<script src="/js/vendor/clsx.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/react-toastify.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/sweetalert2.min.js" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/clsx.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/react-toastify.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
-	<script src="/js/common.js?[% version%]" type="text/JAVASCRIPT"></script>
-	<script src="/js/server.js?[% version%]" type="text/JAVASCRIPT"></script>
-	<script src="/js/batch.js?[% version%]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/batch.js?$version") %]" type="text/JAVASCRIPT"></script>
 
 </head>
 

--- a/templates/category.html.tt2
+++ b/templates/category.html.tt2
@@ -28,6 +28,7 @@
     <script src="[% c.url_for("/js/vendor/react-toastify.umd.js") %]" type="text/JAVASCRIPT"></script>
     <script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
+    <script>window.LRR_BASEURL = "[% c.LRR_BASEURL %]";</script>
     <script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
     <script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
     <script src="[% c.url_for("/js/category.js?$version") %]" type="text/JAVASCRIPT"></script>

--- a/templates/category.html.tt2
+++ b/templates/category.html.tt2
@@ -28,7 +28,6 @@
     <script src="[% c.url_for("/js/vendor/react-toastify.umd.js") %]" type="text/JAVASCRIPT"></script>
     <script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
-    <script>window.LRR_BASEURL = "[% c.LRR_BASEURL %]";</script>
     <script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
     <script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
     <script src="[% c.url_for("/js/category.js?$version") %]" type="text/JAVASCRIPT"></script>

--- a/templates/category.html.tt2
+++ b/templates/category.html.tt2
@@ -13,24 +13,24 @@
 
     <link type="image/png" rel="icon" href="/favicon.ico" />
     <link rel="manifest" href="app.webappmanifest" />
-    <link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version%]" />
-    <link rel="stylesheet" type="text/css" href="/css/vendor/fontawesome-all.min.css" />
-    <link rel="stylesheet" type="text/css" href="/css/vendor/ReactToastify.min.css" />
-    <link rel="stylesheet" type="text/css" href="/css/vendor/sweetalert2.min.css" />
+    <link rel="stylesheet" type="text/css" href="[% c.url_for("/css/lrr.css?$version") %]" />
+    <link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/fontawesome-all.min.css") %]" />
+    <link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/ReactToastify.min.css") %]" />
+    <link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/sweetalert2.min.css") %]" />
     [% csshead %]
 
-    <script src="/js/vendor/jquery.min.js" type="text/JAVASCRIPT"></script>
-    <script src="/js/vendor/preact.umd.js" type="text/JAVASCRIPT"></script>
-    <script src="/js/vendor/hooks.umd.js" type="text/JAVASCRIPT"></script>
-    <script src="/js/vendor/compat.umd.js" type="text/JAVASCRIPT"></script>
+    <script src="[% c.url_for("/js/vendor/jquery.min.js") %]" type="text/JAVASCRIPT"></script>
+    <script src="[% c.url_for("/js/vendor/preact.umd.js") %]" type="text/JAVASCRIPT"></script>
+    <script src="[% c.url_for("/js/vendor/hooks.umd.js") %]" type="text/JAVASCRIPT"></script>
+    <script src="[% c.url_for("/js/vendor/compat.umd.js") %]" type="text/JAVASCRIPT"></script>
     <script>window.React = window.preactCompat; window.react = window.preactCompat;</script>
-    <script src="/js/vendor/clsx.min.js" type="text/JAVASCRIPT"></script>
-    <script src="/js/vendor/react-toastify.umd.js" type="text/JAVASCRIPT"></script>
-    <script src="/js/vendor/sweetalert2.min.js" type="text/JAVASCRIPT"></script>
+    <script src="[% c.url_for("/js/vendor/clsx.min.js") %]" type="text/JAVASCRIPT"></script>
+    <script src="[% c.url_for("/js/vendor/react-toastify.umd.js") %]" type="text/JAVASCRIPT"></script>
+    <script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
-    <script src="/js/common.js?[% version%]" type="text/JAVASCRIPT"></script>
-    <script src="/js/server.js?[% version%]" type="text/JAVASCRIPT"></script>
-    <script src="/js/category.js?[% version%]" type="text/JAVASCRIPT"></script>
+    <script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
+    <script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
+    <script src="[% c.url_for("/js/category.js?$version") %]" type="text/JAVASCRIPT"></script>
 
 </head>
 

--- a/templates/config.html.tt2
+++ b/templates/config.html.tt2
@@ -30,6 +30,7 @@
 	<script src="[% c.url_for("/js/vendor/allcollapsible.min.js") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
+        <script>window.LRR_BASEURL = "[% c.LRR_BASEURL %]";</script>
 	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/config.js?$version") %]" type="text/JAVASCRIPT"></script>

--- a/templates/config.html.tt2
+++ b/templates/config.html.tt2
@@ -11,28 +11,28 @@
 
 	<link type="image/png" rel="icon" href="favicon.ico" />
 	<link rel="manifest" href="app.webappmanifest" />
-	<link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version%]" />
-	<link rel="stylesheet" type="text/css" href="/css/config.css" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/lrr.css?$version") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/config.css") %]" />
 
-	<link rel="stylesheet" type="text/css" href="/css/vendor/fontawesome-all.min.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/allcollapsible.min.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/ReactToastify.min.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/sweetalert2.min.css" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/fontawesome-all.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/allcollapsible.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/ReactToastify.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/sweetalert2.min.css") %]" />
 	[% csshead %]
 
-	<script src="/js/vendor/jquery.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/preact.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/hooks.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/compat.umd.js" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/jquery.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/preact.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/hooks.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/compat.umd.js") %]" type="text/JAVASCRIPT"></script>
 	<script>window.React = window.preactCompat; window.react = window.preactCompat;</script>
-	<script src="/js/vendor/clsx.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/react-toastify.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/allcollapsible.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/sweetalert2.min.js" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/clsx.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/react-toastify.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/allcollapsible.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
-	<script src="/js/common.js?[% version %]" type="text/JAVASCRIPT"></script>
-	<script src="/js/server.js?[% version %]" type="text/JAVASCRIPT"></script>
-	<script src="/js/config.js?[% version %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/config.js?$version") %]" type="text/JAVASCRIPT"></script>
 
 </head>
 
@@ -43,7 +43,7 @@
 		<br>
 		<div class="left-column">
 
-			<img class="logo-container" src="./img/logo.png">
+			<img class="logo-container" src="[% c.url_for("/img/logo.png") %]">
 			<br>
 			<h1 style="margin-bottom: 2px">LANraragi</h1>
 			Version [% version %], "[% vername %]"

--- a/templates/config.html.tt2
+++ b/templates/config.html.tt2
@@ -30,7 +30,6 @@
 	<script src="[% c.url_for("/js/vendor/allcollapsible.min.js") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
-        <script>window.LRR_BASEURL = "[% c.LRR_BASEURL %]";</script>
 	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/config.js?$version") %]" type="text/JAVASCRIPT"></script>

--- a/templates/edit.html.tt2
+++ b/templates/edit.html.tt2
@@ -11,28 +11,28 @@
 
 	<link type="image/png" rel="icon" href="favicon.ico" />
 	<link rel="manifest" href="app.webappmanifest" />
-	<link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version%]" />
-	<link rel="stylesheet" type="text/css" href="/css/config.css" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/lrr.css?$version") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/config.css") %]" />
 
-	<link rel="stylesheet" type="text/css" href="/css/vendor/fontawesome-all.min.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/tagger.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/ReactToastify.min.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/sweetalert2.min.css" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/fontawesome-all.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/tagger.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/ReactToastify.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/sweetalert2.min.css") %]" />
 	[% csshead %]
 
-	<script src="/js/vendor/jquery.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/preact.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/hooks.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/compat.umd.js" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/jquery.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/preact.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/hooks.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/compat.umd.js") %]" type="text/JAVASCRIPT"></script>
 	<script>window.React = window.preactCompat; window.react = window.preactCompat;</script>
-	<script src="/js/vendor/clsx.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/react-toastify.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/tagger.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/sweetalert2.min.js" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/clsx.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/react-toastify.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/tagger.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
-	<script src="/js/common.js?[% version%]" type="text/JAVASCRIPT"></script>
-	<script src="/js/server.js?[% version%]" type="text/JAVASCRIPT"></script>
-	<script src="/js/edit.js?[% version%]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/edit.js?$version") %]" type="text/JAVASCRIPT"></script>
 
 </head>
 

--- a/templates/edit.html.tt2
+++ b/templates/edit.html.tt2
@@ -30,7 +30,6 @@
 	<script src="[% c.url_for("/js/vendor/tagger.js") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
-        <script>window.LRR_BASEURL = "[% c.LRR_BASEURL %]";</script>
 	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/edit.js?$version") %]" type="text/JAVASCRIPT"></script>

--- a/templates/edit.html.tt2
+++ b/templates/edit.html.tt2
@@ -30,6 +30,7 @@
 	<script src="[% c.url_for("/js/vendor/tagger.js") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
+        <script>window.LRR_BASEURL = "[% c.LRR_BASEURL %]";</script>
 	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/edit.js?$version") %]" type="text/JAVASCRIPT"></script>

--- a/templates/index.html.tt2
+++ b/templates/index.html.tt2
@@ -41,6 +41,7 @@
 	<script src="[% c.url_for("/js/vendor/swiper-bundle.min.js") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
+        <script>window.LRR_BASEURL = "[% c.LRR_BASEURL %]";</script>
 	<script src="[% c.url_for("/js/index.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>

--- a/templates/index.html.tt2
+++ b/templates/index.html.tt2
@@ -41,7 +41,6 @@
 	<script src="[% c.url_for("/js/vendor/swiper-bundle.min.js") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
-        <script>window.LRR_BASEURL = "[% c.LRR_BASEURL %]";</script>
 	<script src="[% c.url_for("/js/index.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>

--- a/templates/index.html.tt2
+++ b/templates/index.html.tt2
@@ -11,40 +11,40 @@
 
 	<link type="image/png" rel="icon" href="favicon.ico" />
 	<link rel="manifest" href="app.webappmanifest" />
-	<link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/lrr.css?$version") %]" />
 
-	<link rel="stylesheet" type="text/css" href="/css/vendor/fontawesome-all.min.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/jquery.contextMenu.min.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/awesomplete.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/tippy.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/allcollapsible.min.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/swiper-bundle.min.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/ReactToastify.min.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/sweetalert2.min.css" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/fontawesome-all.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/jquery.contextMenu.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/awesomplete.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/tippy.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/allcollapsible.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/swiper-bundle.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/ReactToastify.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/sweetalert2.min.css") %]" />
 	[% csshead %]
 
-	<script src="/js/vendor/jquery.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/jquery.dataTables.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/preact.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/hooks.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/compat.umd.js" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/jquery.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/jquery.dataTables.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/preact.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/hooks.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/compat.umd.js") %]" type="text/JAVASCRIPT"></script>
 	<script>window.React = window.preactCompat; window.react = window.preactCompat;</script>
-	<script src="/js/vendor/clsx.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/react-toastify.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/jquery.ui.position.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/jquery.contextMenu.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/awesomplete.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/popper.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/tippy-bundle.umd.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/marked.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/allcollapsible.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/swiper-bundle.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/sweetalert2.min.js" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/clsx.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/react-toastify.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/jquery.ui.position.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/jquery.contextMenu.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/awesomplete.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/popper.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/tippy-bundle.umd.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/marked.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/allcollapsible.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/swiper-bundle.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
-	<script src="/js/index.js?[% version %]" type="text/JAVASCRIPT"></script>
-	<script src="/js/common.js?[% version %]" type="text/JAVASCRIPT"></script>
-	<script src="/js/server.js?[% version %]" type="text/JAVASCRIPT"></script>
-	<script src="/js/index_datatables.js?[% version %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/index.js?$version") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/index_datatables.js?$version") %]" type="text/JAVASCRIPT"></script>
 
 </head>
 
@@ -53,29 +53,29 @@
 	[% IF userlogged %]
 	<p id="nb">
 		<i class="fa fa-caret-right"></i>
-		<a href="./upload">Add Archives</a>
+		<a href="[% c.url_for("/upload") %]">Add Archives</a>
 		<span style="margin-left:5px"></span>
 		<i class="fa fa-caret-right"></i>
-		<a href="./batch">Batch Operations</a>
+		<a href="[% c.url_for("/batch") %]">Batch Operations</a>
 		<span style="margin-left:5px"></span>
 		<i class="fa fa-caret-right"></i>
-		<a href="./config">Settings</a>
+		<a href="[% c.url_for("/config") %]">Settings</a>
 		<span style="margin-left:5px"></span>
 		<i class="fa fa-caret-right"></i>
-		<a href="./config/categories">Modify Categories</a>
+		<a href="[% c.url_for("/config/categories") %]">Modify Categories</a>
 		<span style="margin-left:5px"></span>
 		<i class="fa fa-caret-right"></i>
-		<a href="./stats">Statistics</a>
+		<a href="[% c.url_for("/stats") %]">Statistics</a>
 		<i class="fa fa-caret-right"></i>
-		<a href="./logs">Logs</a>
+		<a href="[% c.url_for("/logs") %]">Logs</a>
 	</p>
 	[% ELSE %]
 	<p id="nb">
 		<i class="fa fa-caret-right"></i>
-		<a href="./login">Admin Login</a>
+		<a href="[% c.url_for("/login") %]">Admin Login</a>
 		<span style="margin-left:5px"></span>
 		<i class="fa fa-caret-right"></i>
-		<a href="./stats">Statistics</a>
+		<a href="[% c.url_for("/stats") %]">Statistics</a>
 	</p>
 	[% END %]
 
@@ -199,7 +199,7 @@
 			//If the json has the "default password" flag, flash a friendly notification inviting the user to change his password
 			LRR.toast({
 				heading: 'You\'re using the default password and that\'s super baka of you',
-				text: '<a href="login">Login</a> with password "kamimamita" and <a href="config">change that shit</a> on the double.<br/>...Or just disable it! <br/>Why not check the configuration options afterwards, while you\'re at it? ',
+				text: '<a href="[% c.url_for("/login") %]">Login</a> with password "kamimamita" and <a href="[% c.url_for("/config") %]">change that shit</a> on the double.<br/>...Or just disable it! <br/>Why not check the configuration options afterwards, while you\'re at it? ',
 				icon: 'warning',
 				hideAfter: 25000,
 				closeOnClick: false,

--- a/templates/login.html.tt2
+++ b/templates/login.html.tt2
@@ -11,12 +11,12 @@
 
 	<link type="image/png" rel="icon" href="favicon.ico" />
 	<link rel="manifest" href="app.webappmanifest" />
-	<link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version%]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/lrr.css?$version") %]" />
 
-	<link rel="stylesheet" type="text/css" href="./css/vendor/fontawesome-all.min.css" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/fontawesome-all.min.css") %]" />
 	[% csshead %]
 
-	<script src="./js/vendor/jquery.min.js" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/jquery.min.js") %]" type="text/JAVASCRIPT"></script>
 </head>
 
 <body>

--- a/templates/logs.html.tt2
+++ b/templates/logs.html.tt2
@@ -25,6 +25,7 @@
 	<script src="[% c.url_for("/js/vendor/clsx.min.js") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/vendor/react-toastify.umd.js") %]" type="text/JAVASCRIPT"></script>
 
+        <script>window.LRR_BASEURL = "[% c.LRR_BASEURL %]";</script>
 	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/logs.js?$version") %]" type="text/JAVASCRIPT"></script>
 </head>

--- a/templates/logs.html.tt2
+++ b/templates/logs.html.tt2
@@ -25,7 +25,6 @@
 	<script src="[% c.url_for("/js/vendor/clsx.min.js") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/vendor/react-toastify.umd.js") %]" type="text/JAVASCRIPT"></script>
 
-        <script>window.LRR_BASEURL = "[% c.LRR_BASEURL %]";</script>
 	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/logs.js?$version") %]" type="text/JAVASCRIPT"></script>
 </head>

--- a/templates/logs.html.tt2
+++ b/templates/logs.html.tt2
@@ -11,22 +11,22 @@
 
 	<link type="image/png" rel="icon" href="favicon.ico" />
 	<link rel="manifest" href="app.webappmanifest" />
-	<link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version%]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/lrr.css?$version") %]" />
 
-	<link rel="stylesheet" type="text/css" href="./css/vendor/fontawesome-all.min.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/ReactToastify.min.css" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/fontawesome-all.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/ReactToastify.min.css") %]" />
 	[% csshead %]
 
-	<script src="./js/vendor/jquery.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/preact.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/hooks.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/compat.umd.js" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/jquery.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/preact.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/hooks.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/compat.umd.js") %]" type="text/JAVASCRIPT"></script>
 	<script>window.React = window.preactCompat; window.react = window.preactCompat;</script>
-	<script src="/js/vendor/clsx.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/react-toastify.umd.js" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/clsx.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/react-toastify.umd.js") %]" type="text/JAVASCRIPT"></script>
 
-	<script src="./js/common.js?[% version%]" type="text/JAVASCRIPT"></script>
-	<script src="./js/logs.js?[% version%]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/logs.js?$version") %]" type="text/JAVASCRIPT"></script>
 </head>
 
 <body>

--- a/templates/opds.html.tt2
+++ b/templates/opds.html.tt2
@@ -29,7 +29,7 @@
  
     [% FOREACH cat IN catlist %]
     <link rel="http://opds-spec.org/facet" 
-        href="[% c.url_for("/api/opds?category=$cat->{id}$api_key_and") %]"
+        href="[% c.url_for("/api/opds?category=$cat.id$api_key_and") %]"
         title="[% cat.name %]"  
         opds:facetGroup="Categories" 
         [% IF cat.count %]thr:count="[% cat.count %]" [% END %][% IF cat.active %]opds:activeFacet="true" [% END %]/>

--- a/templates/opds.html.tt2
+++ b/templates/opds.html.tt2
@@ -7,10 +7,10 @@
 
     <id>urn:lrr:0</id>
 
-    <link rel="self" href="/api/opds[% api_key_query %]" type="application/atom+xml;profile=opds-catalog;kind=acquisition" />
-    <link rel="start" href="/api/opds[% api_key_query %]" type="application/atom+xml;profile=opds-catalog;kind=acquisition" />
+    <link rel="self" href="[% c.url_for("/api/opds$api_key_query") %]" type="application/atom+xml;profile=opds-catalog;kind=acquisition" />
+    <link rel="start" href="[% c.url_for("/api/opds$api_key_query") %]" type="application/atom+xml;profile=opds-catalog;kind=acquisition" />
 
-    <link rel="next" href="/api/opds?start=[% nextpage %][% api_key_and %]" type="application/atom+xml;profile=opds-catalog;kind=navigation" />
+    <link rel="next" href="[% c.url_for("/api/opds?start=$nextpage$api_key_and") %]" type="application/atom+xml;profile=opds-catalog;kind=navigation" />
 
     <title>[% title %]</title>
     <updated>2010-01-10T10:03:10Z</updated>
@@ -22,14 +22,14 @@
     </author>
 
     <link rel="http://opds-spec.org/facet" 
-        href="/api/opds[% api_key_query %]" 
+        href="[% c.url_for("/api/opds$api_key_query") %]"
         title="All Archives" 
         opds:facetGroup="Categories" 
         [% IF nocat %]opds:activeFacet="true" [% END %]/>
  
     [% FOREACH cat IN catlist %]
     <link rel="http://opds-spec.org/facet" 
-        href="/api/opds?category=[% cat.id %][% api_key_and %]" 
+        href="[% c.url_for("/api/opds?category=$cat->{id}$api_key_and") %]"
         title="[% cat.name %]"  
         opds:facetGroup="Categories" 
         [% IF cat.count %]thr:count="[% cat.count %]" [% END %][% IF cat.active %]opds:activeFacet="true" [% END %]/>
@@ -55,19 +55,19 @@
         [% END %]
         <summary>[% arc.tags %]</summary>
 
-        <link rel="alternate" href="/api/opds/[% arc.arcid %][% api_key_query %]"
+        <link rel="alternate" href="[% c.url_for("/api/opds/$arc.arcid$api_key_query") %]"
             type="application/atom+xml;type=entry;profile=opds-catalog" />
 
-        <link rel="http://opds-spec.org/image" href="/api/archives/[% arc.arcid %]/thumbnail[% api_key_query %]" type="image/jpeg" />
-        <link rel="http://opds-spec.org/image/thumbnail" href="/api/archives/[% arc.arcid %]/thumbnail[% api_key_query %]"
+        <link rel="http://opds-spec.org/image" href="[% c.url_for("/api/archives/$arc.arcid/thumbnail$api_key_query") %]" type="image/jpeg" />
+        <link rel="http://opds-spec.org/image/thumbnail" href="[% c.url_for("/api/archives/$arc.arcid/thumbnail$api_key_query") %]"
             type="image/jpeg" />
-        <link rel="http://opds-spec.org/acquisition" href="/api/archives/[% arc.arcid %]/download[% api_key_query %]" title="Download/Read"
+        <link rel="http://opds-spec.org/acquisition" href="[% c.url_for("/api/archives/$arc.arcid/download$api_key_query") %]" title="Download/Read"
             type="[% arc.mimetype %]" />
         <link rel="http://vaemendis.net/opds-pse/stream" type="image/jpeg"
-            href="/api/opds/[% arc.arcid %]/pse?page={pageNumber}[% api_key_and %]" pse:count="[% arc.pagecount %]" 
+            href="[% c.url_for("/api/opds/$arc.arcid/pse?page={pageNumber}$api_key_and") %]" pse:count="[% arc.pagecount %]"
             [% IF arc.progress %] pse:lastRead="[% arc.progress %]" [% END %] 
             [% IF arc.lastreaddate %] pse:lastReadDate="[% arc.lastreaddate %]" [% END %]/>
-        <link type="text/html" rel="alternate" title="Open in LANraragi" href="/reader?id=[% arc.arcid %][% api_key_and %]" />
+        <link type="text/html" rel="alternate" title="Open in LANraragi" href="[% c.url_for("/reader?id=$arc.arcid$api_key_and") %]" />
     </entry>
     [% END %]
 

--- a/templates/opds_entry.html.tt2
+++ b/templates/opds_entry.html.tt2
@@ -7,8 +7,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:schema="http://schema.org/">
 
-    <link rel="start" href="/api/opds[% api_key_query %]" type="application/atom+xml;profile=opds-catalog;kind=navigation" />
-    <link rel="self" href="/api/opds/[% arc.arcid %][% api_key_query %]" type="application/atom+xml;type=entry;profile=opds-catalog" />
+    <link rel="start" href="[% c.url_for("/api/opds$api_key_query") %]" type="application/atom+xml;profile=opds-catalog;kind=navigation" />
+    <link rel="self" href="[% c.url_for("/api/opds/$arc.arcid$api_key_query") %]" type="application/atom+xml;type=entry;profile=opds-catalog" />
 
     <title>[% arc.title %]</title>
     <id>urn:lrr:[% arc.arcid %]</id>
@@ -28,14 +28,14 @@
     [% END %]
     <summary>[% arc.tags %]</summary>
 
-    <link rel="http://opds-spec.org/image" href="/api/archives/[% arc.arcid %]/thumbnail[% api_key_query %]" type="image/jpeg" />
-    <link rel="http://opds-spec.org/image/thumbnail" href="/api/archives/[% arc.arcid %]/thumbnail[% api_key_query %]" type="image/jpeg" />
-    <link rel="http://opds-spec.org/acquisition" href="/api/archives/[% arc.arcid %]/download[% api_key_query %]" title="Download/Read"
+    <link rel="http://opds-spec.org/image" href="[% c.url_for("/api/archives/$arc.arcid/thumbnail$api_key_query") %]" type="image/jpeg" />
+    <link rel="http://opds-spec.org/image/thumbnail" href="[% c.url_for("/api/archives/$arc.arcid/thumbnail$api_key_query") %]" type="image/jpeg" />
+    <link rel="http://opds-spec.org/acquisition" href="[% c.url_for("/api/archives/$arc.arcid/download$api_key_query") %]" title="Download/Read"
         type="[% arc.mimetype %]" />
     <link rel="http://vaemendis.net/opds-pse/stream" type="image/jpeg"
-        href="/api/opds/[% arc.arcid %]/pse?page={pageNumber}[% api_key_and %]" pse:count="[% arc.pagecount %]" 
+        href="[% c.url_for("/api/opds/$arc.arcid/pse?page={pageNumber}$api_key_and") %]" pse:count="[% arc.pagecount %]" 
         [% IF arc.progress %] pse:lastRead="[% arc.progress %]" [% END %] 
         [% IF arc.lastreaddate %] pse:lastReadDate="[% arc.lastreaddate %]" [% END %] />
-    <link type="text/html" rel="alternate" title="Open in LANraragi" href="/reader?id=[% arc.arcid %][% api_key_and %]" />
+    <link type="text/html" rel="alternate" title="Open in LANraragi" href="[% c.url_for("/reader?id=$arc.arcid$api_key_and") %]" />
 
 </entry>

--- a/templates/plugins.html.tt2
+++ b/templates/plugins.html.tt2
@@ -33,6 +33,7 @@
 	<script src="[% c.url_for("/js/vendor/allcollapsible.min.js") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
+        <script>window.LRR_BASEURL = "[% c.LRR_BASEURL %]";</script>
 	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/plugins.js?$version") %]" type="text/JAVASCRIPT"></script>

--- a/templates/plugins.html.tt2
+++ b/templates/plugins.html.tt2
@@ -11,31 +11,31 @@
 
 	<link type="image/png" rel="icon" href="/favicon.ico" />
 	<link rel="manifest" href="app.webappmanifest" />
-	<link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version%]" />
-	<link rel="stylesheet" type="text/css" href="/css/config.css" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/lrr.css?$version") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/config.css") %]" />
 
-	<link rel="stylesheet" type="text/css" href="/css/vendor/fontawesome-all.min.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/jquery.fileupload.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/allcollapsible.min.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/ReactToastify.min.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/sweetalert2.min.css" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/fontawesome-all.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/jquery.fileupload.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/allcollapsible.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/ReactToastify.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/sweetalert2.min.css") %]" />
 	[% csshead %]
 
-	<script src="/js/vendor/jquery.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/preact.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/hooks.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/compat.umd.js" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/jquery.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/preact.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/hooks.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/compat.umd.js") %]" type="text/JAVASCRIPT"></script>
 	<script>window.React = window.preactCompat; window.react = window.preactCompat;</script>
-	<script src="/js/vendor/clsx.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/react-toastify.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/jquery.ui.widget.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/jquery.fileupload.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/allcollapsible.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/sweetalert2.min.js" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/clsx.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/react-toastify.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/jquery.ui.widget.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/jquery.fileupload.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/allcollapsible.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
-	<script src="/js/common.js?[% version%]" type="text/JAVASCRIPT"></script>
-	<script src="/js/server.js?[% version%]" type="text/JAVASCRIPT"></script>
-	<script src="/js/plugins.js?[% version%]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/plugins.js?$version") %]" type="text/JAVASCRIPT"></script>
 
 </head>
 
@@ -133,6 +133,7 @@
 [% FOREACH plugin IN plugins %]
 <span style="display:inline-block; text-align: left; width:80%; border-bottom-width: 1px;border-bottom-style: solid">
 	[% IF plugin.icon %]
+        [%# the plugin.icon attr is always a data: URI, so we don't need to worry about the base URL %]
 	<img height=20 width=20 src="[% plugin.icon %]" />
 	[% ELSE %]
 	<i class="fa fa-puzzle-piece" style="font-size:20px"></i>

--- a/templates/plugins.html.tt2
+++ b/templates/plugins.html.tt2
@@ -33,7 +33,6 @@
 	<script src="[% c.url_for("/js/vendor/allcollapsible.min.js") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
-        <script>window.LRR_BASEURL = "[% c.LRR_BASEURL %]";</script>
 	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/plugins.js?$version") %]" type="text/JAVASCRIPT"></script>

--- a/templates/reader.html.tt2
+++ b/templates/reader.html.tt2
@@ -28,6 +28,7 @@
     <script src="[% c.url_for("/js/vendor/react-toastify.umd.js") %]" type="text/JAVASCRIPT"></script>
     <script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
+    <script>window.LRR_BASEURL = "[% c.LRR_BASEURL %]";</script>
     <script src="[% c.url_for("/js/common.js?$version") %]" type="text/javascript"></script>
     <script src="[% c.url_for("/js/server.js?$version") %]" type="text/javascript"></script>
     <script src="[% c.url_for("/js/reader.js?$version") %]" type="text/javascript"></script>

--- a/templates/reader.html.tt2
+++ b/templates/reader.html.tt2
@@ -11,29 +11,29 @@
 
     <link type="image/png" rel="icon" href="favicon.ico" />
     <link rel="manifest" href="app.webappmanifest" />
-    <link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version %]" />
-    <link rel="stylesheet" type="text/css" href="/css/config.css?[% version %]" />
+    <link rel="stylesheet" type="text/css" href="[% c.url_for("/css/lrr.css?$version") %]" />
+    <link rel="stylesheet" type="text/css" href="[% c.url_for("/css/config.css?$version") %]" />
 
-    <link rel="stylesheet" type="text/css" href="./css/vendor/fontawesome-all.min.css" />
-    <link rel="stylesheet" type="text/css" href="/css/vendor/ReactToastify.min.css" />
-    <link rel="stylesheet" type="text/css" href="/css/vendor/sweetalert2.min.css" />
+    <link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/fontawesome-all.min.css") %]" />
+    <link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/ReactToastify.min.css") %]" />
+    <link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/sweetalert2.min.css") %]" />
     [% csshead %]
 
-    <script src="./js/vendor/jquery.min.js" type="text/javascript"></script>
-    <script src="/js/vendor/preact.umd.js" type="text/JAVASCRIPT"></script>
-    <script src="/js/vendor/hooks.umd.js" type="text/JAVASCRIPT"></script>
-    <script src="/js/vendor/compat.umd.js" type="text/JAVASCRIPT"></script>
+    <script src="[% c.url_for("/js/vendor/jquery.min.js") %]" type="text/javascript"></script>
+    <script src="[% c.url_for("/js/vendor/preact.umd.js") %]" type="text/JAVASCRIPT"></script>
+    <script src="[% c.url_for("/js/vendor/hooks.umd.js") %]" type="text/JAVASCRIPT"></script>
+    <script src="[% c.url_for("/js/vendor/compat.umd.js") %]" type="text/JAVASCRIPT"></script>
     <script>window.React = window.preactCompat; window.react = window.preactCompat;</script>
-    <script src="/js/vendor/clsx.min.js" type="text/JAVASCRIPT"></script>
-    <script src="/js/vendor/react-toastify.umd.js" type="text/JAVASCRIPT"></script>
-    <script src="/js/vendor/sweetalert2.min.js" type="text/JAVASCRIPT"></script>
+    <script src="[% c.url_for("/js/vendor/clsx.min.js") %]" type="text/JAVASCRIPT"></script>
+    <script src="[% c.url_for("/js/vendor/react-toastify.umd.js") %]" type="text/JAVASCRIPT"></script>
+    <script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
-    <script src="./js/common.js?[% version %]" type="text/javascript"></script>
-    <script src="./js/server.js?[% version %]" type="text/javascript"></script>
-    <script src="./js/reader.js?[% version %]" type="text/javascript"></script>
+    <script src="[% c.url_for("/js/common.js?$version") %]" type="text/javascript"></script>
+    <script src="[% c.url_for("/js/server.js?$version") %]" type="text/javascript"></script>
+    <script src="[% c.url_for("/js/reader.js?$version") %]" type="text/javascript"></script>
 
     <script type="module">
-        import('./js/vendor/fscreen.esm.js').then(r => {
+        import('[% c.url_for("/js/vendor/fscreen.esm.js") %]').then(r => {
             window.fscreen = r.default;
             Reader.initializeAll();
         })
@@ -68,7 +68,7 @@
 
         <div id="i5">
             <div class="sb">
-                <a href="./?[% ref_query %]" id="return-to-index" title="Done reading? Go back to Archive Index">
+                <a href="[% c.url_for("/").query(ref_query) %]" id="return-to-index" title="Done reading? Go back to Archive Index">
                     <i class="fa fa-angle-down fa-3x"></i>
                 </a>
             </div>
@@ -78,7 +78,7 @@
             <i class="fa fa-caret-right fa-lg"></i>
             <a id="imgLink" style="cursor:pointer;">View full-size image</a>
             <i class="fa fa-caret-right fa-lg"></i>
-            <a href="./random">Switch to another random archive</a>
+            <a href="[% c.url_for("/random") %]">Switch to another random archive</a>
         </div>
 
     </div>
@@ -95,7 +95,7 @@
             <br>
             <div style="margin-bottom:16px;">
                 <div class="id3 nocrop reader-thumbnail">
-                    <img src="./api/archives/[% id %]/thumbnail" />
+                    <img src="[% c.url_for("/api/archives/$id/thumbnail") %]" />
                 </div>
 
                 [% IF userlogged %]
@@ -118,7 +118,7 @@
                     <div id="archive-categories" style="display:inline-block">
                         [% FOREACH arc_categories %]
                         <div class="gt" style="font-size:14px; padding:4px">
-                            <a href="/?c=[% id %]">
+                            <a href="[% c.url_for("/").query("c=$id") %]">
                                 <span class="label">[% name %]</span>
                                 <a href="#" class="remove-category" data-id="[% id %]"
                                     style="margin-left:4px; margin-right:2px">×</a>

--- a/templates/reader.html.tt2
+++ b/templates/reader.html.tt2
@@ -28,7 +28,6 @@
     <script src="[% c.url_for("/js/vendor/react-toastify.umd.js") %]" type="text/JAVASCRIPT"></script>
     <script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
-    <script>window.LRR_BASEURL = "[% c.LRR_BASEURL %]";</script>
     <script src="[% c.url_for("/js/common.js?$version") %]" type="text/javascript"></script>
     <script src="[% c.url_for("/js/server.js?$version") %]" type="text/javascript"></script>
     <script src="[% c.url_for("/js/reader.js?$version") %]" type="text/javascript"></script>

--- a/templates/stats.html.tt2
+++ b/templates/stats.html.tt2
@@ -11,29 +11,29 @@
 
 	<link type="image/png" rel="icon" href="favicon.ico" />
 	<link rel="manifest" href="app.webappmanifest" />
-	<link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version%]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/lrr.css?$version") %]" />
 
-	<link rel="stylesheet" type="text/css" href="./css/vendor/fontawesome-all.min.css" />
-	<link rel="stylesheet" type="text/css" href="./css/vendor/jqcloud.min.css">
-	<link rel="stylesheet" type="text/css" href="/css/vendor/allcollapsible.min.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/ReactToastify.min.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/sweetalert2.min.css" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/fontawesome-all.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/jqcloud.min.css") %]">
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/allcollapsible.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/ReactToastify.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/sweetalert2.min.css") %]" />
 	[% csshead %]
 
-	<script src="./js/vendor/jquery.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/preact.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/hooks.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/compat.umd.js" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/jquery.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/preact.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/hooks.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/compat.umd.js") %]" type="text/JAVASCRIPT"></script>
 	<script>window.React = window.preactCompat; window.react = window.preactCompat;</script>
-	<script src="/js/vendor/clsx.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/react-toastify.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="./js/vendor/jqcloud.min.js"></script>
-	<script src="/js/vendor/allcollapsible.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/sweetalert2.min.js" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/clsx.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/react-toastify.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/jqcloud.min.js") %]"></script>
+	<script src="[% c.url_for("/js/vendor/allcollapsible.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
-	<script src="./js/common.js?[% version%]" type="text/JAVASCRIPT"></script>
-	<script src="./js/server.js?[% version%]" type="text/JAVASCRIPT"></script>
-	<script src="./js/stats.js?[% version%]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/stats.js?$version") %]" type="text/JAVASCRIPT"></script>
 </head>
 
 <body>

--- a/templates/stats.html.tt2
+++ b/templates/stats.html.tt2
@@ -31,7 +31,6 @@
 	<script src="[% c.url_for("/js/vendor/allcollapsible.min.js") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
-        <script>window.LRR_BASEURL = "[% c.LRR_BASEURL %]";</script>
 	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/stats.js?$version") %]" type="text/JAVASCRIPT"></script>

--- a/templates/stats.html.tt2
+++ b/templates/stats.html.tt2
@@ -31,6 +31,7 @@
 	<script src="[% c.url_for("/js/vendor/allcollapsible.min.js") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
+        <script>window.LRR_BASEURL = "[% c.LRR_BASEURL %]";</script>
 	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/stats.js?$version") %]" type="text/JAVASCRIPT"></script>

--- a/templates/templates_config/config_theme.html.tt2
+++ b/templates/templates_config/config_theme.html.tt2
@@ -18,7 +18,7 @@
                 %]>
             <label for="modern">
                 <div id="modern-div" style="cursor:pointer">
-                    <img title="Hachikuji" src="img/theme_preview/hachikuji.png" class="theme-preview">
+                    <img title="Hachikuji" src="[% c.url_for("/img/theme_preview/hachikuji.png") %]" class="theme-preview">
                     <h3>Hachikuji</h3>
                 </div>
 
@@ -30,7 +30,7 @@
                 %]checked[% END %]>
             <label for="modern_clear">
                 <div id="modern-clear-div" style="cursor:pointer">
-                    <img title="Yotsugi" src="img/theme_preview/yotsugi.png" class="theme-preview">
+                    <img title="Yotsugi" src="[% c.url_for("/img/theme_preview/yotsugi.png") %]" class="theme-preview">
                     <h3>Yotsugi</h3>
                 </div>
             </label>
@@ -41,7 +41,7 @@
                 %]checked[% END %]>
             <label for="modern_red">
                 <div id="modern-red-div" style="cursor:pointer">
-                    <img title="Nadeko" src="img/theme_preview/nadeko.png" class="theme-preview">
+                    <img title="Nadeko" src="[% c.url_for("/img/theme_preview/nadeko.png") %]" class="theme-preview">
                     <h3>Nadeko</h3>
                 </div>
             </label>
@@ -51,7 +51,7 @@
             <input type="radio" id="ex" name="theme" value="ex.css" [% IF theme=="ex.css" %]checked[% END %]>
             <label for="ex">
                 <div id="ex-div" style="cursor:pointer">
-                    <img title="Sad Panda" src="img/theme_preview/sadpanda.png" class="theme-preview">
+                    <img title="Sad Panda" src="[% c.url_for("/img/theme_preview/sadpanda.png") %]" class="theme-preview">
                     <h3>Sad Panda</h3>
                 </div>
             </label>
@@ -61,7 +61,7 @@
             <input type="radio" id="g" name="theme" value="g.css" [% IF theme=="g.css" %]checked[% END %]>
             <label for="g">
                 <div id="g-div" style="cursor:pointer">
-                    <img title="H-Verse" src="img/theme_preview/hverse.png" class="theme-preview">
+                    <img title="H-Verse" src="[% c.url_for("/img/theme_preview/hverse.png") %]" class="theme-preview">
                     <h3>H-Verse</h3>
                 </div>
             </label>

--- a/templates/upload.html.tt2
+++ b/templates/upload.html.tt2
@@ -11,28 +11,28 @@
 
 	<link type="image/png" rel="icon" href="favicon.ico" />
 	<link rel="manifest" href="app.webappmanifest" />
-	<link rel="stylesheet" type="text/css" href="/css/lrr.css?[% version%]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/lrr.css?$version") %]" />
 
-	<link rel="stylesheet" type="text/css" href="./css/vendor/jquery.fileupload.css" />
-	<link rel="stylesheet" type="text/css" href="./css/vendor/fontawesome-all.min.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/ReactToastify.min.css" />
-	<link rel="stylesheet" type="text/css" href="/css/vendor/sweetalert2.min.css" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/jquery.fileupload.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/fontawesome-all.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/ReactToastify.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/sweetalert2.min.css") %]" />
 	[% csshead %]
 
-	<script src="./js/vendor/jquery.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/preact.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/hooks.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/compat.umd.js" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/jquery.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/preact.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/hooks.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/compat.umd.js") %]" type="text/JAVASCRIPT"></script>
 	<script>window.React = window.preactCompat; window.react = window.preactCompat;</script>
-	<script src="/js/vendor/clsx.min.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/react-toastify.umd.js" type="text/JAVASCRIPT"></script>
-	<script src="./js/vendor/jquery.ui.widget.js" type="text/JAVASCRIPT"></script>
-	<script src="./js/vendor/jquery.fileupload.js" type="text/JAVASCRIPT"></script>
-	<script src="/js/vendor/sweetalert2.min.js" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/clsx.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/react-toastify.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/jquery.ui.widget.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/jquery.fileupload.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
-	<script src="./js/common.js?[% version%]" type="text/JAVASCRIPT"></script>
-	<script src="./js/server.js?[% version%]" type="text/JAVASCRIPT"></script>
-	<script src="./js/upload.js?[% version%]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/upload.js?$version") %]" type="text/JAVASCRIPT"></script>
 </head>
 
 <body>
@@ -72,7 +72,7 @@
 				Download jobs will keep going even if you close this window!<br><br>
 
 				Type in your URLs (separated by a newline), and click the download button. <br>
-				If a <a href="/config/plugins">Downloader plugin</a> is compatible with the URL, it'll be automatically
+				If a <a href="[% c.url_for("/config/plugins") %]>Downloader plugin</a> is compatible with the URL, it'll be automatically
 				used.<br><br>
 
 				<label for="download_url">URL(s) to download:</label>

--- a/templates/upload.html.tt2
+++ b/templates/upload.html.tt2
@@ -30,6 +30,7 @@
 	<script src="[% c.url_for("/js/vendor/jquery.fileupload.js") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
+        <script>window.LRR_BASEURL = "[% c.LRR_BASEURL %]";</script>
 	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/upload.js?$version") %]" type="text/JAVASCRIPT"></script>

--- a/templates/upload.html.tt2
+++ b/templates/upload.html.tt2
@@ -30,7 +30,6 @@
 	<script src="[% c.url_for("/js/vendor/jquery.fileupload.js") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
 
-        <script>window.LRR_BASEURL = "[% c.LRR_BASEURL %]";</script>
 	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/upload.js?$version") %]" type="text/JAVASCRIPT"></script>

--- a/tests/opds.t
+++ b/tests/opds.t
@@ -49,6 +49,11 @@ $mojo->mock(
         my $tt = Template->new( { INCLUDE_PATH => $cwd . "/templates" } ) || die "$Template::ERROR\n";
         my $output;
 
+        # this mocks the Mojo url_for helper function, which is now
+        # used in the templates
+        $vars{c} = {
+            url_for => sub { return $_[0]; }
+        };
         $tt->process( $vars{template} . ".html.tt2", \%vars, \$output ) || die $tt->error(), "\n";
         return $output;
     }

--- a/tools/Documentation/advanced-usage/proxy-setup.md
+++ b/tools/Documentation/advanced-usage/proxy-setup.md
@@ -37,6 +37,38 @@ server {
 }
 ```
 
+By default, LRR runs at the server root,
+e.g. https://lanraragi.example.com/. You may wish to instead run it under a
+specific URL subdirectory, e.g. https://example.com/lanraragi/.
+
+This configuration requires that the reverse proxy be configured to strip the
+URL prefix from requests before forwarding it. For nginx, this is:
+
+```
+server {
+    # ...
+
+    location /lanraragi {
+        rewrite ^/lanraragi(.*)$ $1 last;
+        # ...rest of the block here
+    }
+}
+```
+
+After this is done, you need to configure LANraragi to use the new prefix. This
+is set under `lrr.conf` in the app root directory. Set the variable
+`base_url_path` as desired, e.g.:
+
+```
+{
+  # other directives...
+  base_url_path => "/lanraragi",
+}
+```
+
+Make sure to restart the server after editing `lrr.conf`. This will make the app
+available under `/lanraragi`.
+
 ## Setting up LANraragi to use a proxy for outbound network requests
 
 This is a less common scenario, but you might want to have downloads or metadata requests to external services go through a proxy, in case said external services are blocked by your friendly local totalitarian regime.  


### PR DESCRIPTION
This is toward adding a base URL feature, as discussed in https://github.com/Difegue/LANraragi/issues/363.

This works as follows: you can configure a reverse proxy server to forward traffic to LANraragi only under a given path. The proxy must be configured to strip the path prefix from the forwarded requests (e.g. in Caddy this is the `handle_path` directive, as opposed to `handle`). Once this is configured, LANraragi can be viewed as usual using subdirectories of that path. E.g. if a top-level deployment had the URL `manga.example.com`, a subdirectory deployment might have the URL `example.com/manga`. LANraragi can be used as normal, with all its internal URLs rewritten to be under the `/manga` subdirectory.

Internally, this works as follows: the reverse proxy strips the path prefix from requests as they pass through. Thus, LANraragi still sees ordinary requests to `/api`, `/js`, etc. However, all internal links generated by LANraragi are generated relative to the new path prefix. The user will click a link to `/manga/reader`, which will be processed into `/reader` by the reverse proxy. The main server-side system for this is the Mojo `url_for` helper (https://docs.mojolicious.org/Mojolicious/Controller#url_for). `url_for` constructs URLs relative to the incoming request URL's `base` member. Thus, when a base URL is configured, the `before_dispatch` hook alters the URL base to include that path prefix. This makes all URLs generated via `url_for` include it.

For the Javascript frontend, the base URL will be passed to the frontend via code in the template. Then, if configured, all API calls will be rewritten to include the base URL. This is not yet finished as I submit this draft.