### PR TITLE
Fix thumbnail cropping for tall images

### DIFF
--- a/public/css/lrr.css
+++ b/public/css/lrr.css
@@ -62,6 +62,13 @@ div.id3.nocrop img {
   max-width: 95%;
 }
 
+div.id3:not(.nocrop) img {
+  object-fit: cover;
+  object-position: top;
+  width: 95%;
+  height: 100%;
+}
+
 div.id4 {
   white-space: nowrap;
 }


### PR DESCRIPTION
When displaying the thumbnail of a tall image while with "crop thumbnails" enabled, the entire image would be a long strip in the thumbnail. The expected behavior should be to see the top part of the image fill the container. At least, this is what I believe the function of cropping thumbnails should achieve.

Screenshot of cropped thumbnail in current branch:

![Screen Shot 2025-04-12 at 00 09 28 AM](https://github.com/user-attachments/assets/7680ff47-c005-47e1-9cdc-b897d00ded9c)

Screenshot of cropped thumbnail in bugfix branch:

![Screen Shot 2025-04-12 at 00 12 48 AM](https://github.com/user-attachments/assets/892c1f4b-6f64-43c5-82c8-c964cc873fbb)
