### PR TITLE
Fix noisy logs

### DIFF
--- a/lib/LANraragi/Controller/Api/Search.pm
+++ b/lib/LANraragi/Controller/Api/Search.pm
@@ -65,7 +65,7 @@ sub handle_api {
 
     my $filter     = $req->param('filter');
     my $category   = $req->param('category') || "";
-    my $start      = $req->param('start');
+    my $start      = $req->param('start') || 0;
     my $sortkey    = $req->param('sortby');
     my $sortorder  = $req->param('order');
     my $newfilter  = $req->param('newonly') || "false";

--- a/lib/LANraragi/Model/Stats.pm
+++ b/lib/LANraragi/Model/Stats.pm
@@ -28,7 +28,7 @@ sub get_archive_count {
 sub get_page_stat {
 
     my $redis = LANraragi::Model::Config->get_redis_config;
-    my $stat  = $redis->get("LRR_TOTALPAGESTAT") + 0 || 0;
+    my $stat  = $redis->get("LRR_TOTALPAGESTAT") || 0 + 0;
     $redis->quit();
 
     return $stat;

--- a/lib/LANraragi/Model/Stats.pm
+++ b/lib/LANraragi/Model/Stats.pm
@@ -28,7 +28,7 @@ sub get_archive_count {
 sub get_page_stat {
 
     my $redis = LANraragi::Model::Config->get_redis_config;
-    my $stat  = $redis->get("LRR_TOTALPAGESTAT") || 0 + 0;
+    my $stat  = ($redis->get("LRR_TOTALPAGESTAT") || 0) + 0;
     $redis->quit();
 
     return $stat;

--- a/lib/LANraragi/Plugin/Metadata/EHentai.pm
+++ b/lib/LANraragi/Plugin/Metadata/EHentai.pm
@@ -203,7 +203,7 @@ sub ehentai_parse {
     my $firstgal = $dom->at(".glink")->parent->attr('href');
 
     # A EH link looks like xhentai.org/g/{gallery id}/{gallery token}
-    my $url = ( split( 'hentai.org/g/', $firstgal ) )[1];
+    $url = ( split( 'hentai.org/g/', $firstgal ) )[1];
     my ( $gID, $gToken ) = ( split( '/', $url ) );
 
     if ( index( $dom->to_string, "You are opening" ) != -1 ) {


### PR DESCRIPTION
Small fixes to code that cause lots of "use of uninitialized value" and redeclaration warnings. In particular, the "start" var is often undefined and throws a warning whenever search is called. Hopefully this commit will lead to less noisy logs.