### PR TITLE
Image Snapping & Navigation improvements

### DIFF
--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -351,7 +351,9 @@ Reader.initInfiniteScrollView = function () {
         loaded += 1;
         if (loaded === images.length) {
             allImagesLoaded = true;
-            Reader.goToPage(Reader.currentPage);
+            if (window.scrollY === 0) {
+                Reader.goToPage(Reader.currentPage);
+            }
         }
     });
 };
@@ -672,7 +674,7 @@ Reader.goToPage = function (page) {
     Reader.showingSinglePage = false;
 
     if (Reader.infiniteScroll) {
-        $("#display img").get(Reader.currentPage).scrollIntoView();
+        $("#display img").get(Reader.currentPage).scrollIntoView({ block: 'nearest' });
     } else {
         $("#img_doublepage").attr("src", "");
         $("#display").removeClass("double-mode");


### PR DESCRIPTION
I have debug overlays active so you can test it for yourself and give feedback **before merge**

Adds more functionality:
- Fixes the sensitivity issue where you had to tap space stupidly fast or it would trigger twice.
-  Continuous** scroll if spacebar is held for > 250 ms  (same as browsers normally do except no initial scroll on keydown then repeating)
- Overshoot Snapping when exiting continuous scroll this snaps you back to the image in the center. It has a rather large 40% snapping radius but this felt good to me when I was testing
- The goto page function has been modified so if you are infinitereader it goes to the bottom of the previous page if going back a page
- Undershoot Snapping this snaps to the edge of the current image if you almost make it to the edge (15%)

Old functions like preventing you from scrolling past the current image on a single press or not doing anything for webtoon strip galleries are still there