### PR TITLE
Fix Incorrect recordsTotal value in search API.

### DIFF
--- a/lib/LANraragi/Model/Search.pm
+++ b/lib/LANraragi/Model/Search.pm
@@ -36,8 +36,11 @@ sub do_search ( $filter, $category_id, $start, $sortkey, $sortorder, $newonly, $
 
     my $tankcount = $redis->scard("LRR_TANKGROUPED") + 0;
 
+    # Get tank ids count
+    my $tankidscount = scalar(LANraragi::Model::Config->get_redis->keys('TANK_??????????'));
+
     # Total number of archives (as int)
-    my $total = $grouptanks ? $tankcount : $redis->zcard("LRR_TITLES") - $tankcount;
+    my $total = $grouptanks ? $tankcount : $redis->zcard("LRR_TITLES") - $tankidscount;
 
     # Look in searchcache first
     my $sortorder_inv = $sortorder ? 0 : 1;


### PR DESCRIPTION
Fix incorrect recordsTotal value in search API due to arithmetic error.

According to the comment in lib\LANraragi\Model\Stats.pm:
```
# - LRR_TITLES, which is a lexicographically sorted set containing all (archive + tank) titles in the DB, alongside their ID. (In the "title\0ID" format)
# - LRR_TANKGROUPED, which is a set containing all tank IDs in the DB, and the archive IDs that aren't in any tanks.
```

The issue occurs here:
`$redis->zcard("LRR_TITLES") - $tankidscount;`
This causes an incorrect result when there are no tanks, as `LRR_TITLES` and `LRR_TANKGROUPED` are equal, and their difference becomes `0`.
In cases with tanks, a similar issue occurs, leading to incorrect results and ultimately an incorrect `recordsTotal` value.