### PR TITLE
Implement Duplicate Finder

### DIFF
--- a/lib/LANraragi/Controller/Api/Other.pm
+++ b/lib/LANraragi/Controller/Api/Other.pm
@@ -107,6 +107,26 @@ sub regen_thumbnails {
     );
 }
 
+# Queue the find_duplicates Minion job.
+sub find_duplicates {
+    my $self      = shift;
+    my $threshold = 5;
+
+    if ($self->req->param('threshold')) {
+        $threshold = int($self->req->param('threshold'));
+    }
+
+    my $jobid = $self->minion->enqueue( find_duplicates => [ $threshold ] => { priority => 0 } );
+
+    $self->render(
+        json => {
+            operation => "find_duplicates",
+            success   => 1,
+            job       => $jobid
+        }
+    );
+}
+
 sub download_url {
     my ($self) = shift;
     my $url    = $self->req->param('url');

--- a/lib/LANraragi/Controller/Duplicates.pm
+++ b/lib/LANraragi/Controller/Duplicates.pm
@@ -1,0 +1,79 @@
+package LANraragi::Controller::Duplicates;
+use Mojo::Base 'Mojolicious::Controller';
+use utf8;
+use URI::Escape;
+use Redis;
+use POSIX      qw(strftime);
+use Encode;
+
+use Mojo::JSON qw(decode_json encode_json);
+use LANraragi::Utils::Logging qw(get_logger);
+
+use LANraragi::Utils::Generic qw(generate_themes_header);
+
+# Go through the archives in the content directory and build the template at the end.
+sub index {
+    my $self  = shift;
+    my $redis = $self->LRR_CONF->get_redis;
+    my $logger = get_logger("Duplicates", "lanraragi");
+
+    my $userlogged = $self->LRR_CONF->enable_pass == 0 || $self->session('is_logged');
+
+    if ( $userlogged && $self->req->param('delete') ) {
+        $logger->debug("Cleared all detected duplicates!");
+        $redis->del("duplicate_groups");
+    }
+
+    my %duplicate_groups = $redis->hgetall("duplicate_groups");
+
+    my @duplicates;
+    foreach my $key (keys %duplicate_groups) {
+        # Decode the JSON-encoded array of IDs
+        my $deserialized = decode_json($duplicate_groups{$key});
+        my @ids = @{$deserialized};
+
+        my @archives;
+        foreach my $id (@ids) {
+            my %archive = $redis->hgetall($id);
+
+            # Check if archive still exists
+            if (%archive) {
+                $archive{'arcid'} = $id;
+                $archive{'group_key'} = $key;
+
+                if ($archive{'tags'} =~ /date_added:(\d+)/) {
+                    $archive{'date_added'} = strftime("%Y-%m-%d %H:%M:%S", localtime($1));
+                }
+
+                push @archives, \%archive;
+            } else {
+                # if dup size of group less than 2, its not a group anymore
+                if (scalar @ids <= 2) {
+                    my $size = scalar @ids;
+                    $logger->debug("group $key: too small ($size) - removing key");
+                    $redis->hdel("duplicate_groups", $key);
+                } else {
+                    # archive vanished -> remove from dupes
+                    @ids = grep { $_ ne $id } @ids;
+                    $logger->debug("group $key: archive $id vanished - removing from group");
+                    $redis->hset("duplicate_groups", $key, encode_json(\@ids))
+                }
+            }
+        }
+        push @duplicates, \@archives
+    }
+
+    $redis->quit();
+
+    $self->render(
+        template => "duplicates",
+        title    => $self->LRR_CONF->get_htmltitle,
+        duplicates => \@duplicates,
+        userlogged => $userlogged,
+        descstr  => $self->LRR_DESC,
+        csshead  => generate_themes_header($self),
+        version  => $self->LRR_VERSION
+    );
+}
+
+1;

--- a/lib/LANraragi/Utils/Minion.pm
+++ b/lib/LANraragi/Utils/Minion.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Encode;
+use Mojo::JSON qw(encode_json);
 use Mojo::UserAgent;
 use Parallel::Loops;
 
@@ -137,6 +138,100 @@ sub add_tasks {
             };
 
             $job->finish( { errors => \@errors } );
+        }
+    );
+
+    $minion->add_task(
+        find_duplicates => sub {
+            my ( $job,      @args )  = @_;
+            my ( $threshold ) = @args;
+
+            my $logger = get_logger( "Minion", "minion" );
+            my $redis  = LANraragi::Model::Config->get_redis;
+            my @keys   = $redis->keys('????????????????????????????????????????');
+            $redis->quit();
+
+            $logger->info("Starting find duplicate job (threshold = $threshold)");
+
+            my $numCpus = Sys::CpuAffinity::getNumCpus();
+            my $pl      = Parallel::Loops->new($numCpus);
+
+            $logger->debug("Number of available cores for processing: $numCpus");
+
+            # Gather thumbhashes
+            my %thumbhashes;
+            foreach my $id (@keys) {
+                my $thumbhash = $redis->hget( $id, "thumbhash" );
+                $thumbhashes{$id} = $thumbhash if $thumbhash;
+            }
+
+            # Prepare to track visited nodes
+            my %visited :shared;
+            my @ids = keys %thumbhashes; # List of IDs to check
+
+            # Share the %visited hash across threads
+            $pl->share( \%visited );
+
+            my @sections = split_workload_by_cpu( $numCpus, @ids );
+            eval {
+                $pl->foreach(
+                    \@sections,
+                    sub {
+                        my $redis = LANraragi::Model::Config->get_redis;
+
+                        foreach my $id (@$_) {
+                            # Skip if this ID has already been processed in another thread
+                            next if $visited{$id};
+                            my @stack = ($id);
+                            my @group;
+
+                            while (@stack) {
+                                my $node = pop @stack;
+                                next if $visited{$node};
+
+                                # Mark the node as visited
+                                {
+                                    lock(%visited);
+                                    $visited{$node} = 1;
+                                }
+                                push @group, $node;
+
+                                # Find all potential duplicates for this node
+                                foreach my $other_id (keys %thumbhashes) {
+                                    next if $node eq $other_id || $visited{$other_id};
+
+                                    # Calculate Hamming distance
+                                    my $distance = 0;
+                                    for (my $i = 0; $i < length($thumbhashes{$node}); $i++) {
+                                        $distance++ if substr($thumbhashes{$node}, $i, 1) ne substr($thumbhashes{$other_id}, $i, 1);
+                                        last if $distance > $threshold;  # Early exit if threshold exceeded
+                                    }
+
+                                    # If within threshold, add to stack for further exploration
+                                    if ($distance <= $threshold) {
+                                        $logger->debug("Found potential duplicate: $node and $other_id with distance $distance");
+                                        push @stack, $other_id;
+                                    }
+                                }
+                            }
+
+                            # Add the discovered group to redis
+                            # to avoid redudnant groups in different orders - sort and composite key
+                            if (@group && scalar @group >= 2) {
+                                @group = sort @group;
+                                my $composite_key = join '', map { substr($_, 0, 10) } @group;
+                                my $group_json = encode_json(\@group);
+                                $logger->debug("duplicate group '$composite_key': $group_json");
+                                $redis->hset("duplicate_groups", "dupgp_$composite_key", $group_json);
+                            }
+                        }
+
+                        $redis->quit();
+                    }
+                );
+            };
+
+            $job->finish( { } );
         }
     );
 

--- a/lib/LANraragi/Utils/Routing.pm
+++ b/lib/LANraragi/Utils/Routing.pm
@@ -88,6 +88,8 @@ sub apply_routes {
 
     $logged_in->get('/tankoubons')->to('tankoubon#index');
 
+    $logged_in->get('/duplicates')->to('duplicates#index');
+
     # OPDS API
     $public_api->get('/api/opds')->to('api-other#serve_opds_catalog');
     $public_api->get('/api/opds/:id')->to('api-other#serve_opds_item');
@@ -101,6 +103,7 @@ sub apply_routes {
     $logged_in_api->delete('/api/tempfolder')->to('api-other#clean_tempfolder');
     $logged_in_api->post('/api/download_url')->to('api-other#download_url');
     $logged_in_api->post('/api/regen_thumbs')->to('api-other#regen_thumbnails');
+    $logged_in_api->post('/api/find_dupes')->to('api-other#find_duplicates');
 
     # Archive API
     $public_api->get('/api/archives')->to('api-archive#serve_archivelist');

--- a/public/js/duplicates.js
+++ b/public/js/duplicates.js
@@ -1,0 +1,191 @@
+/**
+ * Duplicate Operations.
+ */
+const Duplicates = {};
+
+Duplicates.dt = {};
+
+
+Duplicates.initializeAll = function () {
+    // bind events to DOM
+    $(document).on("click.goback", "#goback", () => { window.location.replace("./"); });
+    $(document).on("mouseenter.thumbnail-wrapper", ".thumbnail-wrapper", (e) => $(e.currentTarget).find(".thumbnail-popover").show());
+    $(document).on("mouseleave.thumbnail-wrapper", ".thumbnail-wrapper", (e) => $(e.currentTarget).find(".thumbnail-popover").hide());
+
+    $(document).on("click.find-duplicates", ".find-duplicates", Server.findDuplicates);
+    $(document).on("click.clear-duplicates", ".clear-duplicates", () => { window.location.href = new LRR.apiURL("/duplicates?delete=1"); });
+    $(document).on("click.delete-archive", ".delete-archive", Duplicates.deleteArchive);
+    $(document).on("click.delete-selected", ".delete-selected", Duplicates.deleteArchives);
+
+    $(document).on("change.duplicate-select-condition", ".duplicate-select-condition", Duplicates.conditionChange);
+    Duplicates.inizializeDataTable();
+}
+
+Duplicates.drawCallbackDataTable = function (settings) {
+    var groupColumn = 0;
+    var api = this.api();
+    var rows = api.rows({ page: 'current' }).nodes();
+    var lastGroup = null;
+
+    // Iterate over the data once to insert group rows at end of each group
+    api.column(groupColumn, { page: 'current' })
+        .data()
+        .each(function (group, i) {
+            if (lastGroup && lastGroup !== group) {
+                $(rows).eq(i).before(
+                    '<tr class="separator"><td colspan="10" style="padding: 0px;"></td></tr>'
+                );
+            }
+            lastGroup = group;
+        });
+}
+
+Duplicates.inizializeDataTable = function () {
+    Duplicates.dt = $('#ds').DataTable({
+        dom: '<"table-control-wrapper" <"search-box" f><"length-box" l>><t><p>',
+        // avoid sorting columns as it messes with the grouping
+        columns: [
+            { title: 'Group-Key', visible: false },
+            { title: '', orderable: false },
+            { title: '', orderable: false },
+            { title: 'Title', orderable: false },
+            { title: 'Pages', orderable: false },
+            { title: 'Filename', orderable: false },
+            { title: 'Filesize', orderable: false },
+            { title: 'Date', orderable: false },
+            { title: 'Tags', orderable: false },
+            { title: 'Action', orderable: false }
+        ],
+        order: [[0, 'asc']],
+        autoWidth: false,
+        pageLength: 10,
+        deferRender: true,
+        drawCallback: Duplicates.drawCallbackDataTable
+    });
+};
+
+Duplicates.compareDuplicates = function (rows, field, fieldType, order = 'desc') {
+    var values = [];
+    var rowToExclude = null;
+
+    // Determine comparator and starting value based on order
+    var comparator = order === 'asc' ? Math.min : Math.max;
+    var targetValue = order === 'asc' ? Infinity : -Infinity;
+
+    // Function to parse the value based on the field type
+    function parseValue(value) {
+        if (fieldType === 'integer') {
+            return parseInt(value, 10);
+        } else if (fieldType === 'float') {
+            return parseFloat(value);
+        } else if (fieldType === 'date') {
+            return new Date(value).getTime();
+        }
+        return value;
+    }
+    // Iterate over rows to find the target row based on the comparator
+    rows.each(function () {
+        var row = $(this);
+        var value = parseValue(row.find(`.${field}`).text());
+        values.push(value);
+
+        if (comparator(value, targetValue) === value) {
+            targetValue = value;
+            rowToExclude = row;
+        }
+    });
+
+    // Do not check anything if all values are equal
+    var allEqual = values.every((val) => val === values[0]);
+    if (allEqual) return;
+
+    // Iterate over rows again to check the checkbox for all rows except the target row
+    rows.each(function () {
+        var row = $(this);
+        if (rowToExclude && row[0] !== rowToExclude[0]) {
+            row.find('.form-check-input').prop('checked', true);
+        }
+    });
+}
+
+Duplicates.conditionChange = function (event) {
+    var option = $(event.target).val();
+
+    // Clear current selection
+    $('.form-check-input').prop('checked', false);
+
+    // Early return if none should be selected
+    if (option === 'none') {
+        return;
+    }
+
+    $('.duplicate-group').each((_, group) => {
+        // Find all rows of a group
+        var groupRow = $(group);
+        var rowsInGroup = groupRow.add(groupRow.nextUntil('.separator'));
+
+        // Compare rows in group according to selected option
+        switch (option) {
+            case 'less-tags':
+                Duplicates.compareDuplicates(rowsInGroup, "tag-count", "integer");
+                break;
+            case 'less-size':
+                Duplicates.compareDuplicates(rowsInGroup, "file-size", "float");
+                break;
+            case 'less-pages':
+                Duplicates.compareDuplicates(rowsInGroup, "page-count", "integer");
+                break;
+            case 'not-old':
+                Duplicates.compareDuplicates(rowsInGroup, "date-added", "date");
+                break;
+            case 'not-young':
+                Duplicates.compareDuplicates(rowsInGroup, "date-added", "date", "asc");
+                break;
+        };
+    });
+};
+
+Duplicates.deleteArchive = function (event) {
+    LRR.showPopUp({
+        text: "Are you sure you want to delete this archive?",
+        icon: "warning",
+        showCancelButton: true,
+        focusConfirm: false,
+        confirmButtonText: "Yes, delete it!",
+        reverseButtons: true,
+        confirmButtonColor: "#d33",
+    }).then((result) => {
+        if (result.isConfirmed) {
+            archiveid = $(event.currentTarget).attr('data-id');
+            Server.deleteArchive(archiveid, () => { Duplicates.dt.row($(event.currentTarget).parents('tr')).remove().draw()});
+        }
+    });
+};
+
+Duplicates.deleteArchives = function () {
+    LRR.showPopUp({
+        text: "Are you sure you want to delete all selected archives?",
+        icon: "warning",
+        showCancelButton: true,
+        focusConfirm: false,
+        confirmButtonText: "Yes, delete all!",
+        reverseButtons: true,
+        confirmButtonColor: "#d33",
+    }).then((result) => {
+        if (result.isConfirmed) {
+            $("table tbody tr").each(function () {
+                const row = $(this);
+                const isChecked = row.find(".form-check-input").is(":checked");
+                const dataId = row.find(".delete-archive").attr("data-id");
+
+                if (isChecked && dataId) {
+                    Server.deleteArchive(dataId, () => { Duplicates.dt.row(row).remove().draw() });
+                }
+            });
+        }
+    });
+};
+
+jQuery(() => {
+    Duplicates.initializeAll();
+});

--- a/public/js/server.js
+++ b/public/js/server.js
@@ -327,6 +327,42 @@ Server.deleteArchive = function (arcId, callback) {
 };
 
 /**
+ * Sends a POST request to queue a find_duplicates job,
+ * detecting archive duplicates based on their thumbnail hashes.
+ */
+Server.findDuplicates = function () {
+    Server.callAPI(`/api/find_dupes`, "POST",
+        "Queued up a job to find duplicates! Stay tuned for updates or check the Minion console.",
+        "Error while sending job to Minion:",
+        (data) => {
+            // Disable the buttons to avoid accidental double-clicks.
+            $(".find-duplicates").prop("disabled", true);
+
+            // Check minion job state periodically while we're on this page
+            Server.checkJobStatus(
+                data.job,
+                true,
+                (d) => {
+                    $(".find-duplicates").prop("disabled", false);
+                    LRR.toast({
+                        heading: "All duplicates found! Encountered the following errors:",
+                        text: d.result.errors,
+                        icon: "success",
+                        hideAfter: 15000,
+                        closeOnClick: false,
+                        draggable: false,
+                    });
+                },
+                (error) => {
+                    $(".find-duplicates").prop("disabled", false);
+                    LRR.showErrorToast("The Find Duplicates job failed!", error);
+                },
+            );
+        },
+    );
+};
+
+/**
  * Sends a UPDATE request for the metadata of the archive ID
  * @param {*} arcId Archive ID
  */

--- a/templates/duplicates.html.tt2
+++ b/templates/duplicates.html.tt2
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+
+<head>
+	<title>[% title %] - Duplicates</title>
+
+	<meta name="viewport" content="width=device-width" />
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta name="apple-mobile-web-status-bar-style" content="black" />
+	<meta name="mobile-web-app-capable" content="yes" />
+	<meta name="apple-mobile-web-app-capable" content="yes" />
+
+	<link type="image/png" rel="icon" href="favicon.ico" />
+	<link rel="manifest" href="app.webappmanifest" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/lrr.css?$version") %]" />
+
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/fontawesome-all.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/jqcloud.min.css") %]">
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/allcollapsible.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/ReactToastify.min.css") %]" />
+	<link rel="stylesheet" type="text/css" href="[% c.url_for("/css/vendor/sweetalert2.min.css") %]" />
+	[% csshead %]
+
+	<script src="[% c.url_for("/js/vendor/jquery.min.js") %]" type="text/JAVASCRIPT"></script>
+    <script src="[% c.url_for("/js/vendor/jquery.dataTables.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/preact.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/hooks.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/compat.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script>window.React = window.preactCompat; window.react = window.preactCompat;</script>
+	<script src="[% c.url_for("/js/vendor/clsx.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/react-toastify.umd.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/jqcloud.min.js") %]"></script>
+	<script src="[% c.url_for("/js/vendor/allcollapsible.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
+
+	<script src="[% c.url_for("/js/common.js?$version") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/server.js?$version") %]" type="text/JAVASCRIPT"></script>
+    <script src="[% c.url_for("/js/duplicates.js?$version") %]" type="text/JAVASCRIPT"></script>
+    <style>
+        /* Table styling */
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            font-family: Geist, sans-serif;
+            font-size: 10pt;
+            margin-top: 20px;
+            margin:auto;
+        }
+
+        /* Header styling */
+        table thead tr {
+            color: white;
+            font-weight: bold;
+        }
+
+        table thead th {
+            padding: 12px;
+            text-align: center;
+        }
+
+        /* Zebra striping */
+        table tbody tr:nth-child(2n+1) {
+            background-color: #363940;
+        }
+
+        /* Cell styling */
+        table tbody td {
+            padding: 10px;
+            text-align: center;
+            vertical-align: middle;
+        }
+
+        /* Thumbnail image */
+        table .thumbnail {
+            width: 50px;
+            height: auto;
+            border-radius: 4px;
+        }
+
+        /* Separator row */
+        .separator {
+            border-bottom: 2px solid #ddd;
+        }
+
+        /* Buttons */
+        .action-button {
+            margin: 0 5px;
+            padding: 5px 10px;
+            font-size: 9pt;
+            min-width: 50px;
+        }
+
+        .btn-danger {
+            background-color: #d9534f;
+            color: white;
+            border: none;
+        }
+
+        .btn-danger:hover {
+            background-color: #c9302c;
+        }
+
+        .thumbnail-wrapper {
+            margin: auto;
+            overflow: visible; /*hidden;*/
+            position: relative;
+            text-align: center;
+        }
+
+        /* Popover */
+        .thumbnail-popover {
+            display: none;
+            position: absolute;
+            top: -10px;
+            left: 60px;
+            width: 350px;
+            padding: 5px;
+            z-index: 100;
+        }
+
+        /* Popover image */
+        .thumbnail-popover img {
+            width: 100%;
+            height: auto;
+            border-radius: 4px;
+        }
+
+        .tag-column {
+            max-width: 700px;
+            text-align: center;
+            margin: auto;
+            max-height: 80px;
+            white-space: normal;
+            text-wrap: auto;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .table-control-wrapper {
+            display: flex;
+            justify-content: space-between;
+            padding: 15px;
+            font-family: Geist, sans-serif;
+            font-size: 13px;
+        }
+
+        .duplicate-control-btn-group {
+            margin-bottom: 15px;
+        }
+    </style>
+</head>
+
+<body>
+	<div class='ido' style='text-align:center; overflow-x:auto;'>
+		<h2 class="ih" style="text-align:center">Duplicates</h2>
+        <p>Found [% duplicates.size %] duplicate groups</p>
+
+        [% IF userlogged %]
+        <div class="control-btn-group">
+            <div class="duplicate-control-btn-group">
+                <button type="button" class="stdbtn find-duplicates">Find Duplicates</button>
+                <button type="button" class="stdbtn clear-duplicates">Clear Duplicates</button>
+            </div>
+            <div class="select-btn-group">
+                <select class="duplicate-select-condition" name="duplicate-select-condition" id="duplicate-select">
+                    <option value="none">Select none</option>
+                    <option value="less-tags">Select every file in each duplicate group, except the file with the most tags</option>
+                    <option value="less-size">Select every file in each duplicate group, except the file with largest size</option>
+                    <option value="less-pages">Select every file in each duplicate group, except the file with most pages</option>
+                    <option value="not-old">Select every file in each duplicate group, except the youngest file</option>
+                    <option value="not-young"> Select every file in each duplicate group, except the oldest file</option>
+                </select>
+                <button type="button" class="stdbtn delete-selected btn-danger">Delete Selected</button>
+            </div>
+        </div>
+        [% END %]
+        <table id="ds" class="ds">
+            <thead>
+                <tr>
+                    <td>group-key</th>
+                    <th>check</th>
+                    <th>thumb</th>
+                    <th>Title</th>
+                    <th>Pages</th>
+                    <th>Filename</th>
+                    <th>Filesize</th>
+                    <th>Date</th>
+                    <th>Tags</th>
+                    [% IF userlogged %]
+                    <th>Action</th>
+                    [% END %]
+                </tr>
+            </thead>
+            <tbody>
+                [% FOREACH group IN duplicates %]
+                    [% first_archive = 1 %]
+                    [% FOREACH archive IN group %]
+                        <tr class="[% first_archive ? 'duplicate-group' : '' %]">
+                            <td>[% archive.group_key %]</td>
+                            <td>
+                                <div class="form-check">
+                                    <input type="checkbox" class="form-check-input">
+                                </div>
+                            </td>
+                            <td>
+                                <div class="thumbnail-wrapper">
+                                    <a href="/reader?id=[% archive.arcid %]" title="[% archive.title %]">
+                                        <img class="thumbnail" src="/api/archives/[% archive.arcid %]/thumbnail" width="100"/>
+                                    </a>
+                                    <div class="thumbnail-popover">
+                                        <img src="/api/archives/[% archive.arcid %]/thumbnail" />
+                                    </div>
+                                </div>
+                            </td>
+                            <td>[% archive.title %]</td>
+                            <td class="page-count">[% archive.pagecount %]</td>
+                            <td>[% archive.name %]</td>
+                            <td class="file-size">
+                                [% arcsize_mb = archive.arcsize / (1024 * 1024) %]
+                                [% arcsize_mb FILTER format('%.2f') %] MB
+                            </td>
+                            <td class="date-added">[% archive.date_added %]</td>
+                            <td class="tag-count">
+                                <i class="fa-solid fa-tag"></i>
+                                [% archive.tags.split(",").size %]
+                            </td>
+                            [% IF userlogged %]
+                            <td><button type="button" data-id="[% archive.arcid %]" class="stdbtn delete-archive action-button btn-danger">Delete</button></td>
+                            [% END %]
+                        </tr>
+                        [% first_archive = 0 %]
+                    [% END %]
+                [% END %]
+            </tbody>
+        </table>
+		<br>
+		<input id="goback" type="button" value="Return to Library" class="stdbtn">
+	</div>
+	[% INCLUDE footer %]
+
+</body>
+
+
+</html>


### PR DESCRIPTION
Implement a feature to detect and delete duplicate archives in the library based on the hamming distance between thumbnail hashes (https://github.com/Difegue/LANraragi/issues/338).

The minion job is parallelized and is way faster than the initial plugin, for my library (27k archives, 730GB) a full run took about 1h.
Additionally, I improved upon the script instead of only return duplicate pairs (e.g. we have 3 duplicate archives: id1 -> id2, id1 -> id3, id1 -> id3, now it returns one group [id1, id2, id3]).

view in `/duplicates`,  it is currently not connected from anywhere else. Should be considered if it should be linked to from navbar or settings. Furthermore, the CSS is defined inline in the HTML, maybe it should be separated into separate file?

![view-duplicates](https://github.com/user-attachments/assets/49fb0bed-e9e9-4db8-9bcd-5f6e1d094fd1)

I could not figure out how to do the tooltip for the tags like it is on index page. Would be great to see the actual tags if you hover over the tag count. I would need some help there.

I implemented different ways to delete the duplicates:
- manual - one by one
- selecting based on attribute
  - tag count
  - file size
  - page count
  - date

![select](https://github.com/user-attachments/assets/04766411-cd8f-4935-8261-87f58895675b)

A batch delete endpoint in the API would be great, the toasts are a bit annoying if you delete some archives in batch.

Tested on my library, detected and deleted 776 duplicate groups.

Would appreciate any feedback.

