### PR TITLE
add option to use FAKKU plugin safely

### DIFF
--- a/lib/LANraragi/Plugin/Metadata/Fakku.pm
+++ b/lib/LANraragi/Plugin/Metadata/Fakku.pm
@@ -25,7 +25,7 @@ sub plugin_info {
         namespace   => "fakkumetadata",
         login_from  => "fakkulogin",
         author      => "Difegue, Nodja, Nixis198",
-        version     => "0.98",
+        version     => "0.99",
         description =>
           "Searches FAKKU for tags matching your archive. If you have an account, don't forget to enter the matching cookie in the login plugin to be able to access controversial content. <br/><br/>
            <i class='fa fa-exclamation-circle'></i> <b>This plugin can and will return invalid results depending on what you're searching for!</b> <br/>The FAKKU search API isn't very precise and I recommend you either enable 'Only use current title for exact matches', or use the Chaika.moe plugin when possible.",

--- a/lib/LANraragi/Plugin/Metadata/Fakku.pm
+++ b/lib/LANraragi/Plugin/Metadata/Fakku.pm
@@ -28,11 +28,11 @@ sub plugin_info {
         version     => "0.98",
         description =>
           "Searches FAKKU for tags matching your archive. If you have an account, don't forget to enter the matching cookie in the login plugin to be able to access controversial content. <br/><br/>
-           <i class='fa fa-exclamation-circle'></i> <b>This plugin can and will return invalid results depending on what you're searching for!</b> <br/>The FAKKU search API isn't very precise and I recommend you use the Chaika.moe plugin when possible.",
+           <i class='fa fa-exclamation-circle'></i> <b>This plugin can and will return invalid results depending on what you're searching for!</b> <br/>The FAKKU search API isn't very precise and I recommend you either enable 'Only use current title for exact matches', or use the Chaika.moe plugin when possible.",
         icon =>
           "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAACZSURBVDhPlY+xDYQwDEWvZgRGYA22Y4frqJDSZhFugiuuo4cqPGT0iTjAYL3C+fGzktc3hEcsQvJq6HtjE2Jdv4viH4a4pWnL8q4A6g+ET9P8YhS2/kqwIZXWnwqChDxPfCFfD76wOzJ2IOR/0DSwnuRKYAKUW3gq2OsJTYM0jr7QVRVwlabJEaw3ARYBcmFXeomxphIeEMIMmh3lOLQR+QQAAAAASUVORK5CYII=",
         oneshot_arg => "FAKKU Gallery URL (Will attach tags matching this exact gallery to your archive)",
-        parameters  => [ { type => "bool", desc => "Add 'Source' tag" } ]
+        parameters  => [ { type => "bool", desc => "Add 'Source' tag" }, { type => "bool", desc => "Only use current title for exact matches" } ]
     );
 
 }
@@ -43,7 +43,7 @@ sub get_tags {
     shift;
     my $lrr_info     = shift;                     # Global info hash
     my $ua           = $lrr_info->{user_agent};
-    my ($add_source) = @_;
+    my ($add_source, $safe_mode) = @_;
 
     my $logger = get_plugin_logger();
 
@@ -60,6 +60,9 @@ sub get_tags {
     # No URL? Looks for the "source:" in the existing tags.
     $fakku_URL = get_url_from_tags( $lrr_info->{existing_tags} ) if ( !$fakku_URL );
 
+    # Assume URLs coming from the one-shot parameter or tags are reliable.
+    my $URL_safe = !!$fakku_URL;
+
     # Still nothing? Search for a FAKKU URL using the title
     $fakku_URL = search_for_fakku_url( $lrr_info->{archive_title}, $ua ) if ( !$fakku_URL );
 
@@ -72,6 +75,13 @@ sub get_tags {
     $logger->debug("Detected FAKKU URL: $fakku_URL");
 
     my ( $newtags, $newtitle, $newSummary ) = get_tags_from_fakku( $fakku_URL, $ua, $add_source );
+
+    my $current_title = $lrr_info->{archive_title};
+
+    if ($safe_mode && !$URL_safe && $newtitle ne $current_title) {
+        $logger->info("Found FAKKU Gallery '$newtitle', but it does not match current title '$current_title' exactly");
+        die "Exact title match not found\n";
+    }
 
     $logger->info("Sending the following tags to LRR: $newtags");
 


### PR DESCRIPTION
Since the FAKKU search API is unreliable, this allows the user to reject search results whose title doesn't match the current title exactly.
URLs coming from source tags or the one-shot parameter are assumed to be reliable since they are given explicitly.

This prevents the plugin from adding metadata from the wrong manga, which is particularly useful in batch operations or automatic runs, which destructively modify metadata without user input.

This does have the trade-off of causing more false negatives, and may require some preprocessing on the archive to obtain the correct title, such as using the filename parsing plugin, hence the toggle.