### PR TITLE
Added search option to batch operations

### DIFF
--- a/public/js/batch.js
+++ b/public/js/batch.js
@@ -36,9 +36,10 @@ Batch.getSearchResults = function () {
     $("#loading-placeholder").show();
 
     let search_filter = $("#search-input").val();
-    Server.callAPI(`/api/search?filter=${search_filter}`, "GET", null, "Couldn't load search results!",
+    Server.callAPI(`/api/search?filter=${search_filter}&start=-1`, "GET", null, "Couldn't load search results!",
                    (resp) => {
                        let data = resp.data;
+                       $("#arclist").empty();
                        data.forEach((archive) => {
                            const escapedTitle = LRR.encodeHTML(archive.title) + (archive.isnew === "true" ? " 🆕" : "");
                            const html = `<li><input type='checkbox' name='archive' id='${archive.arcid}' class='archive' ><label for='${archive.arcid}'>${escapedTitle}</label></li>`;
@@ -58,6 +59,7 @@ Batch.getAllArchives = function () {
 
     Server.callAPI("/api/archives", "GET", null, "Couldn't load the complete archive list!",
         (data) => {
+            $("#arclist").empty();
             // Parse the archive list and add <li> elements to arclist
             data.forEach((archive) => {
                 const escapedTitle = LRR.encodeHTML(archive.title) + (archive.isnew === "true" ? " 🆕" : "");

--- a/public/js/common.js
+++ b/public/js/common.js
@@ -60,9 +60,12 @@ LRR.getTagSearchURL = function (namespace, tag) {
 };
 
 /**
- * Load tag suggestions for the tag search bar.
+ * Load tag suggestions for the tag search bar. input_tag is the
+ * selector to pass to the Awesomeplete constructor. instance_cb, if
+ * provided, will be invoked after construction with the Awesomeplete
+ * instance as argument.
  */
-LRR.setupTagSearchAutocomplete = function (input_tag) {
+LRR.setupTagSearchAutocomplete = function (input_tag, instance_cb) {
     // Query the tag cloud API to get the most used tags.
     Server.callAPI("/api/database/stats?minweight=2", "GET", null, "Couldn't load tag suggestions",
         (data) => {
@@ -75,8 +78,7 @@ LRR.setupTagSearchAutocomplete = function (input_tag) {
             });
 
             // Setup awesomplete for the tag search bar
-            // Index.awesomplete =
-            new Awesomplete(input_tag, {
+            let inst = new Awesomplete(input_tag, {
                 list: data,
                 data(tag) {
                     // Format tag objects from the API into a format awesomplete likes.
@@ -100,6 +102,10 @@ LRR.setupTagSearchAutocomplete = function (input_tag) {
                     this.input.value = `${before + text}$, `;
                 },
             });
+
+            if (instance_cb) {
+                instance_cb(inst);
+            }
         },
     );
 };

--- a/public/js/common.js
+++ b/public/js/common.js
@@ -60,6 +60,51 @@ LRR.getTagSearchURL = function (namespace, tag) {
 };
 
 /**
+ * Load tag suggestions for the tag search bar.
+ */
+LRR.setupTagSearchAutocomplete = function (input_tag) {
+    // Query the tag cloud API to get the most used tags.
+    Server.callAPI("/api/database/stats?minweight=2", "GET", null, "Couldn't load tag suggestions",
+        (data) => {
+            // Get namespaces objects in the data array to fill the namespace-sortby combobox
+            const namespacesSet = new Set(data.map((element) => (element.namespace === "parody" ? "series" : element.namespace)));
+            namespacesSet.forEach((element) => {
+                if (element !== "" && element !== "date_added") {
+                    $("#namespace-sortby").append(`<option value="${element}">${element.charAt(0).toUpperCase() + element.slice(1)}</option>`);
+                }
+            });
+
+            // Setup awesomplete for the tag search bar
+            // Index.awesomplete =
+            new Awesomplete(input_tag, {
+                list: data,
+                data(tag) {
+                    // Format tag objects from the API into a format awesomplete likes.
+                    let label = tag.text;
+                    if (tag.namespace !== "") label = `${tag.namespace}:${tag.text}`;
+
+                    return { label, value: tag.weight };
+                },
+                // Sort by weight
+                sort(a, b) {
+                    return b.value - a.value;
+                },
+                filter(text, input) {
+                    return Awesomplete.FILTER_CONTAINS(text, input.match(/[^, -]*$/)[0]);
+                },
+                item(text, input) {
+                    return Awesomplete.ITEM(text, input.match(/[^, -]*$/)[0]);
+                },
+                replace(text) {
+                    const before = this.input.value.match(/^.*(,|-)\s*-*|/)[0];
+                    this.input.value = `${before + text}$, `;
+                },
+            });
+        },
+    );
+};
+
+/**
  * Open the given URL in a new browser tab.
  * @param {*} url The URL
  */

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -4,7 +4,6 @@
  */
 const Index = {};
 Index.selectedCategory = "";
-Index.awesomplete = {};
 Index.carouselInitialized = false;
 Index.swiper = {};
 Index.serverVersion = "";
@@ -115,7 +114,7 @@ Index.initializeAll = function () {
             }
 
             Index.migrateProgress();
-            Index.loadTagSuggestions();
+            LRR.setupTagSearchAutocomplete('#search-input');
             Index.loadCategories();
 
             // Initialize DataTables
@@ -559,50 +558,6 @@ Index.handleContextMenu = function (option, id) {
     default:
         break;
     }
-};
-
-/**
- * Load tag suggestions for the tag search bar.
- */
-Index.loadTagSuggestions = function () {
-    // Query the tag cloud API to get the most used tags.
-    Server.callAPI("/api/database/stats?minweight=2", "GET", null, "Couldn't load tag suggestions",
-        (data) => {
-            // Get namespaces objects in the data array to fill the namespace-sortby combobox
-            const namespacesSet = new Set(data.map((element) => (element.namespace === "parody" ? "series" : element.namespace)));
-            namespacesSet.forEach((element) => {
-                if (element !== "" && element !== "date_added") {
-                    $("#namespace-sortby").append(`<option value="${element}">${element.charAt(0).toUpperCase() + element.slice(1)}</option>`);
-                }
-            });
-
-            // Setup awesomplete for the tag search bar
-            Index.awesomplete = new Awesomplete("#search-input", {
-                list: data,
-                data(tag) {
-                    // Format tag objects from the API into a format awesomplete likes.
-                    let label = tag.text;
-                    if (tag.namespace !== "") label = `${tag.namespace}:${tag.text}`;
-
-                    return { label, value: tag.weight };
-                },
-                // Sort by weight
-                sort(a, b) {
-                    return b.value - a.value;
-                },
-                filter(text, input) {
-                    return Awesomplete.FILTER_CONTAINS(text, input.match(/[^, -]*$/)[0]);
-                },
-                item(text, input) {
-                    return Awesomplete.ITEM(text, input.match(/[^, -]*$/)[0]);
-                },
-                replace(text) {
-                    const before = this.input.value.match(/^.*(,|-)\s*-*|/)[0];
-                    this.input.value = `${before + text}$, `;
-                },
-            });
-        },
-    );
 };
 
 /**

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -4,6 +4,7 @@
  */
 const Index = {};
 Index.selectedCategory = "";
+Index.awesomplete = {};
 Index.carouselInitialized = false;
 Index.swiper = {};
 Index.serverVersion = "";
@@ -114,7 +115,7 @@ Index.initializeAll = function () {
             }
 
             Index.migrateProgress();
-            LRR.setupTagSearchAutocomplete('#search-input');
+            LRR.setupTagSearchAutocomplete('#search-input', (inst) => { Index.awesomplete = inst; });
             Index.loadCategories();
 
             // Initialize DataTables

--- a/templates/batch.html.tt2
+++ b/templates/batch.html.tt2
@@ -17,6 +17,7 @@
 	<link rel="stylesheet" type="text/css" href="/css/vendor/fontawesome-all.min.css" />
 	<link rel="stylesheet" type="text/css" href="/css/vendor/ReactToastify.min.css" />
 	<link rel="stylesheet" type="text/css" href="/css/vendor/sweetalert2.min.css" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/awesomplete.css") %]" />
 	[% csshead %]
 
 	<script src="/js/vendor/jquery.min.js" type="text/JAVASCRIPT"></script>
@@ -27,6 +28,7 @@
 	<script src="/js/vendor/clsx.min.js" type="text/JAVASCRIPT"></script>
 	<script src="/js/vendor/react-toastify.umd.js" type="text/JAVASCRIPT"></script>
 	<script src="/js/vendor/sweetalert2.min.js" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/awesomplete.min.js") %]" type="text/JAVASCRIPT"></script>
 
 	<script src="/js/common.js?[% version%]" type="text/JAVASCRIPT"></script>
 	<script src="/js/server.js?[% version%]" type="text/JAVASCRIPT"></script>
@@ -42,6 +44,17 @@
 		You can apply modifications to multiple archives in one go here.<br><br>
 		Select what you'd like to do, check archives you want to use it on, and get rolling! <br>
 		Archives with no tags have been pre-checked.<br><br>
+
+		<div class='idi'>
+			<div id="category-container">
+				<!-- Categories go here -->
+			</div>
+			<input type='text' id='search-input' class='search stdinput' size='90' style='width:95%'
+			       placeholder='Search Title, Artist, Series, Language or Tags' />
+			<input id='use-search' class='searchbtn stdbtn' type='button' value='Use Search Results' />
+			<input id='use-all' class='searchbtn stdbtn' type='button' value='Use All Archives' />
+		</div>
+
 
 		<div style='margin-left:auto; margin-right:auto;'>
 			<div style='text-align:left; width:400px !important' class='left-column'>
@@ -204,11 +217,11 @@
 
 			<div class="id1 right-column"
 				style='text-align:center; min-width:400px; width: 60% !important; height:500px;'>
-				<ul class='checklist' id="arclist">
+				<ul class='checklist' id="arclist" style="display: none">
 				</ul>
 
 				<div id="loading-placeholder"
-					style="align-content: center;top: 150px; position: relative; margin-left: auto; margin-right: auto; width: 90%;">
+					style="align-content: center;top: 150px; position: relative; margin-left: auto; margin-right: auto; width: 90%; display: none">
 					<i class="fas fa-8x fa-spin fa-compact-disc"></i><br><br>
 					<h2>Preparing your data.</h2>
 				</div>


### PR DESCRIPTION
This is an initial implementation of some basic filtering for batch operations, as previously discussed in e.g. https://github.com/Difegue/LANraragi/issues/893 and https://github.com/Difegue/LANraragi/issues/570.

This basically just copies the search UI from the index page to the batch page, then populates the batch archive list from the search results instead of the all-archive list. The old behavior is available behind the "Use all archives" button. The batch page's search bar has tag autocomplete as well; to facilitate this, I moved the loadTagSuggestions function from index into common. That specific function could be pulled out with very little change.

The search UI is not complete here; it lacks categories or any way to apply other search filters. I'm primarily looking for feedback on the basic concept. Personally, this version satisfies one of my big problems with the batch operation interface.