### PR TITLE
Do not use greedy regex

### DIFF
--- a/lib/LANraragi/Model/Search.pm
+++ b/lib/LANraragi/Model/Search.pm
@@ -408,7 +408,7 @@ sub sort_results( $sortkey, $sortorder, @filtered ) {
 
         # For other tags, we use the first tag we found that matches the sortkey/namespace.
         # (If no tag, defaults to "zzzz")
-        %tmpfilter = map { $_ => ( $redis->hget( $_, "tags" ) =~ m/.*${re}:(.*)(\,.*|$)/ ) ? $1 : "zzzz" } @filtered;
+        %tmpfilter = map { $_ => ( $redis->hget( $_, "tags" ) =~ m/.*${re}:(.*?)(\,.*|$)/ ) ? $1 : "zzzz" } @filtered;
 
         # Read comments from the bottom up for a better understanding of this sort algorithm.
         @sorted = map { $_->[0] }                  # Map back to only having the ID


### PR DESCRIPTION
Closes #1122.

The sorting issue happens in the search API, which uses regex to get the sortingkey and passes it to ncmp. After logging arguments for ncmp I found that it's taking not only the value for a key-value tag, but it's also getting subsequent tags, i.e. the comma is being included, e.g.

tags = "date_uploaded:123,date_added:321,tag1,tag2" with sortkey "date_uploaded" can sometimes overreach and be "123,date_added:321" instead of "123" and resulting in incorrectly sorted search results.

Checking again, turns out this regex is greedy. The fix is to disable greediness.