### PR TITLE
Add locales dir to architecture docs

### DIFF
--- a/locales/template/zh.po
+++ b/locales/template/zh.po
@@ -757,7 +757,7 @@ msgid "You can check LANraragi logs here for debugging purposes."
 msgstr "您可以在此处查看LANraragi日志以进行调试。"
 
 msgid "By default, this view only shows the last 100 lines of each logfile, newest lines last."
-msgstr "默认情况下，此视图仅显示每个日志文件的最后100行，最新的日记在最后。"
+msgstr "默认情况下，此视图仅显示每个日志文件的最后100行，最新的日志在最后。"
 
 msgid "General Logs pertain to the main application."
 msgstr "常规日志与主应用程序有关。"
@@ -1166,7 +1166,7 @@ msgid "Are you sure you want to delete this archive?"
 msgstr "您确定要删除此文档吗？"
 
 msgid "Are you sure you want to delete the selected archives?"
-msgstr "您确定要删除一下文档吗？"
+msgstr "您确定要删除以下文档吗？"
 
 msgid "This action cannot be undone!"
 msgstr "此操作无法撤销！"

--- a/tools/Documentation/extending-lanraragi/architecture.md
+++ b/tools/Documentation/extending-lanraragi/architecture.md
@@ -85,6 +85,12 @@ root/
 |        |- *.pm 
 |        +- Minion.pm <- Minion jobs are implemented here
 |
+|- locales       <- Internationalization/Localization files
+|  +- template    
+|     |- en.po      <- English translations in .po (gettext) format
+|     |- zh.po      <- Chinese translations in .po format
+|     |- ...
+|
 |- log           <- Application Logs end up here
 |
 |- public        <- Files available to Web Clients


### PR DESCRIPTION
Minor update to add the locales directory to architecture.

There's probably going to be more documentation PRs in the future, esp with client-side translations, but I figure this might be an easy thing to miss, might as well just shoot this out of the way.

Also fix some cn typos