### PR TITLE
Fix incorrect sort display

### DIFF
--- a/public/js/index_datatables.js
+++ b/public/js/index_datatables.js
@@ -283,7 +283,7 @@ IndexTable.drawCallback = function () {
         if (currentSort > currentCustomColumnCount) {
             localStorage.indexSort = 0;
         }
-        if (currentSort >= 1 && currentSort <= columnCount) {
+        if (currentSort >= 1 && currentSort <= columnCount.value) {
             currentSort = localStorage[`customColumn${currentSort}`] || `Header ${currentSort}`;
         } else {
             currentSort = "title";


### PR DESCRIPTION
Closes #1183 

`columnCount` isn't a number, it's some html object and cannot be properly compared with a number. To get the value of column count you would need to access the value attribute.

Making the change results in a correct comparison, but please double-check if the logic is correct