### PR TITLE
Test for file existance before removing mojo/minion/shinobu pid files

### DIFF
--- a/tools/build/docker/s6/cont-init.d/01-lrr-setup
+++ b/tools/build/docker/s6/cont-init.d/01-lrr-setup
@@ -52,11 +52,21 @@ chown -R koyomi /home/koyomi/lanraragi/public/temp
 chmod u+rwx /home/koyomi/lanraragi/public/temp
 
 #Remove mojo, minion and shinobu pid files
-rm /home/koyomi/lanraragi/public/temp/server.pid
-rm /home/koyomi/lanraragi/public/temp/shinobu.pid
-rm /home/koyomi/lanraragi/public/temp/shinobu.pid-s6
-rm /home/koyomi/lanraragi/public/temp/minion.pid
-rm /home/koyomi/lanraragi/public/temp/minion.pid-s6
+if [ -f /home/koyomi/lanraragi/public/temp/server.pid ]; then
+    rm /home/koyomi/lanraragi/public/temp/server.pid
+fi
+if [ -f /home/koyomi/lanraragi/public/temp/shinobu.pid ]; then
+    rm /home/koyomi/lanraragi/public/temp/shinobu.pid
+fi
+if [ -f /home/koyomi/lanraragi/public/temp/shinobu.pid-s6 ]; then
+    rm /home/koyomi/lanraragi/public/temp/shinobu.pid-s6
+fi
+if [ -f /home/koyomi/lanraragi/public/temp/minion.pid ]; then
+    rm /home/koyomi/lanraragi/public/temp/minion.pid
+fi
+if [ -f /home/koyomi/lanraragi/public/temp/minion.pid-s6 ]; then
+  rm /home/koyomi/lanraragi/public/temp/minion.pid-s6
+fi
 
 # https://redis.io/topics/faq#background-saving-fails-with-a-fork-error-under-linux-even-if-i-have-a-lot-of-free-ram
 OVERCOMMIT=$(cat /proc/sys/vm/overcommit_memory)


### PR DESCRIPTION
Just a quick PR to remove a handful of common startup errors from the logs. This PR updates the pid file removals in 01-lrr-setup to only happen if the files actually exist.

Tested on my container-based deployment.