### PR TITLE
plugin loader should do all the checks

### DIFF
--- a/lib/LANraragi/Utils/Plugins.pm
+++ b/lib/LANraragi/Utils/Plugins.pm
@@ -29,6 +29,12 @@ sub get_plugins {
         # Check that the metadata sub is there before invoking it
         if ( $plugin->can('plugin_info') ) {
             my %pluginfo = $plugin->plugin_info();
+
+            if    ( $type eq 'script' )   { next if ( !$plugin->can('run_script') ); }
+            elsif ( $type eq 'metadata' ) { next if ( !$plugin->can('get_tags') ); }
+            elsif ( $type eq 'download' ) { next if ( !$plugin->can('provide_url') ); }
+            elsif ( $type eq 'login' )    { next if ( !$plugin->can('do_login') ); }
+
             if ( $pluginfo{type} eq $type || $type eq "all" ) { push( @validplugins, \%pluginfo ); }
         }
     }

--- a/tests/LANraragi/Model/Plugins.t
+++ b/tests/LANraragi/Model/Plugins.t
@@ -36,19 +36,6 @@ note('calling exec_metadata_plugin without providing an ID');
     cmp_deeply( \%rdata, { 'error' => re('without providing an id') }, 'returned error' );
 }
 
-note('calling exec_metadata_plugin with a plugin without get_tags sub');
-{
-    no warnings 'once', 'redefine';
-    local *LANraragi::Model::Plugins::get_logger = sub { return get_logger_mock() };
-
-    my $plugin_mock = Test::MockObject->new();
-
-    my %rdata = LANraragi::Model::Plugins::exec_metadata_plugin( $plugin_mock, 'dummy', undef, undef );
-
-    cmp_deeply( \%rdata, { 'error' => re('get_tags') }, 'returned error' );
-
-}
-
 note('exec_metadata_plugin doesn\'t die when get_tags fails');
 {
     my $plugin_mock = Test::MockObject->new();


### PR DESCRIPTION
I think we should rely on the plugin loader to check the required subs. This would make the code simpler.

With this PR we loose the visibility of the invalid plugins, but it's not a problem for the official ones.
If it's necessary, `get_plugins()` can also return a list of invalid plugins to be used inside the startup sub.