### PR TITLE
Explicitly use ipv4 in Docker healthcheck

### DIFF
--- a/tools/build/docker/Dockerfile
+++ b/tools/build/docker/Dockerfile
@@ -19,7 +19,7 @@ ENTRYPOINT ["//init"]
 # Check application health
 HEALTHCHECK --interval=1m --timeout=10s --retries=3 \
   CMD wget --quiet --tries=1 --no-check-certificate --spider -Y off \
-  http://localhost:3000 || exit 1
+  http://127.0.0.1:3000 || exit 1
 
 #Default mojo server port
 EXPOSE 3000


### PR DESCRIPTION
When running the current Docker image, the healthcheck fails. This is because (by inspecting `/etc/hosts`), localhost is resolved to an ipv6 address. By default, Docker does not use/support ipv6. (https://docs.docker.com/engine/daemon/ipv6/, https://www.reddit.com/r/ipv6/comments/1alpzmb/docker_deployments_and_ipv6_how_do_you_do_it/) The solution is to explicitly use an ipv4 address rather than resolve it using localhost (it will take ~1min for the health status to be reflected).