### PR TITLE
Fixed Fakku summary (again) and added "thumb" folder to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 content
+thumb
 .minion.db*
 npm-debug.log
 dump.rdb

--- a/lib/LANraragi/Plugin/Metadata/Fakku.pm
+++ b/lib/LANraragi/Plugin/Metadata/Fakku.pm
@@ -25,14 +25,16 @@ sub plugin_info {
         namespace   => "fakkumetadata",
         login_from  => "fakkulogin",
         author      => "Difegue, Nodja, Nixis198",
-        version     => "0.99",
+        version     => "1.0.1",
         description =>
           "Searches FAKKU for tags matching your archive. If you have an account, don't forget to enter the matching cookie in the login plugin to be able to access controversial content. <br/><br/>
            <i class='fa fa-exclamation-circle'></i> <b>This plugin can and will return invalid results depending on what you're searching for!</b> <br/>The FAKKU search API isn't very precise and I recommend you either enable 'Only use current title for exact matches', or use the Chaika.moe plugin when possible.",
         icon =>
           "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAAACZSURBVDhPlY+xDYQwDEWvZgRGYA22Y4frqJDSZhFugiuuo4cqPGT0iTjAYL3C+fGzktc3hEcsQvJq6HtjE2Jdv4viH4a4pWnL8q4A6g+ET9P8YhS2/kqwIZXWnwqChDxPfCFfD76wOzJ2IOR/0DSwnuRKYAKUW3gq2OsJTYM0jr7QVRVwlabJEaw3ARYBcmFXeomxphIeEMIMmh3lOLQR+QQAAAAASUVORK5CYII=",
         oneshot_arg => "FAKKU Gallery URL (Will attach tags matching this exact gallery to your archive)",
-        parameters  => [ { type => "bool", desc => "Add 'Source' tag" }, { type => "bool", desc => "Only use current title for exact matches" } ]
+        parameters  => [
+            { type => "bool", desc => "Add 'Source' tag" }, { type => "bool", desc => "Only use current title for exact matches" }
+        ]
     );
 
 }
@@ -41,9 +43,9 @@ sub plugin_info {
 sub get_tags {
 
     shift;
-    my $lrr_info     = shift;                     # Global info hash
-    my $ua           = $lrr_info->{user_agent};
-    my ($add_source, $safe_mode) = @_;
+    my $lrr_info = shift;                     # Global info hash
+    my $ua       = $lrr_info->{user_agent};
+    my ( $add_source, $safe_mode ) = @_;
 
     my $logger = get_plugin_logger();
 
@@ -78,7 +80,7 @@ sub get_tags {
 
     my $current_title = $lrr_info->{archive_title};
 
-    if ($safe_mode && !$URL_safe && $newtitle ne $current_title) {
+    if ( $safe_mode && !$URL_safe && $newtitle ne $current_title ) {
         $logger->info("Found FAKKU Gallery '$newtitle', but it does not match current title '$current_title' exactly");
         die "Exact title match not found\n";
     }
@@ -193,14 +195,13 @@ sub get_tags_from_fakku {
     my @tags = ();
 
     # Finds the DIV for the Summary.
-    my $summ_selector =
-      '.table-cell.w-full.align-top.text-left.space-y-2.leading-relaxed.link\:text-blue-700.dark\:link\:text-white';
-    my $summ_div = $dom->at($summ_selector);
+    my $summ_selector = 'meta[name="description"]';
+    my $summ_div      = $dom->at($summ_selector);
     my $summary;
 
-    # If the Summary DIV doesn't exist, return a blank string.
-    if ( defined $summ_div ) {
-        $summary = $summ_div->all_text;
+    # # If the Summary DIV doesn't exist, return a blank string.
+    if ($summ_div) {
+        $summary = $summ_div->{content};
     } else {
         $summary = "";
     }

--- a/tests/samples/fakku/002_gallery_front.html
+++ b/tests/samples/fakku/002_gallery_front.html
@@ -31,7 +31,7 @@
     <meta name="Robots" content="Index,Follow">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
 
-    <meta name="description" content="">
+    <meta name="description" content="Bold baby bold. This is a test summary. Hi mom.">
     <meta property="og:title" content="Kairakuten Cover Girl&#39;s Episode 009: Hamao Hentai by Hamao - FAKKU">
     <meta property="og:type" content="article">
     <meta property="og:locale" content="en_US">
@@ -323,7 +323,9 @@
                         </div>
                         <div class="table text-sm w-full">
                             <div
-                                class="table-cell w-full align-top text-left space-y-2 leading-relaxed link:text-blue-700 dark:link:text-white"><b>Bold baby bold. </b>This is a test summary. Hi mom.</div>
+                                class="table-cell w-full align-top text-left space-y-2 leading-relaxed link:text-blue-700 dark:link:text-white">
+                                <b>Bold baby bold. </b>This is a test summary. Hi mom.
+                            </div>
                         </div>
 
 


### PR DESCRIPTION
Fakku been updating their website again and broke the summary part.
Looking at the HTML it seems that they put the summary in a div that shouldn't change so this fix should last for a bit.
I updated the test HTML to simulate the new format, so all tests pass for it.

I also added the "thumb" folder to the gitignore list.