### PR TITLE
Spacebar snapping logic & next page fix

### DIFF
--- a/public/css/lrr.css
+++ b/public/css/lrr.css
@@ -1,5 +1,9 @@
 /* Global LANraragi CSS. Don't mess !*/
 
+html {
+  scroll-snap-type: y mandatory;
+}
+
 body {
   touch-action: manipulation;
 }
@@ -287,6 +291,7 @@ p#nb {
   user-select: none;
   align-self: center;
   cursor: pointer;
+  scroll-snap-align: end; /* Snap to the bottom of the current image */
 }
 
 .caption-reader {


### PR DESCRIPTION
The new spacebar logic to go to next page doesn't work on Firefox at all, whereas the previous logic only worked on some pages. It turns out my theory about fractual pixels was correct, if an image had its pixel count rounded up/down which changed the dimensions/aspect ratio, LRR wouldn't know it was at the end of the page.

Fixing that could've been as simple as setting a pixel offset of 3 here:
```
if (($(window).height() + $(window).scrollTop()) >= (LRR.getDocHeight() - 3)) {
    (Reader.mangaMode) ? Reader.changePage(-1) : Reader.changePage(1);
}
```
But I decided to make the spacebar logic better, now you can easily spam it to keep going down, snap to bottom of images, or skip to next image if already at the bottom. And the opposite for going up and to previous pages with shift+space.