### PR TITLE
Check that gallery_info exist inside eze info.json

### DIFF
--- a/lib/LANraragi/Plugin/Metadata/Eze.pm
+++ b/lib/LANraragi/Plugin/Metadata/Eze.pm
@@ -86,6 +86,10 @@ sub get_tags {
 
     $logger->debug("Loaded the following JSON: $stringjson");
 
+    if ($hashjson->{gallery_info} == undef) {
+        return (error => "The info.json file could not be parsed as an eze file!");
+    }
+
     #Parse it
     my ( $tags, $title ) = tags_from_eze_json( $origin_title, $additional_tags, $hashjson );
 

--- a/tests/LANraragi/Plugin/Metadata/Eze.t
+++ b/tests/LANraragi/Plugin/Metadata/Eze.t
@@ -106,4 +106,17 @@ note("eze-full Tests, origin_title on, additional_tags off");
     );
 }
 
+
+note("eze no gallery_info file");
+{
+    my $origin_title    = 1;
+    my $additional_tags = 0;
+
+    my %ezetags = eve_test( "/eze/eze_broken.json", $origin_title, $additional_tags );
+
+    is( $ezetags{title}, undef, "no title returned");
+    is( $ezetags{tags}, undef, "no tags returned");
+    isnt( $ezetags{error}, undef, "Proper error returned");
+}
+
 done_testing();

--- a/tests/samples/eze/eze_broken.json
+++ b/tests/samples/eze/eze_broken.json
@@ -1,0 +1,3 @@
+{
+	"title": "Broken"
+}


### PR DESCRIPTION
Makes eze plugin return a proper error if `gallery_info` is missing.
Previously, it errored out and showed `Error: Month '-1' out of range 0..11 at /home/koyomi/lanraragi/script/../lib/LANraragi/Plugin/Metadata/Eze.pm line 155.` in the notification.