### PR TITLE
fixes inconsistencies in plugin parameters returned by the API

### DIFF
--- a/lib/LANraragi/Controller/Api/Other.pm
+++ b/lib/LANraragi/Controller/Api/Other.pm
@@ -87,6 +87,17 @@ sub list_plugins {
     my $type = $self->stash('type');
 
     my @plugins = get_plugins($type);
+
+    foreach my $plugin (@plugins) {
+        if ( ref( $plugin->{parameters} ) eq 'HASH' ) {
+            my @parameters_array;
+            while ( my ( $name, $value ) = each %{ $plugin->{parameters} } ) {
+                push @parameters_array, { %{$value}, 'name' => $name };
+            }
+            $plugin->{parameters} = \@parameters_array;
+        }
+    }
+
     $self->render( json => \@plugins );
 }
 


### PR DESCRIPTION
As pointed out by @Guerra24 in [this comment](https://github.com/Difegue/LANraragi/pull/1091#issuecomment-2480458807), there were some inconsistencies in the way plugin parameters were returned by the API `/api/plugins/:type`.

This should fix them.