### PR TITLE
Fix the maketext errors (and add some CN translations)

### DIFF
--- a/lib/LANraragi/Utils/I18NInitializer.pm
+++ b/lib/LANraragi/Utils/I18NInitializer.pm
@@ -36,9 +36,11 @@ sub initialize {
             my @encoded_args = map { Encode::encode( 'UTF-8', $_ ) } @args;
 
             my $translated;
+            my $error;
             eval { $translated = $handle->maketext( $key, @encoded_args ); };
-            if ($@) {
-                $c->LRR_LOGGER->error("Maketext error: $@");
+            $error = $@;
+            if ($error) {
+                $c->LRR_LOGGER->error("Maketext error: [$error]");
                 return $key;
             }
 

--- a/locales/template/en.po
+++ b/locales/template/en.po
@@ -1310,6 +1310,7 @@ msgstr "Error getting basic server info."
 
 msgid "You're running in Debug Mode!"
 msgstr "You're running in Debug Mode!"
+
 msgid "Advanced server statistics can be viewed <a href=\"\${url}\")>here</a>."
 msgstr "Advanced server statistics can be viewed <a href=\"${url}\")>here</a>."
 
@@ -1364,7 +1365,7 @@ msgstr "Click here to check it out."
 msgid "Error getting changelog for new version"
 msgstr "Error getting changelog for new version"
 
-msgid Couldn't load data for \${id}!"
+msgid "Couldn't load data for \${id}!"
 msgstr "Couldn't load data for ${id}!"
 
 msgid "This archive isn't in any category."
@@ -1500,7 +1501,7 @@ msgid "Added \${id} to category \${cat}!"
 msgstr "Added ${id} to category ${cat}!"
 
 msgid "Removed \${id} from category \${cat}!"
-msgstr "Removed ${id} from category ${cat}!"$
+msgstr "Removed ${id} from category ${cat}!"
 
 msgid "Couldn't delete archive file. <br/> (Maybe it has already been deleted beforehand?)"
 msgstr "Couldn't delete archive file. <br/> (Maybe it has already been deleted beforehand?)"

--- a/locales/template/zh.po
+++ b/locales/template/zh.po
@@ -1112,3 +1112,434 @@ msgid "Return to Library"
 msgstr "返回库"
 
 # ------End of Upload.html.tt2------
+
+msgid "Rescan Archive Directory"
+msgstr "重新扫描指定文件夹"
+
+msgid "Click this button to trigger a rescan of the Archive Directory in case you're missing files, or some data such as total page counts."
+msgstr "Click this button to trigger a rescan of the Archive Directory in case you're missing files, or some data such as total page counts."
+
+# ------Stary of i18n.html.tt2------
+
+msgid "Backup restored!"
+msgstr "还原备份成功！"
+
+msgid "An error occured while restoring the backup.<br/> Please check the server logs and that your JSON is correctly formatted."
+msgstr "An error occured while restoring the backup.<br/> Please check the server logs and that your JSON is correctly formatted."
+
+msgid "Couldn't load the complete archive list! Please reload the page."
+msgstr "Couldn't load the complete archive list! Please reload the page."
+
+msgid "Couldn't load the tag statistics! Please reload the page."
+msgstr "无法加载标签统计！请刷新页面。"
+
+msgid "Error getting untagged archives!"
+msgstr "无标签文档获取失败！"
+
+msgid "Are you sure you want to delete this archive?"
+msgstr "您确定要删除此文档吗？"
+
+msgid "Are you sure you want to delete the selected archives?"
+msgstr "您确定要删除一下文档吗？"
+
+msgid "This action cannot be undone!"
+msgstr "此操作无法撤销！"
+
+msgid "This action (truly) cannot be undone!"
+msgstr "此操作（真的）无法撤销！"
+
+msgid "Yes, delete it!"
+msgstr "确定删除！"
+
+msgid "No, keep it!"
+msgstr "保留！"
+
+msgid "Error while deleting cache! Check application logs."
+msgstr "删除缓存失败！请查看应用日志。"
+
+msgid "Error while processing request"
+msgstr "处理请求失败"
+
+msgid "Error checking Minion job status"
+msgstr "Minion 任务状态查看失败"
+
+msgid "Saved!"
+msgstr "已保存！"
+
+msgid "Error saving data"
+msgstr "保存失败"
+
+msgid "Started Batch Operation..."
+msgstr "批量操作已启动。。。"
+
+msgid "Batch Operation complete!"
+msgstr "批量操作已完成！"
+
+msgid "An error occured during batch tagging!"
+msgstr "批量添加标签时出错！"
+
+msgid "Please check application logs."
+msgstr "请查看应用日志。"
+
+msgid "Error! Terminating session."
+msgstr "批量操作发生错误，正在中止。"
+
+msgid "Sleeping for \${x} seconds."
+msgstr "等待${x}秒."
+
+msgid "Error while processing ID \${id} (\${msg})"
+msgstr "处理文档 ${id} 出错：(${msg})"
+
+msgid "Processed ID \${id} with \"\${plug}\" (Added tags: \${tags})"
+msgstr "已处理文档 ${id}，调用插件 "${plug}"（新增标签: ${tags}）"
+
+msgid "Deleted ID \${id} (Filename: \${filename})"
+msgstr "已删除文档 ${id} (文件名：${filename})"
+
+msgid "Replaced tags for ID \${id} (New tags: \${tags})"
+msgstr "已更新文档 ${id}（新增标签：${tags}）"
+
+msgid "Added ID \${id} to category \${category}! (\${msg})"
+msgstr "已将文档 ${id} 添加到分类 ${category}！（${msg}）"
+
+msgid "Cleared new flag for ID \${id}!"
+msgstr "清楚了文档 ${id} 的未读标签!"
+
+msgid "Unknown operation \${oper} (\${msg})"
+msgstr "未知操作：${oper} (${msg})"
+
+msgid "Changed title to: \${title}"
+msgstr "文档改名为：${title}"
+
+msgid "Reloading page in 5 seconds to account for deleted archives..."
+msgstr "Reloading page in 5 seconds to account for deleted archives..."
+
+msgid "Cancelling Batch Operation..."
+msgstr "取消批量操作中。。。"
+
+msgid "Enter a name for the new category"
+msgstr "请输入新分类的名称"
+
+msgid "My Category"
+msgstr "我的分类"
+
+msgid "Please enter a category name."
+msgstr "请输入分类名称"
+
+msgid "No category"
+msgstr "No category"
+
+msgid "Error getting categories from server"
+msgstr "Error getting categories from server"
+
+msgid "Error modifying category"
+msgstr "Error modifying category"
+
+msgid "The category will be deleted permanently."
+msgstr "The category will be deleted permanently."
+
+msgid "Category deleted!"
+msgstr "Category deleted!"
+
+msgid "Error deleting category"
+msgstr "Error deleting category"
+
+msgid "Writing a Predicate"
+msgstr "Writing a Predicate"
+
+msgid "Predicates follow the same syntax as searches in the Archive Index. Check the Documentation for more information."
+msgstr "Predicates follow the same syntax as searches in the Archive Index. Check the <a href="https://sugoi.gitbook.io/lanraragi/basic-operations/searching\">Documentation</a> for more information."
+
+msgid "Background Worker restarted!"
+msgstr "Background Worker restarted!"
+
+msgid "Error restarting Worker:"
+msgstr "Error restarting Worker:"
+
+msgid "Content folder rescan started!"
+msgstr "Content folder rescan started!"
+
+msgid "Error starting content folder rescan:"
+msgstr "Error starting content folder rescan:"
+
+msgid "Error while querying Shinobu status:"
+msgstr "Error while querying Shinobu status:"
+
+msgid "About Plugins"
+msgstr "About Plugins"
+
+msgid "You can use plugins to automatically fetch metadata for this archive. <br/> Just select a plugin from the dropdown and hit Go! <br/> Some plugins might provide an optional argument for you to specify. If that's the case, a textbox will be available to input said argument."
+msgstr "You can use plugins to automatically fetch metadata for this archive. <br/> Just select a plugin from the dropdown and hit Go! <br/> Some plugins might provide an optional argument for you to specify. If that's the case, a textbox will be available to input said argument."
+
+msgid "Metadata saved!"
+msgstr "Metadata saved!"
+
+msgid "Error saving archive metadata"
+msgstr "Error saving archive metadata"
+
+msgid "Error while fetching tags"
+msgstr "Error while fetching tags"
+
+msgid "Archive title changed to"
+msgstr "Archive title changed to"
+
+msgid "Archive summary updated!"
+msgstr "Archive summary updated!"
+
+msgid "Added the following tags"
+msgstr "Added the following tags"
+
+msgid "No new tags added!"
+msgstr "No new tags added!"
+
+# Do not translate _START_, _END_ or _TOTAL_.
+msgid "Showing _START_ to _END_ of _TOTAL_ ancient chinese lithographies."
+msgstr "Showing _START_ to _END_ of _TOTAL_ ancient chinese lithographies."
+
+msgid "No archives to show you! Try <a href=\"\${url}\")>uploading some</a>?"
+msgstr "No archives to show you! Try <a href=\"${url}\")>uploading some</a>?"
+
+msgid "Welcome to LANraragi \${version}!"
+msgstr "Welcome to LANraragi ${version}!"
+
+msgid "If you want to perform advanced operations on an archive, remember to just right-click its name. Happy reading!"
+msgstr "If you want to perform advanced operations on an archive, remember to just right-click its name. Happy reading!"
+
+msgid "Error getting basic server info."
+msgstr "Error getting basic server info."
+
+msgid "You're running in Debug Mode!"
+msgstr "You're running in Debug Mode!"
+
+msgid "Advanced server statistics can be viewed <a href=\"\${url}\")>here</a>."
+msgstr "Advanced server statistics can be viewed <a href=\"${url}\")>here</a>."
+
+msgid "Enter a tag namespace for this column"
+msgstr "Enter a tag namespace for this column"
+
+msgid "Enter a full namespace without the colon, e.g \"artist\"."
+msgstr "Enter a full namespace without the colon, e.g "artist"."
+
+msgid "If you have multiple tags with the same namespace, only the last one will be shown in the column."
+msgstr "If you have multiple tags with the same namespace, only the last one will be shown in the column."
+
+msgid "Tag namespace"
+msgstr "Tag namespace"
+
+msgid "Please enter a tag namespace."
+msgstr "Please enter a tag namespace."
+
+msgid "Randomly Picked"
+msgstr "随即精选"
+
+msgid "New Archives"
+msgstr "新文档"
+
+msgid "Untagged Archives"
+msgstr "无标签文档"
+
+msgid "On Deck"
+msgstr "On Deck"
+
+msgid "Error getting carousel data!"
+msgstr "Error getting carousel data!"
+
+msgid "Edit this column"
+msgstr "Edit this column"
+
+msgid "Title"
+msgstr "Title"
+
+msgid "Tags"
+msgstr "Tags"
+
+msgid "Header"
+msgstr "Header"
+
+msgid "A new version of LANraragi (\${version}) is available!"
+msgstr "A new version of LANraragi (${version}) is available!"
+
+msgid "Click here to check it out."
+msgstr "Click here to check it out."
+
+msgid "Error getting changelog for new version"
+msgstr "Error getting changelog for new version"
+
+msgid "Couldn't load data for \${id}!"
+msgstr "Couldn't load data for ${id}!"
+
+msgid "This archive isn't in any category."
+msgstr "This archive isn't in any category."
+
+msgid "No Categories yet..."
+msgstr "No Categories yet..."
+
+msgid "Remove rating"
+msgstr "Remove rating"
+
+msgid "Click here to display new archives only."
+msgstr "Click here to display new archives only."
+
+msgid "Click here to display untagged archives only."
+msgstr "Click here to display untagged archives only."
+
+msgid "Click here to display archives in this category only."
+msgstr "Click here to display archives in this category only."
+
+msgid "Your Reading Progression is now saved on the server!"
+msgstr "Your Reading Progression is now saved on the server!"
+
+msgid "You seem to have some local progression hanging around -- Please wait warmly while we migrate it to the server for you."
+msgstr "You seem to have some local progression hanging around -- Please wait warmly while we migrate it to the server for you."
+
+msgid "Error while migrating local progression to server"
+msgstr "Error while migrating local progression to server"
+
+msgid "Reading Progression has been fully migrated"
+msgstr "Reading Progression has been fully migrated"
+
+msgid "You'll have to reopen archives in the Reader to see the migrated progression values."
+msgstr "You'll have to reopen archives in the Reader to see the migrated progression values."
+
+msgid "Plugin uploaded successfully!"
+msgstr "Plugin uploaded successfully!"
+
+msgid "The plugin \${name} has been successfully added. Refresh the page to see it."
+msgstr "The plugin ${name} has been successfully added. Refresh the page to see it."
+
+msgid "Error uploading plugin"
+msgstr "Error uploading plugin"
+
+msgid "Successfully set page \${page} as the thumbnail!"
+msgstr "Successfully set page ${page} as the thumbnail!"
+
+msgid "Error updating thumbnail"
+msgstr "Error updating thumbnail"
+
+msgid "Error clearing new flag"
+msgstr "Error clearing new flag"
+
+msgid "Error getting the archive's imagelist."
+msgstr "Error getting the archive's imagelist."
+
+msgid "This archive seems to be in RAR format!"
+msgstr "This archive seems to be in RAR format!"
+
+msgid "RAR archives might not work properly in LANraragi depending on how they were made. If you encounter errors while reading, consider converting your archive to zip."
+msgstr "RAR archives might not work properly in LANraragi depending on how they were made. If you encounter errors while reading, consider converting your archive to zip."
+
+msgid "EPUB support in LANraragi is minimal"
+msgstr "EPUB support in LANraragi is minimal"
+
+msgid "EPUB books will only show images in the Web Reader, and potentially out of order. If you want text support, consider pairing LANraragi with an OPDS reader."
+msgstr "EPUB books will only show images in the Web Reader, and potentially out of order. If you want text support, consider pairing LANraragi with an <a href='https://sugoi.gitbook.io/lanraragi/advanced-usage/external-readers#generic-opds-readers'>OPDS reader.</a>"
+
+msgid "Navigation Help"
+msgstr "Navigation Help"
+
+msgid "Error updating reading progression"
+msgstr "Error updating reading progression"
+
+msgid "Page \${page}"
+msgstr "Page ${page}"
+
+msgid "The page thumbnailing job didn't conclude properly. Your archive might be corrupted."
+msgstr "The page thumbnailing job didn't conclude properly. Your archive might be corrupted."
+
+msgid "A script is already running."
+msgstr "A script is already running."
+
+msgid "Please wait for it to finish before starting a new one."
+msgstr "Please wait for it to finish before starting a new one."
+
+msgid "An error occured while running the script"
+msgstr "An error occured while running the script"
+
+msgid "Script result"
+msgstr "Script result"
+
+msgid "Script failed with error: \${error}"
+msgstr "Script failed with error: ${error}"
+
+msgid "Temporary folder cleaned!"
+msgstr "Temporary folder cleaned!"
+
+msgid "Error cleaning temporary folder"
+msgstr "Error cleaning temporary folder"
+
+msgid "Threw away the search cache!"
+msgstr "Threw away the search cache!"
+
+msgid "All archives are no longer new!"
+msgstr "All archives are no longer new!"
+
+msgid "Error during cleanup procedure"
+msgstr "Error during cleanup procedure"
+
+msgid "Are you sure you want to wipe the database?"
+msgstr "Are you sure you want to wipe the database?"
+
+msgid "Sayonara! Redirecting you..."
+msgstr "Sayonara! Redirecting you..."
+
+msgid "Successfully cleaned the database and removed \${entries} entries."
+msgstr "Successfully cleaned the database and removed ${entries} entries."
+
+msgid "\${entries} other entries have been unlinked from the database and will be deleted on the next cleanup!"
+msgstr "${entries} other entries have been unlinked from the database and will be deleted on the next cleanup!"
+
+msgid "Do a backup now if some files disappeared from your archive index."
+msgstr "Do a backup now if some files disappeared from your archive index."
+
+msgid "Queued up a job to regenerate thumbnails! Stay tuned for updates or check the Minion console."
+msgstr "Queued up a job to regenerate thumbnails! Stay tuned for updates or check the Minion console."
+
+msgid "All thumbnails generated! Errors will be listed below if there were any."
+msgstr "All thumbnails generated! Errors will be listed below if there were any."
+
+msgid "Added \${id} to category \${cat}!"
+msgstr "Added ${id} to category ${cat}!"
+
+msgid "Removed \${id} from category \${cat}!"
+msgstr "Removed ${id} from category ${cat}!"
+
+msgid "Couldn't delete archive file. <br/> (Maybe it has already been deleted beforehand?)"
+msgstr "Couldn't delete archive file. <br/> (Maybe it has already been deleted beforehand?)"
+
+msgid "Archive metadata has been deleted properly. <br> Please delete the file manually before returning to the archive index."
+msgstr "Archive metadata has been deleted properly. <br> Please delete the file manually before returning to the archive index."
+
+msgid "Archive successfully deleted. Redirecting you..."
+msgstr "Archive successfully deleted. Redirecting you..."
+
+msgid "Error while deleting archive"
+msgstr "Error while deleting archive"
+
+msgid "Processing your upload... (Job #\${jobid})"
+msgstr "Processing your upload... (Job #${jobid})"
+
+msgid "Downloading file... (Job #\${jobid})"
+msgstr "Downloading file... (Job #${jobid})"
+
+msgid "Processing"
+msgstr "Processing"
+
+msgid "Completed"
+msgstr "Completed"
+
+msgid "Failed"
+msgstr "Failed"
+
+msgid "Total"
+msgstr "Total"
+
+msgid "Click here to edit metadata."
+msgstr "Click here to edit metadata."
+
+msgid "Error while processing file."
+msgstr "Error while processing file."
+
+msgid "Error while downloading file."
+msgstr "Error while downloading file."
+
+# ------End of i18n.html.tt2------

--- a/templates/i18n.html.tt2
+++ b/templates/i18n.html.tt2
@@ -67,7 +67,7 @@ I18N.IndexPageCount = "[% c.lh("Showing _START_ to _END_ of _TOTAL_ ancient chin
 I18N.IndexNoArcsFound = (url) => `[% c.lh("No archives to show you! Try <a href=\"\${url}\")>uploading some</a>?") %]`;
 I18N.IndexWelcome = (version) => `[% c.lh("Welcome to LANraragi \${version}!") %]`;
 I18N.IndexWelcome2 = "[% c.lh("If you want to perform advanced operations on an archive, remember to just right-click its name. Happy reading!") %]";
-I18N.ServerInfoError = "[% c.lh("Error getting server info.") %]";
+I18N.ServerInfoError = "[% c.lh("Error getting basic server info.") %]";
 I18N.DebugModeHeader = "[% c.lh("You're running in Debug Mode!") %]";
 I18N.DebugModeDesc = (url) => `[% c.lh("Advanced server statistics can be viewed <a href=\"\${url}\")>here</a>.") %]`;
 I18N.CustomColumn = "[% c.lh("Enter a tag namespace for this column") %]";


### PR DESCRIPTION
From the i18n change, a series of maketext error logs begin to appear in the LRR logs; these error logs however do not contain errors. The first priority was to obtain these errors. According to claude, error messages are not showing because they may be getting cleared. I'm inclined to believe it, and so wrote an error capturer which confirmed its suspicion.

Capturing the log messages, we get

![screenshot](https://github.com/user-attachments/assets/0a2507e2-0c72-4042-8351-55907ec64eb8)

which basically boil down to en.po having typos. Fixing these typos gets rid of the error logs. However, it doesn't remove error logs from a cn browser. To do that we need to match translations with en 1-1.

I took liberty to add a handful of translations. But there are too many, and this is just a bug fix so I'll stop here :p