### PR TITLE
fix file upload permissions

### DIFF
--- a/tools/build/docker/s6/cont-init.d/01-lrr-setup
+++ b/tools/build/docker/s6/cont-init.d/01-lrr-setup
@@ -24,10 +24,10 @@ chmod -R u+rwx /home/koyomi/lanraragi/database
 
 if [ "$FIX_PERMS" -eq 1 ]; then
   echo "Fixing permissions, hold on!"
-  #Ensure thumbnail folder is writable
-  chown -R koyomi /home/koyomi/lanraragi/content/thumb
-  find /home/koyomi/lanraragi/content/thumb -type f -exec chmod u+rw  {} \;
-  find /home/koyomi/lanraragi/content/thumb -type d -exec chmod u+rwx {} \;
+  #Ensure content folder is writable
+  chown -R koyomi /home/koyomi/lanraragi/content
+  find /home/koyomi/lanraragi/content -type f -exec chmod u+rw  {} \;
+  find /home/koyomi/lanraragi/content -type d -exec chmod u+rwx {} \;
 
   chown -R koyomi /home/koyomi/lanraragi/lib/LANraragi/Plugin/Sideloaded
   chmod u+rwx /home/koyomi/lanraragi/lib/LANraragi/Plugin/Sideloaded


### PR DESCRIPTION
Currently when the LRR docker image is run, the contents folder is where archives are saved, and any file uploads will fail due to a lack of permission bc the contents folder in docker is not owned by koyomi. This commit rectifies that.

Checking 01-lrr-setup I saw that permfixes were applied but only to thumb, I'm not sure why only the thumb folder is checked. I could be missing something here