### PR TITLE
Hitomi.pm JS URL

### DIFF
--- a/lib/LANraragi/Plugin/Metadata/Hitomi.pm
+++ b/lib/LANraragi/Plugin/Metadata/Hitomi.pm
@@ -104,7 +104,7 @@ sub get_js_from_hitomi {
 
     my $logger = get_plugin_logger();
 
-    my $gJS = "https://ltn.hitomi.la/galleries/$gID.js";
+    my $gJS = "https://ltn.gold-usergeneratedcontent.net/galleries/$gID.js";
 
     $logger->debug("Hitomi JS: $gJS");
 


### PR DESCRIPTION
Hitomi changed their internal site structure and has started serving CSS and JS from https://ltn.gold-usergeneratedcontent.net instead of https://ltn.hitomi.la - plugin executions with the old URL will hit a 404.