### PR TITLE
Add testing for RegexParse

### DIFF
--- a/lib/LANraragi/Plugin/Metadata/RegexParse.pm
+++ b/lib/LANraragi/Plugin/Metadata/RegexParse.pm
@@ -5,14 +5,14 @@ use warnings;
 
 #Plugins can freely use all Perl packages already installed on the system
 #Try however to restrain yourself to the ones already installed for LRR (see tools/cpanfile) to avoid extra installations by the end-user.
-use Mojo::JSON qw(from_json);
 use File::Basename;
 use Scalar::Util qw(looks_like_number);
 
 #You can also use the LRR Internal API when fitting.
 use LANraragi::Model::Plugins;
 use LANraragi::Utils::Database qw(redis_encode redis_decode);
-use LANraragi::Utils::Logging  qw(get_logger);
+use LANraragi::Utils::Logging qw(get_plugin_logger);
+use LANraragi::Utils::String qw(trim);
 
 #Meta-information about your plugin.
 sub plugin_info {
@@ -39,7 +39,7 @@ sub get_tags {
     shift;
     my $lrr_info = shift;    # Global info hash
 
-    my $logger = get_logger( "regexparse", "plugins" );
+    my $logger = get_plugin_logger();
     my $file   = $lrr_info->{file_path};
 
     # lrr_info's file_path is taken straight from the filesystem, which might not be proper UTF-8.
@@ -61,7 +61,7 @@ sub get_tags {
     #Take variables from the regex selection
     if ( defined $2 ) { $event    = $2; }
     if ( defined $4 ) { $artist   = $4; }
-    if ( defined $5 ) { $title    = $5; }
+    if ( defined $5 ) { $title    = trim($5); }
     if ( defined $7 ) { $series   = $7; }
     if ( defined $9 ) { $language = $9; }
 

--- a/tests/LANraragi/Plugin/Metadata/RegexParse.t
+++ b/tests/LANraragi/Plugin/Metadata/RegexParse.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use utf8;
+
+use Cwd qw( getcwd );
+
+use Test::More;
+
+my $cwd     = getcwd();
+require "$cwd/tests/mocks.pl";
+
+use_ok('LANraragi::Plugin::Metadata::RegexParse');
+
+note("testing basic example");
+{
+    no warnings 'once', 'redefine';
+    local *LANraragi::Plugin::Metadata::RegexParse::get_plugin_logger        = sub { return get_logger_mock(); };
+
+    my %get_tags_params = ( file_path => "/poopoo/peepee/(Release) [Artist] TITLE (Series) [Language].arj" );
+
+    my %response = LANraragi::Plugin::Metadata::RegexParse::get_tags( "", \%get_tags_params );
+    is( $response{title}, "TITLE",  "Title was misparsed" );
+    is( $response{tags},  "event:Release, artist:Artist, series:Series, language:Language", "Wrong tags received" );
+}
+
+done_testing();


### PR DESCRIPTION
RegexParse didn't have tests, so now it does. Also ensure that the title gets trimmed (previously there was a space at the end).