### PR TITLE
[nHentai] Add support to set upload date in timestamp field using epoch stamp

### DIFF
--- a/lib/LANraragi/Plugin/Metadata/nHentai.pm
+++ b/lib/LANraragi/Plugin/Metadata/nHentai.pm
@@ -31,7 +31,7 @@ sub plugin_info {
           <br><i class='fa fa-exclamation-circle'></i> This plugin will use the source: tag of the archive if it exists.",
         icon =>
           "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAAACXBIWXMAAAsTAAALEwEAmpwYAAAA\nB3RJTUUH4wYCFA8s1yKFJwAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUH\nAAACL0lEQVQ4y6XTz0tUURQH8O+59773nLFcaGWTk4UUVCBFiJs27VxEQRH0AyRo4x8Q/Qtt2rhr\nU6soaCG0KYKSwIhMa9Ah+yEhZM/5oZMG88N59717T4sxM8eZCM/ycD6Xwznn0pWhG34mh/+PA8mk\n8jO5heziP0sFYwfgMDFQJg4IUjmquSFGG+OIlb1G9li5kykgTgvzSoUCaIYlo8/Igcjpj5wOkARp\n8AupP0uzJLijCY4zzoXOxdBLshAgABr8VOp7bpAXDEI7IBrhdksnjNr3WzI4LaIRV9fk2iAaYV/y\nA1dPiYjBAALgpQxnhV2XzTCAGWGeq7ACBvCdzKQyTH+voAm2hGlpcmQt2Bc2K+ymAhWPxTzPDQLt\nOKo1FiNBQaArq9WNRQwEgKl7XQ1duzSRSn/88vX0qf7DPQddx1nI5UfHxt+m0sLYPiP3shRAG8MD\nok1XEEXR/EI2ly94nrNYWG6Nx0/2Hp2b94dv34mlZge1e4hVCJ4jc6tl9ZP803n3/i4lpdyzq2N0\n7M3DkSeF5ZVYS8v1qxcGz5+5eey4nPDbmGdE9FpGeWErVNe2tTabX3r0+Nk3PwOgXFkdfz99+exA\nMtFZITEt9F23mpLG0hYTVQCKpfKPlZ/rqWKpYoAPcTmpginW76QBbb0OBaBaDdjaDbNlJmQE3/d0\nMYoaybU9126oPkrEhpr+U2wjtoVVGBowkslEsVSupRKdu0Mduq7q7kqExjSS3V2dvwDLavx0eczM\neAAAAABJRU5ErkJggg==",
-        parameters  => [ { type => "bool", desc => "Add 'date_uploaded' tag" } ],
+        parameters  => [ { type => "bool", desc => "Fetch date uploaded and set timestamp tag" } ],
         oneshot_arg => "nHentai Gallery URL (Will attach tags matching this exact gallery to your archive)"
     );
 
@@ -232,7 +232,7 @@ sub get_tags_from_NH {
         my @tags = get_tags_from_json($json);
         if ($add_uploaded) {
             my @upload = get_upload_from_json($json);
-            push( @tags, "date_uploaded:@upload");
+            push( @tags, "timestamp:@upload");
         }
         push( @tags, "source:nhentai.net/g/$gID" ) if ( @tags > 0 );
 

--- a/lib/LANraragi/Plugin/Metadata/nHentai.pm
+++ b/lib/LANraragi/Plugin/Metadata/nHentai.pm
@@ -31,7 +31,7 @@ sub plugin_info {
           <br><i class='fa fa-exclamation-circle'></i> This plugin will use the source: tag of the archive if it exists.",
         icon =>
           "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAIAAAAC64paAAAACXBIWXMAAAsTAAALEwEAmpwYAAAA\nB3RJTUUH4wYCFA8s1yKFJwAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUH\nAAACL0lEQVQ4y6XTz0tUURQH8O+59773nLFcaGWTk4UUVCBFiJs27VxEQRH0AyRo4x8Q/Qtt2rhr\nU6soaCG0KYKSwIhMa9Ah+yEhZM/5oZMG88N59717T4sxM8eZCM/ycD6Xwznn0pWhG34mh/+PA8mk\n8jO5heziP0sFYwfgMDFQJg4IUjmquSFGG+OIlb1G9li5kykgTgvzSoUCaIYlo8/Igcjpj5wOkARp\n8AupP0uzJLijCY4zzoXOxdBLshAgABr8VOp7bpAXDEI7IBrhdksnjNr3WzI4LaIRV9fk2iAaYV/y\nA1dPiYjBAALgpQxnhV2XzTCAGWGeq7ACBvCdzKQyTH+voAm2hGlpcmQt2Bc2K+ymAhWPxTzPDQLt\nOKo1FiNBQaArq9WNRQwEgKl7XQ1duzSRSn/88vX0qf7DPQddx1nI5UfHxt+m0sLYPiP3shRAG8MD\nok1XEEXR/EI2ly94nrNYWG6Nx0/2Hp2b94dv34mlZge1e4hVCJ4jc6tl9ZP803n3/i4lpdyzq2N0\n7M3DkSeF5ZVYS8v1qxcGz5+5eey4nPDbmGdE9FpGeWErVNe2tTabX3r0+Nk3PwOgXFkdfz99+exA\nMtFZITEt9F23mpLG0hYTVQCKpfKPlZ/rqWKpYoAPcTmpginW76QBbb0OBaBaDdjaDbNlJmQE3/d0\nMYoaybU9126oPkrEhpr+U2wjtoVVGBowkslEsVSupRKdu0Mduq7q7kqExjSS3V2dvwDLavx0eczM\neAAAAABJRU5ErkJggg==",
-        parameters  => [],
+        parameters  => [ { type => "bool", desc => "Add 'date_uploaded' tag" } ],
         oneshot_arg => "nHentai Gallery URL (Will attach tags matching this exact gallery to your archive)"
     );
 
@@ -43,6 +43,7 @@ sub get_tags {
     shift;
     my $lrr_info = shift;                      # Global info hash
     my $ua       = $lrr_info->{user_agent};    # UserAgent from login plugin
+    my ($add_uploaded) = @_;                   # Parameters
 
     my $logger = get_plugin_logger();
 
@@ -77,7 +78,7 @@ sub get_tags {
 
     $logger->debug("Detected nHentai gallery ID is $galleryID");
 
-    my %hashdata = get_tags_from_NH( $galleryID, $ua );
+    my %hashdata = get_tags_from_NH( $galleryID, $ua, $add_uploaded );
 
     $logger->info( "Sending the following tags to LRR: " . $hashdata{tags} );
 
@@ -213,9 +214,14 @@ sub get_title_from_json {
     return $json->{"title"}{"pretty"};
 }
 
+sub get_upload_from_json {
+    my ($json) = @_;
+    return $json->{"upload_date"};
+}
+
 sub get_tags_from_NH {
 
-    my ( $gID, $ua ) = @_;
+    my ( $gID, $ua, $add_uploaded ) = @_;
 
     my %hashdata = ( tags => "" );
 
@@ -224,6 +230,10 @@ sub get_tags_from_NH {
 
     if ($json) {
         my @tags = get_tags_from_json($json);
+        if ($add_uploaded) {
+            my @upload = get_upload_from_json($json);
+            push( @tags, "date_uploaded:@upload");
+        }
         push( @tags, "source:nhentai.net/g/$gID" ) if ( @tags > 0 );
 
         # Use NH's "pretty" names (romaji titles without extraneous data we already have like (Event)[Artist], etc)


### PR DESCRIPTION
Adds support for retrieving and using the epoch upload date stamp in the json data and including it as a ~~date_uploaded~~ timestamp tag.  I also added a toggle so that if a user doesn't want it then it doesn't bother to parse it out.  This is consistent with other plugins that support this functionality.