### PR TITLE
docs(basic-operations/first-steps): links Batch Tagging

### DIFF
--- a/tools/Documentation/basic-operations/first-steps.md
+++ b/tools/Documentation/basic-operations/first-steps.md
@@ -66,7 +66,7 @@ The following formats are supported by LRR for Archives:
 If you plan on setting your content folder to a folder that already contains archives, you might want to enable **some Plugins** beforehand, so that metadata will be fetched for your files as they're added. See the Metadata documentation linked below for more info.
 
 However, beware that if you enable plugins that depend on remote services, querying said services to scrap metadata for a large number of archives might lead to **temporary bans**!\
-If you have a large number of archives (More than 500), you might want to ignore Automatic Plugin execution and use [Batch Tagging](../advanced-usage/batch-tagging/) instead.
+If you have a large number of archives (More than 500), you might want to ignore Automatic Plugin execution and use [Batch Tagging](../advanced-usage/batch-tagging.md) instead.
 {% endhint %}
 
 ## Thumbnail Folder


### PR DESCRIPTION
Markdown extension for navigating intended links.