### PR TITLE
Use CHI for caching page data

### DIFF
--- a/lib/LANraragi.pm
+++ b/lib/LANraragi.pm
@@ -101,6 +101,9 @@ sub startup {
         sleep 2;
     }
 
+    # Initialize cache
+    LANraragi::Utils::PageCache::initialize();
+
     # Load i18n
     LANraragi::Utils::I18NInitializer::initialize($self);
 

--- a/lib/LANraragi/Controller/Api/Minion.pm
+++ b/lib/LANraragi/Controller/Api/Minion.pm
@@ -5,7 +5,6 @@ use Mojo::JSON qw(encode_json decode_json);
 use Redis;
 
 use LANraragi::Model::Stats;
-use LANraragi::Utils::TempFolder qw(get_tempsize clean_temp_full);
 use LANraragi::Utils::Generic    qw(render_api_response);
 use LANraragi::Utils::Plugins    qw(get_plugin get_plugins use_plugin);
 

--- a/lib/LANraragi/Controller/Api/Other.pm
+++ b/lib/LANraragi/Controller/Api/Other.pm
@@ -6,7 +6,6 @@ use Redis;
 
 use LANraragi::Model::Stats;
 use LANraragi::Model::Opds;
-use LANraragi::Utils::TempFolder qw(get_tempsize clean_temp_full);
 use LANraragi::Utils::Generic    qw(render_api_response);
 use LANraragi::Utils::Plugins    qw(get_plugin get_plugins use_plugin);
 
@@ -69,14 +68,14 @@ sub clean_tempfolder {
     my $self = shift;
 
     #Run a full clean, errors are dumped into $@ if they occur
-    eval { clean_temp_full() };
+    eval { LANraragi::Utils::PageCache::clear(); };
 
     $self->render(
         json => {
             operation => "cleantemp",
             success   => $@ eq "",
             error     => $@,
-            newsize   => get_tempsize()
+            newsize   => 0,
         }
     );
 }

--- a/lib/LANraragi/Controller/Config.pm
+++ b/lib/LANraragi/Controller/Config.pm
@@ -46,7 +46,6 @@ sub index {
         hqthumbpages    => $self->LRR_CONF->get_hqthumbpages,
         jxlthumbpages   => $self->LRR_CONF->get_jxlthumbpages,
         csshead         => generate_themes_header($self),
-        tempsize        => 0,
         replacedupe     => $self->LRR_CONF->get_replacedupe
     );
 }

--- a/lib/LANraragi/Controller/Config.pm
+++ b/lib/LANraragi/Controller/Config.pm
@@ -4,7 +4,6 @@ use Mojo::Base 'Mojolicious::Controller';
 use LANraragi::Utils::Generic    qw(generate_themes_header);
 use LANraragi::Utils::String     qw(trim trim_CRLF);
 use LANraragi::Utils::Database   qw(redis_encode save_computed_tagrules);
-use LANraragi::Utils::TempFolder qw(get_tempsize);
 use LANraragi::Utils::Tags       qw(tags_rules_to_array replace_CRLF restore_CRLF);
 use Mojo::JSON                   qw(encode_json);
 
@@ -47,7 +46,7 @@ sub index {
         hqthumbpages    => $self->LRR_CONF->get_hqthumbpages,
         jxlthumbpages   => $self->LRR_CONF->get_jxlthumbpages,
         csshead         => generate_themes_header($self),
-        tempsize        => get_tempsize,
+        tempsize        => 0,
         replacedupe     => $self->LRR_CONF->get_replacedupe
     );
 }

--- a/lib/LANraragi/Model/Archive.pm
+++ b/lib/LANraragi/Model/Archive.pm
@@ -19,7 +19,7 @@ use LANraragi::Utils::Generic    qw(render_api_response);
 use LANraragi::Utils::String     qw(trim trim_CRLF);
 use LANraragi::Utils::TempFolder qw(get_temp);
 use LANraragi::Utils::Logging    qw(get_logger);
-use LANraragi::Utils::Archive    qw(extract_single_file extract_single_file_to_ram extract_thumbnail);
+use LANraragi::Utils::Archive    qw(extract_single_file extract_single_file extract_thumbnail);
 use LANraragi::Utils::Database
   qw(redis_encode redis_decode invalidate_cache set_title set_tags set_summary get_archive_json get_archive_json_multi);
 use LANraragi::Utils::PageCache;
@@ -239,7 +239,7 @@ sub get_page_data ($id, $path) {
         my $redis = LANraragi::Model::Config->get_redis;
         my $archive = $redis->hget($id, "file");
         $redis->quit();
-        $content = extract_single_file_to_ram($archive, $path);
+        $content = extract_single_file($archive, $path);
         LANraragi::Utils::PageCache::put($cachekey, $content);
     }
     return $content;

--- a/lib/LANraragi/Model/Reader.pm
+++ b/lib/LANraragi/Model/Reader.pm
@@ -16,7 +16,7 @@ use Mojo::JSON qw(encode_json);
 use Data::Dumper;
 use URI::Escape;
 
-use LANraragi::Utils::Generic  qw(is_image shasum);
+use LANraragi::Utils::Generic  qw(is_image);
 use LANraragi::Utils::Logging  qw(get_logger);
 use LANraragi::Utils::Archive  qw(get_filelist);
 use LANraragi::Utils::Database qw(redis_decode);

--- a/lib/LANraragi/Model/Reader.pm
+++ b/lib/LANraragi/Model/Reader.pm
@@ -18,7 +18,7 @@ use URI::Escape;
 
 use LANraragi::Utils::Generic  qw(is_image shasum);
 use LANraragi::Utils::Logging  qw(get_logger);
-use LANraragi::Utils::Archive  qw(extract_archive get_filelist);
+use LANraragi::Utils::Archive  qw(get_filelist);
 use LANraragi::Utils::Database qw(redis_decode);
 
 # resize_image(image,quality, size_threshold)
@@ -71,14 +71,6 @@ sub resize_image ( $content, $quality, $threshold ) {
 # build_reader_JSON(mojo, id, forceReload)
 # Opens the archive specified by its ID, and returns a json containing the page names.
 sub build_reader_JSON ( $self, $id, $force ) {
-
-    # Queue a full extract job into Minion.
-    # This'll fill in the missing pages (or regen everything if force = 1)
-    my $jobid = $self->minion->enqueue(
-        extract_archive => [ $id, $force ],
-        { priority => 4 }
-    );
-
     # Get the path from Redis.
     # Filenames are stored as they are on the OS, so no decoding!
     my $redis   = LANraragi::Model::Config->get_redis;
@@ -121,9 +113,6 @@ sub build_reader_JSON ( $self, $id, $force ) {
 
     return {
         pages => \@images_browser,
-
-        # filesizes => \@sizes,
-        job => $jobid
     };
 }
 

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -31,7 +31,7 @@ use LANraragi::Utils::Generic    qw(is_image shasum shasum_str);
 # Relies on Libarchive, ImageMagick and GhostScript for PDFs.
 use Exporter 'import';
 our @EXPORT_OK =
-  qw(is_file_in_archive extract_file_from_archive extract_single_file extract_single_file_to_ram extract_archive extract_thumbnail generate_thumbnail get_filelist);
+  qw(is_file_in_archive extract_file_from_archive extract_single_file extract_archive extract_thumbnail generate_thumbnail get_filelist);
 
 sub is_pdf {
     my ( $filename, $dirs, $suffix ) = fileparse( $_[0], qr/\.[^.]*/ );
@@ -193,7 +193,7 @@ sub extract_thumbnail ( $thumbdir, $id, $page, $set_cover, $use_hq ) {
     $logger->debug("Extracting thumbnail for $id page $page from $requested_image");
 
     # Extract requested image to temp dir if it doesn't already exist
-    my $arcimg       = extract_single_file_to_ram( $file, $requested_image );
+    my $arcimg       = extract_single_file( $file, $requested_image );
 
     my $thumbname;
     unless ($set_cover) {
@@ -320,7 +320,7 @@ sub is_file_in_archive ( $archive, $wantedname ) {
 
 # Extract $file from $archive to $destination and returns the filesystem path it's extracted to.
 # If the file doesn't exist in the archive, this will still create a file, but empty.
-sub extract_single_file ( $archive, $filepath, $destination ) {
+sub extract_single_file_to_file ( $archive, $filepath, $destination ) {
 
     my $logger = get_logger( "Archive", "lanraragi" );
 
@@ -331,44 +331,17 @@ sub extract_single_file ( $archive, $filepath, $destination ) {
     my ( $name, $path, $suffix ) = fileparse( $outfile, qr/\.[^.]*/ );
     make_path($path);
 
-    if ( is_pdf($archive) ) {
+    my $contents = extract_single_file( $archive, $filepath );
 
-        # For pdfs the filenames are always x.jpg, so we pull the page number from that
-        my $page = $filepath;
-        $page =~ s/^(\d+).jpg$/$1/;
-
-        my $gscmd = "gs -dNOPAUSE -dFirstPage=$page -dLastPage=$page -sDEVICE=jpeg -r200 -o '$outfile' '$archive'";
-        $logger->debug("Extracting page $filepath from PDF $archive");
-        $logger->debug($gscmd);
-
-        `$gscmd`;
-    } else {
-
-        my $contents = "";
-        my $peek     = Archive::Libarchive::Peek->new( filename => $archive );
-        my @files    = $peek->files;
-
-        for my $name (@files) {
-            my $decoded_name = LANraragi::Utils::Database::redis_decode($name);
-
-            # This sub can receive either encoded or raw filenames, so we have to test for both.
-            if ( $decoded_name eq $filepath || $name eq $filepath ) {
-                $logger->debug("Found file $filepath in archive $archive");
-                $contents = $peek->file($name);
-                last;
-            }
-        }
-
-        open( my $fh, '>', $outfile )
-          or die "Could not open file '$outfile' $!";
-        print $fh $contents;
-        close $fh;
-    }
+    open( my $fh, '>', $outfile )
+      or die "Could not open file '$outfile' $!";
+    print $fh $contents;
+    close $fh;
 
     return $outfile;
 }
 
-sub extract_single_file_to_ram ( $archive, $filepath ) {
+sub extract_single_file ( $archive, $filepath ) {
 
     my $logger = get_logger( "Archive", "lanraragi" );
 
@@ -414,7 +387,7 @@ sub extract_file_from_archive ( $archive, $filename ) {
     mkdir $path;
 
     my $tmp = tempdir( DIR => $path, CLEANUP => 1 );
-    return extract_single_file( $archive, $filename, $tmp );
+    return extract_single_file_to_file( $archive, $filename, $tmp );
 }
 
 1;

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -25,7 +25,7 @@ use File::Temp qw(tempdir);
 
 use LANraragi::Utils::TempFolder qw(get_temp);
 use LANraragi::Utils::Logging    qw(get_logger);
-use LANraragi::Utils::Generic    qw(is_image shasum shasum_str);
+use LANraragi::Utils::Generic    qw(is_image shasum_str);
 
 # Utilitary functions for handling Archives.
 # Relies on Libarchive, ImageMagick and GhostScript for PDFs.

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -31,7 +31,7 @@ use LANraragi::Utils::Generic    qw(is_image shasum shasum_str);
 # Relies on Libarchive, ImageMagick and GhostScript for PDFs.
 use Exporter 'import';
 our @EXPORT_OK =
-  qw(is_file_in_archive extract_file_from_archive extract_single_file extract_archive extract_thumbnail generate_thumbnail get_filelist);
+  qw(is_file_in_archive extract_file_from_archive extract_single_file extract_thumbnail generate_thumbnail get_filelist);
 
 sub is_pdf {
     my ( $filename, $dirs, $suffix ) = fileparse( $_[0], qr/\.[^.]*/ );
@@ -86,55 +86,6 @@ sub generate_thumbnail ( $data, $thumb_path, $use_hq, $use_jxl ) {
             undef $img;
         }
     }
-}
-
-# Extract the given archive to the given path.
-# This sub won't re-extract files already present in the destination unless force = 1.
-sub extract_archive ( $destination, $to_extract, $force_extract ) {
-
-    my $logger = get_logger( "Archive", "lanraragi" );
-    $logger->debug("Fully extracting archive $to_extract");
-
-    # PDFs are handled by Ghostscript (alas)
-    if ( is_pdf($to_extract) ) {
-        return extract_pdf( $destination, $to_extract );
-    }
-
-    # Prepare libarchive with a callback to skip over existing files (unless force=1)
-    my $ae = Archive::Libarchive::Extract->new(
-        filename => $to_extract,
-        entry    => sub {
-            my $e = shift;
-            if ($force_extract) { return 1; }
-
-            my $filename = $e->pathname;
-            if ( -e "$destination/$filename" ) {
-                $logger->debug("$filename already exists in $destination");
-                return 0;
-            }
-            $logger->debug("Extracting $filename");
-
-            # Pre-emptively create the file to signal we're working on it
-            open( my $fh, ">", "$destination/$filename" )
-              or
-              $logger->error("Couldn't create placeholder file $destination/$filename (might be a folder?), moving on nonetheless");
-            close $fh;
-            return 1;
-        }
-    );
-
-    # Extract to $destination. This method throws if extraction fails.
-    $ae->extract( to => $destination );
-
-    # Get extraction folder
-    my $result_dir = $ae->to;
-    my $cwd        = getcwd();
-
-    # chdir back to the base cwd in case finddepth died midway
-    chdir $cwd;
-
-    # Return the directory we extracted the files to.
-    return $result_dir;
 }
 
 sub extract_pdf ( $destination, $to_extract ) {

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -12,6 +12,7 @@ use File::Basename;
 use File::Path qw(remove_tree make_path);
 use File::Find qw(finddepth);
 use File::Copy qw(move);
+use File::Temp qw(tempfile);
 use Encode;
 use Encode::Guess qw/euc-jp shiftjis 7bit-jis/;
 use Redis;
@@ -24,13 +25,13 @@ use File::Temp qw(tempdir);
 
 use LANraragi::Utils::TempFolder qw(get_temp);
 use LANraragi::Utils::Logging    qw(get_logger);
-use LANraragi::Utils::Generic    qw(is_image shasum);
+use LANraragi::Utils::Generic    qw(is_image shasum shasum_str);
 
 # Utilitary functions for handling Archives.
 # Relies on Libarchive, ImageMagick and GhostScript for PDFs.
 use Exporter 'import';
 our @EXPORT_OK =
-  qw(is_file_in_archive extract_file_from_archive extract_single_file extract_archive extract_thumbnail generate_thumbnail get_filelist);
+  qw(is_file_in_archive extract_file_from_archive extract_single_file extract_single_file_to_ram extract_archive extract_thumbnail generate_thumbnail get_filelist);
 
 sub is_pdf {
     my ( $filename, $dirs, $suffix ) = fileparse( $_[0], qr/\.[^.]*/ );
@@ -40,12 +41,13 @@ sub is_pdf {
 # use ImageMagick to make a thumbnail, height = 500px (view in index is 280px tall)
 # If use_hq is true, the scale algorithm will be used instead of sample.
 # If use_jxl is true, JPEG XL will be used instead of JPEG.
-sub generate_thumbnail ( $orig_path, $thumb_path, $use_hq, $use_jxl ) {
+sub generate_thumbnail ( $data, $thumb_path, $use_hq, $use_jxl ) {
 
     no warnings 'experimental::try';
+    my $img = undef;
     try {
         require Image::Magick;
-        my $img = Image::Magick->new;
+        $img = Image::Magick->new;
 
         my $format = $use_jxl ? 'jxl' : 'jpg';
 
@@ -56,12 +58,14 @@ sub generate_thumbnail ( $orig_path, $thumb_path, $use_hq, $use_jxl ) {
             $img->Set( option => 'jpeg:size=500x' );
         }
 
+        # TODO: Figure out if this is possible with BlobToImage
         # If the image is a gif, only take the first frame
-        if ( $orig_path =~ /\.gif$/ ) {
-            $img->Read( $orig_path . "[0]" );
-        } else {
-            $img->Read($orig_path);
-        }
+        #if ( $orig_path =~ /\.gif$/ ) {
+        #    $img->Read( $orig_path . "[0]" );
+        #} else {
+        #    $img->Read($orig_path);
+        #}
+        $img->BlobToImage($data);
 
         # The "-scale" resize operator is a simplified, faster form of the resize command.
         if ($use_hq) {
@@ -72,12 +76,15 @@ sub generate_thumbnail ( $orig_path, $thumb_path, $use_hq, $use_jxl ) {
 
         $img->Set( quality => "50", magick => $format );
         $img->Write($thumb_path);
-        undef $img;
     } catch ($e) {
 
         # Magick is unavailable, do nothing
         my $logger = get_logger( "Archive", "lanraragi" );
         $logger->debug("ImageMagick is not available , skipping thumbnail generation: $e");
+    } finally {
+        if (defined($img)) {
+            undef $img;
+        }
     }
 }
 
@@ -186,13 +193,7 @@ sub extract_thumbnail ( $thumbdir, $id, $page, $set_cover, $use_hq ) {
     $logger->debug("Extracting thumbnail for $id page $page from $requested_image");
 
     # Extract requested image to temp dir if it doesn't already exist
-    my $temppath     = tempdir();
-    my $archive_temp = get_temp();
-    my $arcimg       = "$archive_temp/$id/$requested_image";
-
-    unless ( -e $arcimg ) {
-        $arcimg = extract_single_file( $file, $requested_image, $temppath );
-    }
+    my $arcimg       = extract_single_file_to_ram( $file, $requested_image );
 
     my $thumbname;
     unless ($set_cover) {
@@ -206,7 +207,7 @@ sub extract_thumbnail ( $thumbdir, $id, $page, $set_cover, $use_hq ) {
 
         # For cover thumbnails, grab the SHA-1 hash for tag research.
         # That way, no need to repeat a costly extraction later.
-        my $shasum = shasum( $arcimg, 1 );
+        my $shasum = shasum_str( $arcimg, 1 );
         $logger->debug("Setting thumbnail hash: $shasum");
         $redis->hset( $id, "thumbhash", $shasum );
         $redis->quit();
@@ -215,8 +216,6 @@ sub extract_thumbnail ( $thumbdir, $id, $page, $set_cover, $use_hq ) {
     # Thumbnail generation
     generate_thumbnail( $arcimg, $thumbname, $use_hq, $use_jxl );
 
-    # Clean up safe folder
-    remove_tree($temppath);
     return $thumbname;
 }
 
@@ -367,6 +366,44 @@ sub extract_single_file ( $archive, $filepath, $destination ) {
     }
 
     return $outfile;
+}
+
+sub extract_single_file_to_ram ( $archive, $filepath ) {
+
+    my $logger = get_logger( "Archive", "lanraragi" );
+
+    # Remove file from $outfile and hand the full directory to make_path
+    if ( is_pdf($archive) ) {
+
+        # For pdfs the filenames are always x.jpg, so we pull the page number from that
+        my $page = $filepath;
+        $page =~ s/^(\d+).jpg$/$1/;
+
+        my ( $fh, $outfile ) = tempfile();
+        my $gscmd = "gs -dNOPAUSE -dFirstPage=$page -dLastPage=$page -sDEVICE=jpeg -r200 -o '$outfile' '$archive'";
+        $logger->debug("Extracting page $filepath from PDF $archive");
+        $logger->debug($gscmd);
+
+        `$gscmd`;
+        return Mojo::File->new($outfile)->slurp;
+    } else {
+
+        my $contents = "";
+        my $peek     = Archive::Libarchive::Peek->new( filename => $archive );
+        my @files    = $peek->files;
+
+        for my $name (@files) {
+            my $decoded_name = LANraragi::Utils::Database::redis_decode($name);
+
+            # This sub can receive either encoded or raw filenames, so we have to test for both.
+            if ( $decoded_name eq $filepath || $name eq $filepath ) {
+                $logger->debug("Found file $filepath in archive $archive");
+                $contents = $peek->file($name);
+                last;
+            }
+        }
+        return $contents;
+    }
 }
 
 # Variant for plugins.

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -58,14 +58,12 @@ sub generate_thumbnail ( $data, $thumb_path, $use_hq, $use_jxl ) {
             $img->Set( option => 'jpeg:size=500x' );
         }
 
-        # TODO: Figure out if this is possible with BlobToImage
-        # If the image is a gif, only take the first frame
-        #if ( $orig_path =~ /\.gif$/ ) {
-        #    $img->Read( $orig_path . "[0]" );
-        #} else {
-        #    $img->Read($orig_path);
-        #}
         $img->BlobToImage($data);
+
+        # If the image is a gif, only take the first frame
+        if ($img->Get('magick') eq 'GIF' ) {
+            $img = $img->[0];
+        }
 
         # The "-scale" resize operator is a simplified, faster form of the resize command.
         if ($use_hq) {

--- a/lib/LANraragi/Utils/Generic.pm
+++ b/lib/LANraragi/Utils/Generic.pm
@@ -20,7 +20,7 @@ use LANraragi::Utils::Logging qw(get_logger);
 
 # Generic Utility Functions.
 use Exporter 'import';
-our @EXPORT_OK = qw(is_image is_archive render_api_response get_tag_with_namespace shasum start_shinobu
+our @EXPORT_OK = qw(is_image is_archive render_api_response get_tag_with_namespace shasum shasum_str start_shinobu
   split_workload_by_cpu start_minion get_css_list generate_themes_header flat get_bytelength array_difference
   intersect_arrays filter_hash_by_keys);
 
@@ -156,6 +156,26 @@ sub shasum {
     eval {
         my $ctx = Digest::SHA->new( $_[1] );
         $ctx->addfile( $_[0] );
+        $digest = $ctx->hexdigest;
+    };
+
+    if ($@) {
+        $logger->error( "Error building hash for " . $_[0] . " -- " . $@ );
+
+        return "";
+    }
+
+    return $digest;
+}
+
+sub shasum_str {
+
+    my $digest = "";
+    my $logger = get_logger( "Hash Computation", "lanraragi" );
+
+    eval {
+        my $ctx = Digest::SHA->new( $_[1] );
+        $ctx->add( $_[0] );
         $digest = $ctx->hexdigest;
     };
 

--- a/lib/LANraragi/Utils/Generic.pm
+++ b/lib/LANraragi/Utils/Generic.pm
@@ -20,7 +20,7 @@ use LANraragi::Utils::Logging qw(get_logger);
 
 # Generic Utility Functions.
 use Exporter 'import';
-our @EXPORT_OK = qw(is_image is_archive render_api_response get_tag_with_namespace shasum shasum_str start_shinobu
+our @EXPORT_OK = qw(is_image is_archive render_api_response get_tag_with_namespace shasum_str start_shinobu
   split_workload_by_cpu start_minion get_css_list generate_themes_header flat get_bytelength array_difference
   intersect_arrays filter_hash_by_keys);
 
@@ -145,29 +145,9 @@ sub start_shinobu {
     return $proc;
 }
 
-#This function gives us a SHA hash for the passed file, which is used for thumbnail reverse search on E-H.
-#First argument is the file, second is the algorithm to use. (1, 224, 256, 384, 512, 512224, or 512256)
+#This function gives us a SHA hash for the passed data, which is used for thumbnail reverse search on E-H.
+#First argument is the data, second is the algorithm to use. (1, 224, 256, 384, 512, 512224, or 512256)
 #E-H only uses SHA-1 hashes.
-sub shasum {
-
-    my $digest = "";
-    my $logger = get_logger( "Hash Computation", "lanraragi" );
-
-    eval {
-        my $ctx = Digest::SHA->new( $_[1] );
-        $ctx->addfile( $_[0] );
-        $digest = $ctx->hexdigest;
-    };
-
-    if ($@) {
-        $logger->error( "Error building hash for " . $_[0] . " -- " . $@ );
-
-        return "";
-    }
-
-    return $digest;
-}
-
 sub shasum_str {
 
     my $digest = "";

--- a/lib/LANraragi/Utils/Minion.pm
+++ b/lib/LANraragi/Utils/Minion.pm
@@ -9,7 +9,7 @@ use Parallel::Loops;
 
 use LANraragi::Utils::Logging    qw(get_logger);
 use LANraragi::Utils::Database   qw(redis_decode);
-use LANraragi::Utils::Archive    qw(extract_thumbnail extract_archive);
+use LANraragi::Utils::Archive    qw(extract_thumbnail);
 use LANraragi::Utils::Plugins    qw(get_downloader_for_url get_plugin get_plugin_parameters use_plugin);
 use LANraragi::Utils::Generic    qw(split_workload_by_cpu);
 use LANraragi::Utils::String     qw(trim_url);
@@ -327,39 +327,6 @@ sub add_tasks {
         }
     );
 
-    $minion->add_task(
-        extract_archive => sub {
-            my ( $job, @args )  = @_;
-            my ( $id,  $force ) = @args;
-
-            my $tempdir = get_temp();
-            my $path    = $tempdir . "/" . $id;
-            my $redis   = LANraragi::Model::Config->get_redis;
-
-            # Get the path from Redis.
-            # Filenames are stored as they are on the OS, so no decoding!
-            my $zipfile = $redis->hget( $id, "file" );
-
-            my $outpath = "";
-            eval { $outpath = extract_archive( $path, $zipfile, $force ); };
-
-            if ($@) {
-                $job->finish(
-                    {   success => 0,
-                        id      => $id,
-                        message => $@
-                    }
-                );
-            } else {
-                $job->finish(
-                    {   success => 1,
-                        id      => $id,
-                        outpath => $outpath
-                    }
-                );
-            }
-        }
-    );
 }
 
 1;

--- a/lib/LANraragi/Utils/PageCache.pm
+++ b/lib/LANraragi/Utils/PageCache.pm
@@ -17,9 +17,14 @@ our @EXPORT_OK = qw(fetch put);
 my $cache = undef;
 
 sub initialize() {
+    my $logger = get_logger( "PageCache", "lanraragi" );
+    my $disk_size = LANraragi::Model::Config->get_tempmaxsize."m";
+    $logger->debug("Initializing cache, disk size: ".$disk_size);
+
+    # TODO: Make memory cache size configurable
     $cache = CHI->new(
         driver     => 'FastMmap',
-        cache_size => LANraragi::Model::Config->get_tempmaxsize,
+        cache_size => $disk_size,
         root_dir => get_temp,
     );
 }
@@ -50,6 +55,16 @@ sub put( $key, $content ) {
     $logger->debug("Put $key");
 
     $cache->set($key, $content);
+}
+
+sub clear() {
+    if (!defined($cache)) {
+        initialize;
+    }
+
+    my $logger = get_logger( "PageCache", "lanraragi" );
+    $logger->debug("Clearing cache");
+    $cache->clear();
 }
 
 1;

--- a/lib/LANraragi/Utils/PageCache.pm
+++ b/lib/LANraragi/Utils/PageCache.pm
@@ -7,19 +7,32 @@ use warnings;
 use utf8;
 
 use LANraragi::Utils::Logging  qw(get_logger);
+use CHI;
+use LANraragi::Utils::TempFolder qw(get_temp);
 
 # Contains all functions related to caching entire pages
 use Exporter 'import';
 our @EXPORT_OK = qw(fetch put);
 
+my $cache = undef;
+
+sub initialize() {
+    $cache = CHI->new(
+        driver     => 'FastMmap',
+        cache_size => LANraragi::Model::Config->get_tempmaxsize,
+        root_dir => get_temp,
+    );
+}
+
 # Fetches data from cache if available. Returns undef if nothing is there
 sub fetch( $key ) {
+    if (!defined($cache)) {
+        initialize;
+    }
     my $logger = get_logger( "PageCache", "lanraragi" );
     $logger->debug("Fetch $key");
 
-    # TODO: Implement filesystem caching, if that's needed!
-    my $redis  = LANraragi::Model::Config->get_redis;
-    my $content = $redis->get($key);
+    my $content = $cache->get($key);
     if (defined $content) {
         $logger->debug("Cache HIT for $key");
     } else {
@@ -30,14 +43,13 @@ sub fetch( $key ) {
 
 # Attempts to store data in the cache. Do not assume that fetch will work immediately after, cache may be disabled etc
 sub put( $key, $content ) {
+    if (!defined($cache)) {
+        initialize;
+    }
     my $logger = get_logger( "PageCache", "lanraragi" );
     $logger->debug("Put $key");
 
-    # TODO: Implement filesystem caching, if that's needed!
-    my $redis  = LANraragi::Model::Config->get_redis;
-
-    # Some random long expiry
-    $redis->set($key,  $content, 'EX', 999999);
+    $cache->set($key, $content);
 }
 
 1;

--- a/lib/LANraragi/Utils/PageCache.pm
+++ b/lib/LANraragi/Utils/PageCache.pm
@@ -1,0 +1,43 @@
+package LANraragi::Utils::PageCache;
+
+use v5.36;
+
+use strict;
+use warnings;
+use utf8;
+
+use LANraragi::Utils::Logging  qw(get_logger);
+
+# Contains all functions related to caching entire pages
+use Exporter 'import';
+our @EXPORT_OK = qw(fetch put);
+
+# Fetches data from cache if available. Returns undef if nothing is there
+sub fetch( $key ) {
+    my $logger = get_logger( "PageCache", "lanraragi" );
+    $logger->debug("Fetch $key");
+
+    # TODO: Implement filesystem caching, if that's needed!
+    my $redis  = LANraragi::Model::Config->get_redis;
+    my $content = $redis->get($key);
+    if (defined $content) {
+        $logger->debug("Cache HIT for $key");
+    } else {
+        $logger->debug("Cache MISS for $key");
+    }
+    return $content;
+}
+
+# Attempts to store data in the cache. Do not assume that fetch will work immediately after, cache may be disabled etc
+sub put( $key, $content ) {
+    my $logger = get_logger( "PageCache", "lanraragi" );
+    $logger->debug("Put $key");
+
+    # TODO: Implement filesystem caching, if that's needed!
+    my $redis  = LANraragi::Model::Config->get_redis;
+
+    # Some random long expiry
+    $redis->set($key,  $content, 'EX', 999999);
+}
+
+1;

--- a/lib/LANraragi/Utils/PageCache.pm
+++ b/lib/LANraragi/Utils/PageCache.pm
@@ -21,7 +21,6 @@ sub initialize() {
     my $disk_size = LANraragi::Model::Config->get_tempmaxsize."m";
     $logger->debug("Initializing cache, disk size: ".$disk_size);
 
-    # TODO: Make memory cache size configurable
     $cache = CHI->new(
         driver     => 'FastMmap',
         cache_size => $disk_size,

--- a/lib/LANraragi/Utils/TempFolder.pm
+++ b/lib/LANraragi/Utils/TempFolder.pm
@@ -5,17 +5,10 @@ use warnings;
 use utf8;
 
 use Cwd 'abs_path';
-use FindBin;
-use File::stat;
-use File::Find;
-use File::Path qw(remove_tree);
-
-use LANraragi::Utils::Generic;
-use LANraragi::Utils::Logging qw(get_logger);
 
 #Contains all functions related to the temporary folder.
 use Exporter 'import';
-our @EXPORT_OK = qw(get_temp get_tempsize clean_temp_full clean_temp_partial);
+our @EXPORT_OK = qw(get_temp);
 
 #Get the current tempfolder.
 #This can be called from any process safely as it uses FindBin.
@@ -29,118 +22,6 @@ sub get_temp {
 
     mkdir $temp_folder;
     return abs_path($temp_folder);
-}
-
-#Get the current size of the tempfolder, in Megabytes.
-sub get_tempsize {
-    my $size = 0;
-
-    #Only stat the temp folder if it exists
-    my $temp = &get_temp;
-    if ( -e $temp ) {
-        find( sub { $size += -s if -f }, $temp );
-    }
-    return int( $size / 1048576 * 100 ) / 100;
-}
-
-# Remove all folders in the tempfolder.
-# Dies if an error occurs.
-sub clean_temp_full {
-
-    my $tempdir = &get_temp;
-
-    # Abort if the temp dir doesn't exist yet
-    return unless ( -e $tempdir );
-
-    opendir( my $dir_fh, $tempdir );
-
-    my @folder_list;
-    while ( my $file = readdir $dir_fh ) {
-
-        next unless -d $tempdir . '/' . $file;
-        next if $file eq '.' or $file eq '..';
-
-        push @folder_list, "$tempdir/$file";
-    }
-    closedir $dir_fh;
-
-    remove_tree( @folder_list, { error => \my $err } );
-
-    my $cleanmsg = "";
-    if (@$err) {
-        for my $diag (@$err) {
-            my ( $file, $message ) = %$diag;
-            if ( $file eq '' ) {
-                die "General error: $message\n";
-            } else {
-                die "Problem unlinking $file: $message\n";
-            }
-        }
-    }
-
-}
-
-# Remove all folders in the tempfolder except the most recent one
-# For this, we use Perl's ctime, which uses inode last modified time.
-sub clean_temp_partial {
-
-    my $logger  = get_logger( "Temporary Folder", "lanraragi" );
-    my $tempdir = &get_temp;
-
-    #Abort if the temp dir doesn't exist yet
-    return unless ( -e $tempdir );
-
-    my $size    = get_tempsize;
-    my $maxsize = LANraragi::Model::Config->get_tempmaxsize;
-
-    if ( $size > $maxsize ) {
-        $logger->info( "Current temporary folder size is $size MBs, " . "Maximum size is $maxsize MBs. Cleaning." );
-
-        # Wipe thumbnail temp folder first
-        if ( -e $tempdir . "/thumb" ) { unlink( $tempdir . "/thumb" ); }
-
-        opendir( my $dir_fh, $tempdir );
-
-        my @folder_list;
-        while ( my $file = readdir $dir_fh ) {
-
-            next unless -d $tempdir . '/' . $file;
-            next if $file eq '.' or $file eq '..';
-
-            push @folder_list, "$tempdir/$file";
-        }
-        closedir $dir_fh;
-
-        if ( scalar @folder_list <= 1 ) {
-            $logger->info("Only one folder left in /temp, aborting clean.");
-            return;
-        }
-
-        @folder_list = sort {
-            my $a_stat = stat($a);
-            my $b_stat = stat($b);
-            $a_stat->ctime <=> $b_stat->ctime;
-        } @folder_list;
-
-        #Remove all folders in folderlist except the last one
-        my $survivor = pop @folder_list;
-        $logger->debug("Deleting all folders in /temp except $survivor");
-
-        remove_tree( @folder_list, { error => \my $err } );
-
-        if (@$err) {
-            for my $diag (@$err) {
-                my ( $file, $message ) = %$diag;
-                if ( $file eq '' ) {
-                    $logger->error("General error: $message\n");
-                } else {
-                    $logger->error("Problem unlinking $file: $message\n");
-                }
-            }
-        }
-
-        $logger->info("Done!");
-    }
 }
 
 1;

--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -81,9 +81,6 @@ sub initialize_from_new_process {
     my $class = ref($contentwatcher);
     $logger->debug("Watcher class is $class");
 
-    # Add watcher to tempfolder
-    my $tempwatcher = File::ChangeNotify->instantiate_watcher( directories => [ get_temp() ] );
-
     # manual event loop
     $logger->info("All done! Now dutifully watching your files. ");
 
@@ -92,11 +89,6 @@ sub initialize_from_new_process {
         # Check events on files
         for my $event ( $contentwatcher->new_events ) {
             $inotifysub->($event);
-        }
-
-        # Check the current temp folder size and clean it if necessary
-        for my $event ( $tempwatcher->new_events ) {
-            clean_temp_partial();
         }
 
         sleep 2;

--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -5,7 +5,6 @@ package Shinobu;
 #  My main tasks are:
 #
 #    Tracking all files in the content folder and making sure they're sync'ed with the database
-#    Automatically cleaning the temporary folder when it reaches a certain size
 #
 
 use strict;
@@ -31,7 +30,6 @@ use Encode;
 
 use LANraragi::Utils::Archive    qw(extract_thumbnail);
 use LANraragi::Utils::Database   qw(redis_encode invalidate_cache compute_id change_archive_id);
-use LANraragi::Utils::TempFolder qw(get_temp);
 use LANraragi::Utils::Logging    qw(get_logger);
 use LANraragi::Utils::Generic    qw(is_archive split_workload_by_cpu);
 

--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -31,7 +31,7 @@ use Encode;
 
 use LANraragi::Utils::Archive    qw(extract_thumbnail);
 use LANraragi::Utils::Database   qw(redis_encode invalidate_cache compute_id change_archive_id);
-use LANraragi::Utils::TempFolder qw(get_temp clean_temp_partial);
+use LANraragi::Utils::TempFolder qw(get_temp);
 use LANraragi::Utils::Logging    qw(get_logger);
 use LANraragi::Utils::Generic    qw(is_archive split_workload_by_cpu);
 

--- a/public/js/server.js
+++ b/public/js/server.js
@@ -190,7 +190,7 @@ Server.triggerScript = function (namespace) {
 };
 
 Server.cleanTemporaryFolder = function () {
-    Server.callAPI("/api/tempfolder", "DELETE", I18N.CleanedTempFolder, I18N.CleanedTempFolderError, null);
+    Server.callAPI("/api/tempfolder", "DELETE", I18N.ClearCache, I18N.ClearCacheError, null);
 };
 
 Server.invalidateCache = function () {

--- a/public/js/server.js
+++ b/public/js/server.js
@@ -190,11 +190,7 @@ Server.triggerScript = function (namespace) {
 };
 
 Server.cleanTemporaryFolder = function () {
-    Server.callAPI("/api/tempfolder", "DELETE", I18N.CleanedTempFolder, I18N.CleanedTempFolderError,
-        (data) => {
-            $("#tempsize").html(data.newsize);
-        },
-    );
+    Server.callAPI("/api/tempfolder", "DELETE", I18N.CleanedTempFolder, I18N.CleanedTempFolderError, null);
 };
 
 Server.invalidateCache = function () {

--- a/templates/i18n.html.tt2
+++ b/templates/i18n.html.tt2
@@ -125,6 +125,8 @@ I18N.ScriptError = "[% c.lh("An error occured while running the script") %]";
 I18N.ScriptResult = "[% c.lh("Script result") %]";
 I18N.ScriptResultFail = (error) => `[% c.lh("Script failed with error: \${error}") %]`;
 
+I18N.ClearCache = "[% c.lh("Threw away the cache!") %]";
+I18N.ClearCacheError = "[% c.lh("Error clearing the cache") %]";
 I18N.CleanedTempFolder = "[% c.lh("Temporary folder cleaned!") %]";
 I18N.CleanedTempFolderError = "[% c.lh("Error cleaning temporary folder") %]";
 I18N.CleanedCacheFolder = "[% c.lh("Threw away the search cache!") %]";

--- a/templates/templates_config/config_files.html.tt2
+++ b/templates/templates_config/config_files.html.tt2
@@ -54,8 +54,6 @@
         <input id='clean-temp' class='stdbtn' type='button' value='[% c.lh("Clean Temporary Folder") %]' />
     </td>
     <td class="config-td">
-        [% c.lh("Current Size:") %]
-        <h2 style="display:inline"><span id="tempsize"> [%tempsize%] </span> MBs </h2>
         <br>[% c.lh("Empty the temporary folder manually by clicking this button.") %]
     </td>
 </tr>

--- a/templates/templates_config/config_files.html.tt2
+++ b/templates/templates_config/config_files.html.tt2
@@ -51,10 +51,10 @@
 
 <tr>
     <td class="option-td">
-        <input id='clean-temp' class='stdbtn' type='button' value='[% c.lh("Clean Temporary Folder") %]' />
+        <input id='clean-temp' class='stdbtn' type='button' value='[% c.lh("Clear Cache") %]' />
     </td>
     <td class="config-td">
-        <br>[% c.lh("Empty the temporary folder manually by clicking this button.") %]
+        <br>[% c.lh("Clear the cache manually by clicking this button.") %]
     </td>
 </tr>
 

--- a/tools/build/docker/redis.conf
+++ b/tools/build/docker/redis.conf
@@ -563,7 +563,7 @@ replica-priority 100
 # output buffers (but this is not needed if the policy is 'noeviction').
 #
 # maxmemory <bytes>
-maxmemory 500mb
+
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
 # is reached. You can select among five behaviors:
 #
@@ -594,7 +594,7 @@ maxmemory 500mb
 # The default is:
 #
 # maxmemory-policy noeviction
-maxmemory-policy volatile-lru
+
 # LRU, LFU and minimal TTL algorithms are not precise algorithms but approximated
 # algorithms (in order to save memory), so you can tune it for speed or
 # accuracy. For default Redis will check five keys and pick the one that was

--- a/tools/build/docker/redis.conf
+++ b/tools/build/docker/redis.conf
@@ -563,7 +563,7 @@ replica-priority 100
 # output buffers (but this is not needed if the policy is 'noeviction').
 #
 # maxmemory <bytes>
-
+maxmemory 500mb
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
 # is reached. You can select among five behaviors:
 #
@@ -594,7 +594,7 @@ replica-priority 100
 # The default is:
 #
 # maxmemory-policy noeviction
-
+maxmemory-policy volatile-lru
 # LRU, LFU and minimal TTL algorithms are not precise algorithms but approximated
 # algorithms (in order to save memory), so you can tune it for speed or
 # accuracy. For default Redis will check five keys and pick the one that was

--- a/tools/cpanfile
+++ b/tools/cpanfile
@@ -70,4 +70,9 @@ requires 'String::Similarity', 1.04;
 
 # I18n
 requires 'Locale::Maketext', 1.33;
-requires 'Locale::Maketext::Lexicon', 1.00
+requires 'Locale::Maketext::Lexicon', 1.00;
+
+# Cache
+requires 'CHI', 0.61;
+requires 'CHI::Driver::FastMmap', 0.61;
+requires 'Cache::FastMmap', 1.57;


### PR DESCRIPTION
This PR replaces the previous system for caching pages with CHI. This fixes some wonky behavior where pages could end up cropped.

This is basically #1212, but reduced in scope. Thumbnail handling is essentially untouched now, except the minimum required for the page data change. (I got #1212 working, but there's not much reason to include the other stuff yet).

Testing with `tools/k6/covers_cold.js` shows no difference in performance compared to dev.