### PR TITLE
Keep cache size inside somewhat reasonable sizes

### DIFF
--- a/lib/LANraragi/Utils/PageCache.pm
+++ b/lib/LANraragi/Utils/PageCache.pm
@@ -9,6 +9,7 @@ use utf8;
 use LANraragi::Utils::Logging  qw(get_logger);
 use CHI;
 use LANraragi::Utils::TempFolder qw(get_temp);
+use List::Util qw(min max);
 
 # Contains all functions related to caching entire pages
 use Exporter 'import';
@@ -16,9 +17,13 @@ our @EXPORT_OK = qw(fetch put);
 
 my $cache = undef;
 
+sub calc_max_size() {
+    return max(0, min(LANraragi::Model::Config->get_tempmaxsize, 4096));
+}
+
 sub initialize() {
     my $logger = get_logger( "PageCache", "lanraragi" );
-    my $disk_size = LANraragi::Model::Config->get_tempmaxsize."m";
+    my $disk_size = calc_max_size."m";
     $logger->debug("Initializing cache, disk size: ".$disk_size);
 
     $cache = CHI->new(


### PR DESCRIPTION
Some people have large cache sizes set. This used to be totally reasonable as it only controlled how much disk could be used, but now will allocate that amount in RAM and on disk. This PR limits cache to a totally arbitrary 4gb.