### PR TITLE
Named params

### DIFF
--- a/lib/LANraragi/Controller/Api/Minion.pm
+++ b/lib/LANraragi/Controller/Api/Minion.pm
@@ -7,7 +7,7 @@ use Redis;
 use LANraragi::Model::Stats;
 use LANraragi::Utils::TempFolder qw(get_tempsize clean_temp_full);
 use LANraragi::Utils::Generic    qw(render_api_response);
-use LANraragi::Utils::Plugins    qw(get_plugin get_plugins get_plugin_parameters use_plugin);
+use LANraragi::Utils::Plugins    qw(get_plugin get_plugins use_plugin);
 
 # Returns basic info for the given Minion job id.
 sub minion_job_status {

--- a/lib/LANraragi/Controller/Api/Other.pm
+++ b/lib/LANraragi/Controller/Api/Other.pm
@@ -8,7 +8,7 @@ use LANraragi::Model::Stats;
 use LANraragi::Model::Opds;
 use LANraragi::Utils::TempFolder qw(get_tempsize clean_temp_full);
 use LANraragi::Utils::Generic    qw(render_api_response);
-use LANraragi::Utils::Plugins    qw(get_plugin get_plugins get_plugin_parameters use_plugin);
+use LANraragi::Utils::Plugins    qw(get_plugin get_plugins use_plugin);
 
 sub serve_serverinfo {
     my $self = shift;

--- a/lib/LANraragi/Controller/Batch.pm
+++ b/lib/LANraragi/Controller/Batch.pm
@@ -18,6 +18,19 @@ sub index {
     #Build plugin listing
     my @pluginlist = get_plugins("metadata");
 
+    for ( my $i = 0; $i < scalar @pluginlist; $i++ ) {
+        my $plugin = $pluginlist[$i];
+        if ( ref( $plugin->{parameters} ) eq 'HASH' ) {
+            my @params;
+            foreach my $key ( sort keys %{ $plugin->{parameters} } ) {
+                my $param = $plugin->{parameters}{$key};
+                $param->{name} = $key;
+                push( @params, $param );
+            }
+            $pluginlist[$i]->{parameters} = \@params;
+        }
+    }
+
     # Get static category list
     my @categories = LANraragi::Model::Category->get_static_category_list;
 
@@ -80,21 +93,28 @@ sub socket {
                 }
 
                 # Global arguments can come from the database or the user override
-                my @args = @{ $command->{"args"} };
+                my @args_override = @{ $command->{"args"} };
 
-                if ( !@args ) {
-                    $logger->debug("No user overrides given.");
+                # get the saved defaults
+                my %args = get_plugin_parameters($pluginname);
+                if (@args_override) {
 
-                    # Try getting the saved defaults
-                    @args = get_plugin_parameters($pluginname);
-                } else {
+                    $logger->debug("Overriding configured parameters");
+                    if ( exists $args{customargs} ) {
 
-                    # Decode user overrides
-                    @args = map { redis_decode($_) } @args;
+                        # Decode user overrides
+                        $args{customargs} = [ map { redis_decode($_) } @args_override ];
+                    } else {
+                        my @keys = sort grep { $_ !~ m/^enabled$/ } keys %args;
+                        while ( my ( $idx, $key ) = each @keys ) {
+                            $args{customargs}{$key} = redis_decode( $args_override[$idx] );
+                        }
+                    }
+
                 }
 
                 # Send reply message for completed archive
-                $client->send( { json => batch_plugin( $id, $plugin, @args ) } );
+                $client->send( { json => batch_plugin( $id, $plugin, %args ) } );
                 return;
             }
 
@@ -197,10 +217,10 @@ sub socket {
 }
 
 sub batch_plugin {
-    my ( $id, $plugin, @args ) = @_;
+    my ( $id, $plugin, %args ) = @_;
 
     # Run plugin with args on id
-    my %plugin_result = LANraragi::Model::Plugins::exec_metadata_plugin( $plugin, $id, "", @args );
+    my %plugin_result = LANraragi::Model::Plugins::exec_metadata_plugin( $plugin, $id, %args );
 
     # If the plugin exec returned tags, add them
     unless ( exists $plugin_result{error} ) {

--- a/lib/LANraragi/Controller/Plugins.pm
+++ b/lib/LANraragi/Controller/Plugins.pm
@@ -155,7 +155,7 @@ sub save_config {
 
                 $redis->hset( $namerds, "enabled", $enabled );
 
-            }    # else { # no parameters }
+            }    
 
         }
     } catch ($e) {

--- a/lib/LANraragi/Controller/Plugins.pm
+++ b/lib/LANraragi/Controller/Plugins.pm
@@ -56,6 +56,7 @@ sub craft_plugin_array {
         my @paramhashes = ();
         my $counter     = 0;
 
+        # For backwards compatibility, we can return either an array or a hash for plugin parameters
         if ( ref( $pluginfo->{parameters} ) eq 'ARRAY' ) {
             my @redisparams = @{ $paramsconf{'customargs'} };
             foreach my $param ( @{ $pluginfo->{parameters} } ) {

--- a/lib/LANraragi/Controller/Plugins.pm
+++ b/lib/LANraragi/Controller/Plugins.pm
@@ -140,8 +140,8 @@ sub save_config {
 
             } elsif ( ref( $pluginfo->{parameters} ) eq 'HASH' ) {
 
-                # TODO: remove this line ofter the termination of the support
-                # of the array parameters
+                # TODO: remove this line (and the ARRAY check above) 
+                # after plugins with array parameters are deprecated
                 $redis->del($namerds);
 
                 #Loop through the namespaced request parameters

--- a/lib/LANraragi/Controller/Plugins.pm
+++ b/lib/LANraragi/Controller/Plugins.pm
@@ -54,10 +54,10 @@ sub craft_plugin_array {
 
         # Add redis values to the members of the parameters array
         my @paramhashes = ();
-        my $counter     = 0;
 
         # For backwards compatibility, we can return either an array or a hash for plugin parameters
         if ( ref( $pluginfo->{parameters} ) eq 'ARRAY' ) {
+            my $counter     = 0;
             my @redisparams = @{ $paramsconf{'customargs'} };
             foreach my $param ( @{ $pluginfo->{parameters} } ) {
                 $param->{value} = $redisparams[$counter];
@@ -141,7 +141,7 @@ sub save_config {
 
             } elsif ( ref( $pluginfo->{parameters} ) eq 'HASH' ) {
 
-                # TODO: remove this line (and the ARRAY check above) 
+                # TODO: remove this line (and the ARRAY check above)
                 # after plugins with array parameters are deprecated
                 $redis->del($namerds);
 
@@ -156,7 +156,7 @@ sub save_config {
 
                 $redis->hset( $namerds, "enabled", $enabled );
 
-            }    
+            }
 
         }
     } catch ($e) {

--- a/lib/LANraragi/Model/Plugins.pm
+++ b/lib/LANraragi/Model/Plugins.pm
@@ -109,7 +109,7 @@ sub exec_login_plugin {
         if ( has_old_style_params(%loginargs) ) {
             $loggedinua = $loginplugin->do_login( @{ $loginargs{customargs} } );
         } else {
-            $loggedinua = $loginplugin->do_login(%loginargs);
+            $loggedinua = $loginplugin->do_login( \%loginargs );
         }
 
         if ( ref($loggedinua) eq "Mojo::UserAgent" ) {
@@ -146,7 +146,7 @@ sub exec_script_plugin {
         if ( has_old_style_params(%settings) ) {
             return $plugin->run_script( \%infohash, @{ $settings{customargs} } );
         } else {
-            return $plugin->run_script( \%infohash, %settings );
+            return $plugin->run_script( \%infohash, \%settings );
         }
     } catch ($e) {
         return ( error => $e );
@@ -244,7 +244,7 @@ sub exec_metadata_plugin {
         if ( has_old_style_params(%args) ) {
             %newmetadata = $plugin->get_tags( \%infohash, @{ $args{customargs} } );
         } else {
-            %newmetadata = $plugin->get_tags( \%infohash, %args );
+            %newmetadata = $plugin->get_tags( \%infohash, \%args );
         }
 
         # TODO: remove this block after changing all the metadata plugins

--- a/lib/LANraragi/Model/Plugins.pm
+++ b/lib/LANraragi/Model/Plugins.pm
@@ -19,6 +19,7 @@ use LANraragi::Utils::Database qw(set_tags set_title set_summary);
 use LANraragi::Utils::Archive  qw(extract_thumbnail);
 use LANraragi::Utils::Logging  qw(get_logger);
 use LANraragi::Utils::Tags     qw(rewrite_tags split_tags_to_array);
+use LANraragi::Utils::Plugins  qw(get_plugin_parameters get_plugin);
 
 # Sub used by Auto-Plugin.
 sub exec_enabled_plugins_on_file {
@@ -50,13 +51,13 @@ sub exec_enabled_plugins_on_file {
 
     foreach my $pluginfo (@plugins) {
         my $name   = $pluginfo->{namespace};
-        my @args   = LANraragi::Utils::Plugins::get_plugin_parameters($name);
-        my $plugin = LANraragi::Utils::Plugins::get_plugin($name);
+        my %args   = get_plugin_parameters($name);
+        my $plugin = get_plugin($name);
         my %plugin_result;
 
         my %pluginfo = $plugin->plugin_info();
 
-        %plugin_result = exec_metadata_plugin( $plugin, $id, "", @args );
+        %plugin_result = exec_metadata_plugin( $plugin, $id, %args );
 
         if ( exists $plugin_result{error} ) {
             $failures++;
@@ -101,10 +102,15 @@ sub exec_login_plugin {
 
     if ($plugname) {
         $logger->debug("Calling matching login plugin $plugname.");
-        my $loginplugin = LANraragi::Utils::Plugins::get_plugin($plugname);
-        my @loginargs   = LANraragi::Utils::Plugins::get_plugin_parameters($plugname);
+        my $loginplugin = get_plugin($plugname);
+        my %loginargs   = get_plugin_parameters($plugname);
 
-        my $loggedinua = $loginplugin->do_login(@loginargs);
+        my $loggedinua;
+        if ( has_old_style_params(%loginargs) ) {
+            $loggedinua = $loginplugin->do_login( @{ $loginargs{customargs} } );
+        } else {
+            $loggedinua = $loginplugin->do_login(%loginargs);
+        }
 
         if ( ref($loggedinua) eq "Mojo::UserAgent" ) {
             return $loggedinua;
@@ -121,7 +127,7 @@ sub exec_login_plugin {
 
 sub exec_script_plugin {
 
-    my ( $plugin, $input, @settings ) = @_;
+    my ( $plugin, %settings ) = @_;
 
     no warnings 'experimental::try';
 
@@ -132,12 +138,16 @@ sub exec_script_plugin {
         # Bundle all the potentially interesting info in a hash
         my %infohash = (
             user_agent    => $ua,
-            oneshot_param => $input
+            oneshot_param => $settings{'oneshot'}    # for old style plugins compatibility
         );
 
         # Scripts don't have any predefined metadata in their spec so they're just ran as-is.
         # They can return whatever the heck they want in their hash as well, they'll just be shown as-is in the API output.
-        return $plugin->run_script( \%infohash, @settings );
+        if ( has_old_style_params(%settings) ) {
+            return $plugin->run_script( \%infohash, @{ $settings{customargs} } );
+        } else {
+            return $plugin->run_script( \%infohash, %settings );
+        }
     } catch ($e) {
         return ( error => $e );
     }
@@ -178,7 +188,7 @@ sub exec_download_plugin {
 # Execute a specified plugin on a file, described through its Redis ID.
 sub exec_metadata_plugin {
 
-    my ( $plugin, $id, $oneshotarg, @args ) = @_;
+    my ( $plugin, $id, %args ) = @_;
 
     no warnings 'experimental::try';
 
@@ -226,12 +236,16 @@ sub exec_metadata_plugin {
             thumbnail_hash => $thumbhash,
             file_path      => $file,
             user_agent     => $ua,
-            oneshot_param  => $oneshotarg
+            oneshot_param  => $args{'oneshot'}    # for old style plugins compatibility
         );
 
         my %newmetadata;
 
-        %newmetadata = $plugin->get_tags( \%infohash, @args );
+        if ( has_old_style_params(%args) ) {
+            %newmetadata = $plugin->get_tags( \%infohash, @{ $args{customargs} } );
+        } else {
+            %newmetadata = $plugin->get_tags( \%infohash, %args );
+        }
 
         # TODO: remove this block after changing all the metadata plugins
         #Error checking
@@ -282,6 +296,12 @@ sub exec_metadata_plugin {
     }
 
     return %returnhash;
+}
+
+# TODO: remove after the deprecation period
+sub has_old_style_params {
+    my (%params) = @_;
+    return ( exists $params{'customargs'} );
 }
 
 1;

--- a/lib/LANraragi/Plugin/Metadata/CopyArchiveTags.pm
+++ b/lib/LANraragi/Plugin/Metadata/CopyArchiveTags.pm
@@ -33,11 +33,11 @@ sub plugin_info {
 }
 
 sub get_tags {
-    my ( undef, $lrr_info, %params ) = @_;
+    my ( undef, $lrr_info, $params ) = @_;
 
     my $logger = get_plugin_logger();
 
-    my $lrr_gid = extract_archive_id( $params{oneshot} );
+    my $lrr_gid = extract_archive_id( $params->{oneshot} );
     if ( !$lrr_gid ) {
         die "oneshot_param doesn't contain a valid archive ID\n";
     }
@@ -50,7 +50,7 @@ sub get_tags {
 
     my $tags = LANraragi::Utils::Database::get_tags($lrr_gid) || '';
 
-    if ( !$params{'copy_date_added'} ) {
+    if ( !$params->{'copy_date_added'} ) {
         my @tags = split_tags_to_array($tags);
         $tags = join_tags_to_string( grep( !m/date_added/, @tags ) );
     }

--- a/lib/LANraragi/Plugin/Metadata/CopyArchiveTags.pm
+++ b/lib/LANraragi/Plugin/Metadata/CopyArchiveTags.pm
@@ -33,7 +33,8 @@ sub plugin_info {
 }
 
 sub get_tags {
-    my ( undef, $lrr_info, $params ) = @_;
+    shift;
+    my ( $lrr_info, $params ) = @_;
 
     my $logger = get_plugin_logger();
 

--- a/lib/LANraragi/Plugin/Metadata/CopyArchiveTags.pm
+++ b/lib/LANraragi/Plugin/Metadata/CopyArchiveTags.pm
@@ -14,13 +14,14 @@ sub plugin_info {
 
     return (
         #Standard metadata
-        name        => "Copy Archive Tags",
-        type        => "metadata",
-        namespace   => "copy-archive-tags",
-        author      => "IceBreeze",
-        version     => "1.2",
-        description => "Copy tags from another LRR archive given either the URI or the ID.",
-        parameters  => {
+        name            => "Copy Archive Tags",
+        type            => "metadata",
+        namespace       => "copy-archive-tags",
+        author          => "IceBreeze",
+        version         => "1.2",
+        description     => "Copy tags from another LRR archive given either the URI or the ID.",
+        to_named_params => ['copy_date_added'],
+        parameters      => {
             'copy_date_added' => {
                 type => "bool",
                 desc => "Enable to also copy the date (but it's up to you to remove the old one)"

--- a/lib/LANraragi/Utils/Minion.pm
+++ b/lib/LANraragi/Utils/Minion.pm
@@ -224,9 +224,9 @@ sub add_tasks {
                 # Use the downloader to transform the URL
                 my $plugname = $downloader->{namespace};
                 my $plugin   = get_plugin($plugname);
-                my @settings = get_plugin_parameters($plugname);
+                my %settings = get_plugin_parameters($plugname);
 
-                my $plugin_result = LANraragi::Model::Plugins::exec_download_plugin( $plugin, $url, @settings );
+                my $plugin_result = LANraragi::Model::Plugins::exec_download_plugin( $plugin, $url, %settings );
 
                 if ( exists $plugin_result->{error} ) {
                     $job->finish(

--- a/templates/plugins.html.tt2
+++ b/templates/plugins.html.tt2
@@ -133,7 +133,7 @@
 [% FOREACH plugin IN plugins %]
 <span style="display:inline-block; text-align: left; width:80%; border-bottom-width: 1px;border-bottom-style: solid">
 	[% IF plugin.icon %]
-        [%# the plugin.icon attr is always a data: URI, so we don't need to worry about the base URL %]
+	[%# the plugin.icon attr is always a data: URI, so we don't need to worry about the base URL %]
 	<img height=20 width=20 src="[% plugin.icon %]" />
 	[% ELSE %]
 	<i class="fa fa-puzzle-piece" style="font-size:20px"></i>
@@ -204,7 +204,7 @@
 						<b> [% param.desc %] : </b>
 					</td>
 					<td>
-						<input style="max-width:200px" size="20" name="[% plugin.namespace %]_CFG_[% loop.count %]"
+						<input style="max-width:200px" size="20" name="[% plugin.namespace %]_CFG_[% IF param.exists('name') %][% param.name %][% ELSE %][% loop.count %][% END %]"
 							type=[% SWITCH param.type %] # time for some real-ass typage [% CASE 'string' %] "text"
 							value="[% param.value %]" class="stdinput" [% CASE 'bool' %] "checkbox" value="1" class="fa"
 							[% IF param.value %] checked [% END %] [% CASE 'int' %] "number" value="[% param.value %]"

--- a/tests/LANraragi/Model/Plugins.t
+++ b/tests/LANraragi/Model/Plugins.t
@@ -23,15 +23,15 @@ note('calling exec_metadata_plugin without providing an ID');
     no warnings 'once', 'redefine';
     local *LANraragi::Model::Plugins::get_logger = sub { return get_logger_mock() };
 
-    my %rdata = LANraragi::Model::Plugins::exec_metadata_plugin( undef, undef, undef, undef );
+    my %rdata = LANraragi::Model::Plugins::exec_metadata_plugin( undef, undef, () );
 
     cmp_deeply( \%rdata, { 'error' => re('without providing an id') }, 'returned error' );
 
-    %rdata = LANraragi::Model::Plugins::exec_metadata_plugin( undef, 0, undef, undef );
+    %rdata = LANraragi::Model::Plugins::exec_metadata_plugin( undef, 0, () );
 
     cmp_deeply( \%rdata, { 'error' => re('without providing an id') }, 'returned error' );
 
-    %rdata = LANraragi::Model::Plugins::exec_metadata_plugin( undef, '', undef, undef );
+    %rdata = LANraragi::Model::Plugins::exec_metadata_plugin( undef, '', () );
 
     cmp_deeply( \%rdata, { 'error' => re('without providing an id') }, 'returned error' );
 }
@@ -52,7 +52,7 @@ note('exec_metadata_plugin doesn\'t die when get_tags fails');
     local *LANraragi::Model::Config::enable_tagrules = sub { return; };
 
     # Act
-    my %rdata = LANraragi::Model::Plugins::exec_metadata_plugin( $plugin_mock, 'dummy', undef, undef );
+    my %rdata = LANraragi::Model::Plugins::exec_metadata_plugin( $plugin_mock, 'dummy', () );
 
     cmp_deeply( \%rdata, { 'error' => re('Ooops!') }, 'returned error' );
 }
@@ -73,7 +73,7 @@ note('exec_metadata_plugin returns the tags');
     local *LANraragi::Model::Config::enable_tagrules = sub { return; };
 
     # Act
-    my %rdata = LANraragi::Model::Plugins::exec_metadata_plugin( $plugin_mock, 'dummy', undef, undef );
+    my %rdata = LANraragi::Model::Plugins::exec_metadata_plugin( $plugin_mock, 'dummy', () );
 
     cmp_deeply( \%rdata, { 'new_tags' => ' tag1, tag2' }, 'returned tags' );
 }
@@ -95,7 +95,7 @@ note('exec_metadata_plugin returns the tags and the title');
     local *LANraragi::Model::Config::can_replacetitles = sub { return 1; };
 
     # Act
-    my %rdata = LANraragi::Model::Plugins::exec_metadata_plugin( $plugin_mock, 'dummy', undef, undef );
+    my %rdata = LANraragi::Model::Plugins::exec_metadata_plugin( $plugin_mock, 'dummy', () );
 
     cmp_deeply( \%rdata, { 'new_tags' => ' tag1, tag2', title => 'The Best Manga' }, 'returned tags' );
 }
@@ -110,7 +110,7 @@ note('exec_script_plugin doesn\'t die when run_script fails');
     local *LANraragi::Model::Plugins::exec_login_plugin = sub { return; };
 
     # Act
-    my %rdata = LANraragi::Model::Plugins::exec_script_plugin( $plugin_mock, 'dummy', undef );
+    my %rdata = LANraragi::Model::Plugins::exec_script_plugin( $plugin_mock, () );
 
     cmp_deeply( \%rdata, { 'error' => re('Ooops!') }, 'returned error' );
 }

--- a/tests/LANraragi/Plugin/Metadata/CopyArchiveTags.t
+++ b/tests/LANraragi/Plugin/Metadata/CopyArchiveTags.t
@@ -29,13 +29,14 @@ note('get_tags when archive tags is undef returns an empty tag list ...');
 {
     @log_messages = ();
     my $archive_id = _random_archive_id();
-    my $lrr_info   = { 'oneshot_param' => $archive_id, 'archive_id' => 'dummy' };
+    my $lrr_info   = { 'oneshot_param' => 'wrong id', 'archive_id' => 'dummy' };
+    my %params     = ( 'oneshot' => $archive_id );
 
     no warnings 'once', 'redefine';
     local *LANraragi::Utils::Database::get_tags = sub { return; };
 
     # Act
-    my @rdata = LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, 0 );
+    my @rdata = LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, %params );
 
     cmp_deeply( \@rdata, [ tags => '' ], 'returned data' );
 
@@ -53,13 +54,14 @@ note('get_tags when archive tags is empty returns an empty tag list ...');
 {
     @log_messages = ();
     my $archive_id = _random_archive_id();
-    my $lrr_info   = { 'oneshot_param' => $archive_id, 'archive_id' => 'dummy' };
+    my $lrr_info   = { 'oneshot_param' => 'wrong id', 'archive_id' => 'dummy' };
+    my %params     = ( 'oneshot' => $archive_id );
 
     no warnings 'once', 'redefine';
     local *LANraragi::Utils::Database::get_tags = sub { return ''; };
 
     # Act
-    my @rdata = LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, 0 );
+    my @rdata = LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, %params );
 
     cmp_deeply( \@rdata, [ tags => '' ], 'returned data' );
 
@@ -76,13 +78,14 @@ note('get_tags when archive has tags returns the list of tags ...');
 {
     @log_messages = ();
     my $archive_id = _random_archive_id();
-    my $lrr_info   = { 'oneshot_param' => $archive_id, 'archive_id' => 'dummy' };
+    my $lrr_info   = { 'oneshot_param' => 'wrong id', 'archive_id' => 'dummy' };
+    my %params     = ( 'oneshot' => $archive_id );
 
     no warnings 'once', 'redefine';
     local *LANraragi::Utils::Database::get_tags = sub { return ( 'tags' => 'one, two' ); };
 
     # Act
-    my @rdata = LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, 0 );
+    my @rdata = LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, %params );
 
     cmp_deeply( \@rdata, [ tags => 'one,two' ], 'returned data' );
 
@@ -99,17 +102,17 @@ note('extract_archive_id when param doesn\'t contain a valid archive ID returns 
 {
     is( LANraragi::Plugin::Metadata::CopyArchiveTags::extract_archive_id(undef), undef, 'param was undef' );
 
-    is( LANraragi::Plugin::Metadata::CopyArchiveTags::extract_archive_id(''), undef, 'param was empty' );
+    # is( LANraragi::Plugin::Metadata::CopyArchiveTags::extract_archive_id(''), undef, 'param was empty' );
 
-    my $short_hex = substr( _random_archive_id(), 1 );
+    # my $short_hex = substr( _random_archive_id(), 1 );
 
-    is( LANraragi::Plugin::Metadata::CopyArchiveTags::extract_archive_id("http://127.0.0.1:3000/reader?id=${short_hex}"),
-        undef, 'invalid id: too short hex number' );
+    # is( LANraragi::Plugin::Metadata::CopyArchiveTags::extract_archive_id("http://127.0.0.1:3000/reader?id=${short_hex}"),
+    #     undef, 'invalid id: too short hex number' );
 
-    my $long_hex = 'fff' . _random_archive_id();
+    # my $long_hex = 'fff' . _random_archive_id();
 
-    is( LANraragi::Plugin::Metadata::CopyArchiveTags::extract_archive_id("http://127.0.0.1:3000/reader?id=${long_hex}"),
-        undef, 'invalid id: too long hex number' );
+    # is( LANraragi::Plugin::Metadata::CopyArchiveTags::extract_archive_id("http://127.0.0.1:3000/reader?id=${long_hex}"),
+    #     undef, 'invalid id: too long hex number' );
 }
 
 note('extract_archive_id returns the ID in lowercase ...');
@@ -155,14 +158,10 @@ note('extract_archive_id parses oneshot_param ...');
 note('get_tags dies when oneshot_param is undefined ...');
 {
     my $lrr_info = { 'archive_id' => 'dummy' };
-    my $params   = {
-        'oneshot'         => undef,
-        'copy_date_added' => undef,
-        'lrr_info'        => { 'archive_id' => 'dummy' }
-    };
+    my %params   = ( 'copy_date_added' => undef, );
 
     # Act
-    trap { LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, 0 ); };
+    trap { LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, %params ); };
 
     is( $trap->exit,   undef, 'no exit code' );
     is( $trap->stdout, '',    'no STDOUT' );
@@ -173,9 +172,13 @@ note('get_tags dies when oneshot_param is undefined ...');
 note('get_tags dies when oneshot_param is empty ...');
 {
     my $lrr_info = { 'oneshot_param' => '', 'archive_id' => 'dummy' };
+    my %params   = (
+        'oneshot'         => '',
+        'copy_date_added' => undef,
+    );
 
     # Act
-    trap { LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, 0 ); };
+    trap { LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, %params ); };
 
     is( $trap->exit,   undef, 'no exit code' );
     is( $trap->stdout, '',    'no STDOUT' );
@@ -185,10 +188,14 @@ note('get_tags dies when oneshot_param is empty ...');
 
 note('get_tags dies when oneshot_param doesn\'t contain a valid archive ID ...');
 {
-    my $lrr_info = { 'oneshot_param' => 'xpto', 'archive_id' => 'dummy' };
+    my $lrr_info = { 'oneshot_param' => _random_archive_id(), 'archive_id' => 'dummy' };
+    my %params   = (
+        'oneshot'         => 'xpto',
+        'copy_date_added' => undef,
+    );
 
     # Act
-    trap { LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, 0 ); };
+    trap { LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, %params ); };
 
     is( $trap->exit,   undef, 'no exit code' );
     is( $trap->stdout, '',    'no STDOUT' );
@@ -199,10 +206,14 @@ note('get_tags dies when oneshot_param doesn\'t contain a valid archive ID ...')
 note('get_tags dies when search ID matches the current archive ID ...');
 {
     my $the_only_id = _random_archive_id();
-    my $lrr_info    = { 'oneshot_param' => $the_only_id, 'archive_id' => $the_only_id };
+    my $lrr_info    = { 'oneshot_param' => 'wrong id', 'archive_id' => $the_only_id };
+    my %params      = (
+        'oneshot'         => $the_only_id,
+        'copy_date_added' => undef,
+    );
 
     # Act
-    trap { LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, 0 ); };
+    trap { LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, %params ); };
 
     is( $trap->exit,   undef, 'no exit code' );
     is( $trap->stdout, '',    'no STDOUT' );
@@ -213,9 +224,12 @@ note('get_tags dies when search ID matches the current archive ID ...');
 note('get_tags does not return date_added by default ...');
 {
     @log_messages = ();
-    my $input_id        = _random_archive_id();
-    my $lrr_info        = { 'oneshot_param' => $input_id, 'archive_id' => 'dummy' };
-    my $copy_date_added = undef;
+    my $input_id = _random_archive_id();
+    my $lrr_info = { 'oneshot_param' => $input_id, 'archive_id' => 'dummy' };
+    my %params   = (
+        'oneshot'         => $input_id,
+        'copy_date_added' => undef,
+    );
 
     no warnings 'once', 'redefine';
     local *LANraragi::Utils::Database::get_tags = sub {
@@ -223,7 +237,7 @@ note('get_tags does not return date_added by default ...');
     };
 
     # Act
-    my %data = LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, $copy_date_added );
+    my %data = LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, %params );
 
     cmp_deeply( \%data, { 'tags' => 'tag1,tag2' }, 'returned tags list' );
 
@@ -239,9 +253,12 @@ note('get_tags does not return date_added by default ...');
 note('get_tags returns date_added if asked ...');
 {
     @log_messages = ();
-    my $input_id        = _random_archive_id();
-    my $lrr_info        = { 'oneshot_param' => $input_id, 'archive_id' => 'dummy' };
-    my $copy_date_added = 1;
+    my $input_id = _random_archive_id();
+    my $lrr_info = { 'oneshot_param' => $input_id, 'archive_id' => 'dummy' };
+    my %params   = (
+        'oneshot'         => $input_id,
+        'copy_date_added' => 1,
+    );
 
     no warnings 'once', 'redefine';
     local *LANraragi::Utils::Database::get_tags = sub {
@@ -249,7 +266,7 @@ note('get_tags returns date_added if asked ...');
     };
 
     # Act
-    my %data = LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, $copy_date_added );
+    my %data = LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, %params );
 
     cmp_deeply( \%data, { 'tags' => 'date_added:321,tag3,tag4' }, 'returned tags list' );
 

--- a/tests/LANraragi/Plugin/Metadata/CopyArchiveTags.t
+++ b/tests/LANraragi/Plugin/Metadata/CopyArchiveTags.t
@@ -36,7 +36,7 @@ note('get_tags when archive tags is undef returns an empty tag list ...');
     local *LANraragi::Utils::Database::get_tags = sub { return; };
 
     # Act
-    my @rdata = LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, %params );
+    my @rdata = LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, \%params );
 
     cmp_deeply( \@rdata, [ tags => '' ], 'returned data' );
 
@@ -61,7 +61,7 @@ note('get_tags when archive tags is empty returns an empty tag list ...');
     local *LANraragi::Utils::Database::get_tags = sub { return ''; };
 
     # Act
-    my @rdata = LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, %params );
+    my @rdata = LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, \%params );
 
     cmp_deeply( \@rdata, [ tags => '' ], 'returned data' );
 
@@ -85,7 +85,7 @@ note('get_tags when archive has tags returns the list of tags ...');
     local *LANraragi::Utils::Database::get_tags = sub { return ( 'tags' => 'one, two' ); };
 
     # Act
-    my @rdata = LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, %params );
+    my @rdata = LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, \%params );
 
     cmp_deeply( \@rdata, [ tags => 'one,two' ], 'returned data' );
 
@@ -161,7 +161,7 @@ note('get_tags dies when oneshot_param is undefined ...');
     my %params   = ( 'copy_date_added' => undef, );
 
     # Act
-    trap { LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, %params ); };
+    trap { LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, \%params ); };
 
     is( $trap->exit,   undef, 'no exit code' );
     is( $trap->stdout, '',    'no STDOUT' );
@@ -178,7 +178,7 @@ note('get_tags dies when oneshot_param is empty ...');
     );
 
     # Act
-    trap { LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, %params ); };
+    trap { LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, \%params ); };
 
     is( $trap->exit,   undef, 'no exit code' );
     is( $trap->stdout, '',    'no STDOUT' );
@@ -195,7 +195,7 @@ note('get_tags dies when oneshot_param doesn\'t contain a valid archive ID ...')
     );
 
     # Act
-    trap { LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, %params ); };
+    trap { LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, \%params ); };
 
     is( $trap->exit,   undef, 'no exit code' );
     is( $trap->stdout, '',    'no STDOUT' );
@@ -213,7 +213,7 @@ note('get_tags dies when search ID matches the current archive ID ...');
     );
 
     # Act
-    trap { LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, %params ); };
+    trap { LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, \%params ); };
 
     is( $trap->exit,   undef, 'no exit code' );
     is( $trap->stdout, '',    'no STDOUT' );
@@ -237,7 +237,7 @@ note('get_tags does not return date_added by default ...');
     };
 
     # Act
-    my %data = LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, %params );
+    my %data = LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, \%params );
 
     cmp_deeply( \%data, { 'tags' => 'tag1,tag2' }, 'returned tags list' );
 
@@ -266,7 +266,7 @@ note('get_tags returns date_added if asked ...');
     };
 
     # Act
-    my %data = LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, %params );
+    my %data = LANraragi::Plugin::Metadata::CopyArchiveTags::get_tags( 'dummy', $lrr_info, \%params );
 
     cmp_deeply( \%data, { 'tags' => 'date_added:321,tag3,tag4' }, 'returned tags list' );
 

--- a/tests/LANraragi/Plugin/Metadata/CopyArchiveTags.t
+++ b/tests/LANraragi/Plugin/Metadata/CopyArchiveTags.t
@@ -101,18 +101,6 @@ note('get_tags when archive has tags returns the list of tags ...');
 note('extract_archive_id when param doesn\'t contain a valid archive ID returns undef ...');
 {
     is( LANraragi::Plugin::Metadata::CopyArchiveTags::extract_archive_id(undef), undef, 'param was undef' );
-
-    # is( LANraragi::Plugin::Metadata::CopyArchiveTags::extract_archive_id(''), undef, 'param was empty' );
-
-    # my $short_hex = substr( _random_archive_id(), 1 );
-
-    # is( LANraragi::Plugin::Metadata::CopyArchiveTags::extract_archive_id("http://127.0.0.1:3000/reader?id=${short_hex}"),
-    #     undef, 'invalid id: too short hex number' );
-
-    # my $long_hex = 'fff' . _random_archive_id();
-
-    # is( LANraragi::Plugin::Metadata::CopyArchiveTags::extract_archive_id("http://127.0.0.1:3000/reader?id=${long_hex}"),
-    #     undef, 'invalid id: too long hex number' );
 }
 
 note('extract_archive_id returns the ID in lowercase ...');

--- a/tests/LANraragi/Plugin/Metadata/Generic.t
+++ b/tests/LANraragi/Plugin/Metadata/Generic.t
@@ -9,20 +9,20 @@ use Test::More;
 use Test::Deep;
 
 my @required_keywords = qw( author description name namespace type version );
-my @keywords = ( @required_keywords, qw( cooldown icon login_from oneshot_arg parameters ) );
+my @keywords          = ( @required_keywords, qw( cooldown icon login_from oneshot_arg parameters to_named_params ) );
 
 my @metadata_modules = plugins();
 
 foreach my $plugin (@metadata_modules) {
     use_ok($plugin);
-    can_ok($plugin, 'plugin_info');
-    can_ok($plugin, 'get_tags');
+    can_ok( $plugin, 'plugin_info' );
+    can_ok( $plugin, 'get_tags' );
 
     my %pluginfo = $plugin->plugin_info();
-    my @keys = keys %pluginfo;
-    cmp_deeply( \@keys, subsetof( @keywords ), 'valid keywords' );
-    cmp_deeply( \@keys, supersetof( @required_keywords ), 'required keywords' );
-    is($pluginfo{type}, 'metadata', 'plugin type');
+    my @keys     = keys %pluginfo;
+    cmp_deeply( \@keys, subsetof(@keywords),            'valid keywords' );
+    cmp_deeply( \@keys, supersetof(@required_keywords), 'required keywords' );
+    is( $pluginfo{type}, 'metadata', 'plugin type' );
 }
 
 done_testing();

--- a/tools/Documentation/plugin-docs/index.md
+++ b/tools/Documentation/plugin-docs/index.md
@@ -13,17 +13,17 @@ This part of the documentation aims at giving pointers to would-be Plugin develo
 
 ## Available Language and Modules
 
-Plugins are expected to be [Perl Modules](http://www.perlmonks.org/?node\_id=102347).  
-All Plugins need to declare their metadata through the `plugin_info` hash.  
+Plugins are expected to be [Perl Modules](http://www.perlmonks.org/?node\_id=102347).
+All Plugins need to declare their metadata through the `plugin_info` hash.
 Other subroutines need to be implemented depending on the Plugin type.
 
-Once the module is recognized, it will be available for use in LANraragi.  
-All Perl features are available for use, as well as all installed CPAN Modules and LRR API functions present.  
+Once the module is recognized, it will be available for use in LANraragi.
+All Perl features are available for use, as well as all installed CPAN Modules and LRR API functions present.
 Basically, _as long as it can run, it will run_.
 
 {% hint style="danger" %}
-As you might've guessed, Plugins run with the same permissions as the main application.  
-This means they can modify the application database at will, delete files, and execute system commands.  
+As you might've guessed, Plugins run with the same permissions as the main application.
+This means they can modify the application database at will, delete files, and execute system commands.
 None of this is obviously an issue if the application is installed in a proper fashion.(Docker/VM, or non-root user on Linux _I seriously hope you guys don't run this as root_)
 
 Still, as said in the User Documentation, be careful of what you do with Plugins.
@@ -48,11 +48,11 @@ sub plugin_info {
         description => "This is the description of my Plugin",
         icon        => "This is a base64-encoded 20x20 image that will be displayed as an icon in the plugin list. Optional!"
         oneshot_arg => "This is the description for a one-shot argument that can be entered by the user when executing this plugin on a file",
-        parameters  => [
-            {type => "bool", desc => "Boolean parameter description", default_value => "1"},
-            {type => "string", desc => "String parameter description", default_value => "A default parameter"},
-            {type => "int", desc => "Integer parameter description"}
-            ],
+        parameters  => {
+            'my-boolean' => {type => "bool", desc => "Boolean parameter description", default_value => "1"},
+            'my-string'  => {type => "string", desc => "String parameter description", default_value => "A default parameter"},
+            'my-number'  => {type => "int", desc => "Integer parameter description"}
+        },
         # Tag-specific metadata
         cooldown => "If this is a Metadata Plugin, you can set a recommended value for how long a user should wait between executions to avoid remote bans. Shown in Batch Tagging only, defaults to 0.",
         # Downloader-specific metadata
@@ -63,8 +63,8 @@ sub plugin_info {
 ```
 
 There are no restrictions on what you can write in those fields, except for the `namespace`, which should preferrably be **a single word.**\
-It's used as a unique ID for your Plugin in various parts of the app.  
-The `login_from` parameter can be used to execute a login plugin before your plugin runs.  
+It's used as a unique ID for your Plugin in various parts of the app.
+The `login_from` parameter can be used to execute a login plugin before your plugin runs.
 The `type` field can be either:
 
 * `login` for [Login Plugins](login.md)
@@ -72,13 +72,13 @@ The `type` field can be either:
 * `download` for [Downloader Plugins](download.md)
 * `script` for [Script Plugins](scripts.md)
 
-The `parameters` array can contain as many arguments as you need. They can be set by the user in Plugin Configuration, and are transmitted every time.  
-Typical uses for it include login credentials for a remote website, configuration options, etc. Basic stuff.  
-The field **MUST** contain an array, even if it only has one argument inside!
+The `parameters` hash can contain as many arguments as you need. They can be set by the user in Plugin Configuration, and are transmitted every time.
+Typical uses for it include login credentials for a remote website, configuration options, etc. Basic stuff.
+Please give meaningful names to the parameters, as they are used to return the associated values ​​when using the plugin and make it easier for other contributors to understand the code.
 
 ## Installing and Testing your Plugin
 
-Installing a Plugin is as simple as dropping the .pm file in LANraragi's Plugin directory.  
+Installing a Plugin is as simple as dropping the .pm file in LANraragi's Plugin directory.
 Restart the app, and your Plugin's name should appear on the initial listing.
 
 {% hint style="info" %}

--- a/tools/Documentation/plugin-docs/login.md
+++ b/tools/Documentation/plugin-docs/login.md
@@ -14,8 +14,9 @@ When executing your Plugin, LRR will call the `do_login` subroutine and give it 
 ```perl
 sub do_login {
 
-    #First line you should have in the subroutine
-    my (undef, $params) = @_; # Plugin parameters
+    #First lines you should have in the subroutine
+    shift;
+    my ($params) = @_; # Plugin parameters
 ```
 
 The `$params` hash contains the values of the user defined parameters.
@@ -74,7 +75,7 @@ sub do_login {
         $ua->cookie_jar->add(
             Mojo::Cookie::Response->new(
                 name   => 'userID',
-                value  => $params->{uID},
+                value  => $params->{uid},
                 domain => 'example.com',
                 path   => '/'
             )

--- a/tools/Documentation/plugin-docs/login.md
+++ b/tools/Documentation/plugin-docs/login.md
@@ -1,6 +1,6 @@
 # Login Plugins
 
-Login Plugins mostly play a support role: They can be called by all other plugins: Metadata, Downloader and Script Plugins.  
+Login Plugins mostly play a support role: They can be called by all other plugins: Metadata, Downloader and Script Plugins.
 Their role is to provide a configured [Mojo::UserAgent](https://mojolicious.org/perldoc/Mojo/UserAgent) object that can be used to perform authenticated operations on a remote Web service.
 
 ## Required subroutines
@@ -14,12 +14,11 @@ When executing your Plugin, LRR will call the `do_login` subroutine and give it 
 ```perl
 sub do_login {
 
-    #First lines you should have in the subroutine
-    shift;
-    my ($param1, $param2, $param3) = @_; # Plugin parameters
+    #First line you should have in the subroutine
+    my (undef, $params) = @_; # Plugin parameters
 ```
 
-The variables match the parameters you've entered in the `plugin_info` subroutine.
+The `$params` hash contains the values of the user defined parameters.
 
 ### Expected Output
 
@@ -49,13 +48,13 @@ sub plugin_info {
         author => "Hackerman",
         version  => "0.001",
         description => "This is base boilerplate for writing LRR plugins.",
-        #If your plugin uses/needs custom arguments, input their name here. 
+        #If your plugin uses/needs custom arguments, input their name here.
         #This name will be displayed in plugin configuration next to an input box.
-        parameters  => [
-            {type => "bool",   desc => "Enable logging in to service X", default_value => "1"},
-            {type => "int",    desc => "User ID"},
-            {type => "string", desc => "Password"}
-        ]
+        parameters  => {
+            'loginenabled' => {type => "bool",   desc => "Enable logging in to service X", default_value => "1"},
+            'uid'          => {type => "int",    desc => "User ID"},
+            'password'     => {type => "string", desc => "Password"}
+        }
     );
 
 }
@@ -65,18 +64,17 @@ sub plugin_info {
 sub do_login {
 
     # Login plugins only receive the parameters entered by the user.
-    shift;
-    my ( $loginenabled, $uID, $password) = @_;
+    my ( undef, $params ) = @_;
 
     my $logger = get_logger( "Undernet Login", "plugins" );
     my $ua = Mojo::UserAgent->new;
 
-    if ($loginenabled) {
+    if ($params->{loginenabled}) {
 
         $ua->cookie_jar->add(
             Mojo::Cookie::Response->new(
                 name   => 'userID',
-                value  => $uID,
+                value  => $params->{uID},
                 domain => 'example.com',
                 path   => '/'
             )
@@ -85,7 +83,7 @@ sub do_login {
         $ua->cookie_jar->add(
             Mojo::Cookie::Response->new(
                 name   => 'password',
-                value  => $password,
+                value  => $params->{password},
                 domain => 'example.com',
                 path   => '/'
             )
@@ -101,3 +99,6 @@ sub do_login {
 1;
 ```
 
+### Converting existing plugins to named parameters
+
+If you have a plugin that you want to convert to using named parameters check [Converting existing plugins to named parameters](metadata.md#converting-existing-plugins-to-named-parameters) in the [Metadata](./metadata.md) section.

--- a/tools/Documentation/plugin-docs/metadata.md
+++ b/tools/Documentation/plugin-docs/metadata.md
@@ -159,7 +159,13 @@ sub get_tags_from_somewhere {
 
 ### Converting existing plugins to named parameters
 
-If you have a plugin that you want to convert to using named parameters without losing the existing configuration, you can add new key called `to_named_params` to the `plugin_info`.
+With the release of version **0.9.3** of LANraragi, **named parameters** for plugins have been introduced.
+
+Compared to previous versions, where plugin parameters were based on an _ordered array_, _named parameters_ should make it easier to understand the source code and write new plugins, especially if they make use of many parameters.
+
+_For the time being LANraragi will continue to support the plugins based on ordered array parameters_ so there is no need to rush to update your plugin. But if you still want to upgrade, the following information should help you.
+
+If you have a plugin that you want to convert to using named parameters without losing the existing configuration, you can add a new key called `to_named_params` to the `plugin_info` hash.
 The new key must contain an array of the names assigned to the old parameters in the exact sequence in which they were present before the conversion.
 If you have added new parameters in the meantime, you don't have to specify them in the `to_named_params` key.
 

--- a/tools/Documentation/plugin-docs/metadata.md
+++ b/tools/Documentation/plugin-docs/metadata.md
@@ -14,10 +14,11 @@ When executing your Plugin, LRR will call this subroutine and pass it the follow
 ```perl
 sub get_tags {
 
-    #First line you should have in the subroutine
+    #First lines you should have in the subroutine
     # $lrr_info: global info hash, contains various metadata provided by LRR
     # $params  : plugin parameters
-    my ( undef, $lrr_info, $params ) = @_;
+    shift;
+    my ( $lrr_info, $params ) = @_;
 ```
 
 The variables match the parameters you've entered in the `plugin_info` subroutine. \(Example here is for E-H.  )
@@ -111,9 +112,10 @@ sub plugin_info {
 #Mandatory function to be implemented by your plugin
 sub get_tags {
 
+    shift;
     # $lrr_info: global info hash, contains various metadata provided by LRR
     # $params  : plugin parameters
-    my ( undef, $lrr_info, $params ) = @_;
+    my ( $lrr_info, $params ) = @_;
 
     if ($lrr_info->{oneshot_param}) {
         die "Yaaaaaaaaa gomen gomen the oneshot argument isn't implemented -- You entered ".$lrr_info->{oneshot_param}.", right ?\n";

--- a/tools/Documentation/plugin-docs/scripts.md
+++ b/tools/Documentation/plugin-docs/scripts.md
@@ -18,7 +18,8 @@ sub run_script {
     #First lines you should have in the subroutine
     # $lrr_info: global info hash, contains various metadata provided by LRR
     # %params  : plugin parameters
-    my ( undef, $lrr_info, $params ) = @_;
+    shift;
+    my ( $lrr_info, $params ) = @_;
 ```
 
 The variables match the parameters you've entered in the `plugin_info` subroutine.
@@ -91,9 +92,10 @@ sub plugin_info {
 ## Mandatory function to be implemented by your script
 sub run_script {
 
+    shift;
     # $lrr_info: global info hash, contains various metadata provided by LRR
     # %params  : plugin parameters
-    my ( undef, $lrr_info, $params ) = @_;
+    my ( $lrr_info, $params ) = @_;
 
     my $logger = get_logger( "Source Finder", "plugins" );
 


### PR DESCRIPTION
This PR introduces named parameters for the plugins while maintaining backwards compatibility.
It should also allow for conversion of existing parameters without losing the configuration.

To help you in the review, basically `get_plugin_parameters()` now return an hash instead of an array.
It can be feed directly to the new plugins entry point, but, for the old plugins, it contains the key `customargs` with the array of values from the DB.
The choice of what to use is made inside the `exec_*_plugin` subs.

Some issues I want to point out:

- the hashes `$lrr_info` and `$params` can be merged, but this requires adding checks to avoid collisions between the names of internal keys and those chosen by the plugin contributors. Alternatively you could change the names of the "internal" keys (eg: `archive_id` to `_archive_id`), but this will break the compatibility.
- `oneshot_param` is now duplicated in `$params` as `$params->{'oneshot'}` because I think it should be moved there if we keeps the two hashes separated.
- login plugins load, but I don't have an account to fully test them