### PR TITLE
Fix the issue where "Pin this Category" doesn't work in Chrome

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -663,7 +663,7 @@ Index.loadCategories = function () {
             // Sort by pinned + alpha
             // Pinned categories are shown at the beginning
             data.sort((b, a) => b.name.localeCompare(a.name));
-            data.sort((a, b) => a.pinned < b.pinned);
+            data.sort((a, b) => b.pinned - a.pinned);
             let html = "";
 
             const iteration = (data.length > 10 ? 10 : data.length);


### PR DESCRIPTION
This should fix #1038
Fix the issue where "Pin this Category" doesn't work in Chrome.

According to the documentation: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort The sorting function should return a positive number, negative number, or 0. However, a boolean value is currently being used, which leads to unstable sorting results and unexpected behavior.

I’m not sure why everything works fine in Firefox, but this patch will fix the issue in Chrome and also return the correct results in Firefox.

修复在Chrome浏览器中“Pin this Category”不起作用

根据文档：https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort 排序函数需要返回正数、负数或0，而当前使用的是布尔值，这会导致排序结果不稳定而产生意外结果。

我尚不清楚为何在Firefox中一切正常，不过这个补丁可以修复在Chrome中的问题，同时在Firefox中也能返回正确结果。