### PR TITLE
Add Scroll snap (Help Needed)

### DIFF
--- a/public/css/lrr.css
+++ b/public/css/lrr.css
@@ -1,5 +1,9 @@
 /* Global LANraragi CSS. Don't mess !*/
 
+html {
+  scroll-snap-type: y mandatory;
+}
+
 body {
   touch-action: manipulation;
 }
@@ -287,6 +291,7 @@ p#nb {
   user-select: none;
   align-self: center;
   cursor: pointer;
+  scroll-snap-align: end; /* Snap to the bottom of the current image */
 }
 
 .caption-reader {


### PR DESCRIPTION
Spent 7 hours straight trying many different methods to get scroll-snapping to work on both the top, and bottom of each image, and have it not snap to the bottom of the last image. But doing this via CSS was proving near-impossible. There's no way to set two snapping positions on one element, and if you use two separate elements, then well your margins overlap and tha causes issues too.

This needs either HTML or JS changes to function properly. And allow us to set the scroll type somewhere.. other than inside the HTML Element. Currently thats the only place it can be set in CSS, setting it to any other element or class will cause the image div to have another scrollbar, and now you can only scroll images from the middle of the screen and it breaks the interface.

Well, this extremely basic change in CSS does work, but there's no snapping when scrolling up to previous page, or scrolling to top of current.. Its not ideal. I played around with trying different margins and start/end on the elements but it only works with one at a time.

https://github.com/Difegue/LANraragi/issues/743

