### PR TITLE
Fix server info type coercion of web

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -98,8 +98,8 @@ Index.initializeAll = function () {
     Server.callAPI("/api/info", "GET", null, "Error getting basic server info!",
         (data) => {
             Index.serverVersion = data.version;
-            Index.debugMode = data.debug_mode === "1";
-            Index.isProgressLocal = data.server_tracks_progress !== "1";
+            Index.debugMode = !!data.debug_mode;
+            Index.isProgressLocal = !data.server_tracks_progress;
             Index.pageSize = data.archives_per_page;
 
             // Check version if not in debug mode


### PR DESCRIPTION
Somehow the boolean fields from the server info response are now of boolean type, while the corresponding JS code only treats `"1"` as truthy, causing both debugMode and serverTracksProgress to be effectively false even when enabled.

![image](https://github.com/user-attachments/assets/5976f638-0ead-4d37-8e4e-89d61de0cb84)

In this PR I changed the code to consider canonical truthy values as true.