### PR TITLE
Fix documentation error

### DIFF
--- a/tools/Documentation/plugin-docs/download.md
+++ b/tools/Documentation/plugin-docs/download.md
@@ -89,7 +89,7 @@ sub plugin_info {
 }
 
 ## Mandatory function to be implemented by your script
-sub run_script {
+sub provide_url {
     shift;
     my $lrr_info = shift; # Global info hash
     my ($useposts) = @_; # Plugin parameters


### PR DESCRIPTION
The name of the subroutine should be `provide_url` instead of `run_script`.