### PR TITLE
Add support for running on Windows natively

### DIFF
--- a/.github/workflows/push-continous-delivery.yml
+++ b/.github/workflows/push-continous-delivery.yml
@@ -142,3 +142,24 @@ jobs:
         name: LANraragi_legacy.msi
         path: ./tools/build/windows/Karen/LRR_WSL1.msi
         if-no-files-found: error
+
+  buildMSYS2:
+    name: Build and export native Windows version
+    runs-on: windows-2025
+    steps:
+    - uses: actions/checkout@master
+    - name: Setup MSYS2 UCRT64
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: UCRT64
+        update: true
+    - name: Build
+      shell: msys2 {0}
+      run: |
+        ./tools/build/msys2/install-everything.sh
+        ./tools/build/msys2/create-dist.sh
+    - name: Upload vfs
+      uses: actions/upload-artifact@v4
+      with:
+        name: windows-native
+        path: ./win-dist/

--- a/.github/workflows/push-continous-delivery.yml
+++ b/.github/workflows/push-continous-delivery.yml
@@ -158,6 +158,8 @@ jobs:
       run: |
         ./tools/build/msys2/install-everything.sh
         ./tools/build/msys2/create-dist.sh
+    - name: Enable UTF-8
+      run: ./tools/build/msys2/utf8-support.ps1
     - name: Upload vfs
       uses: actions/upload-artifact@v4
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ autobackup.json
 Makefile
 oshino
 temp
+win-dist

--- a/lib/LANraragi.pm
+++ b/lib/LANraragi.pm
@@ -23,6 +23,8 @@ use LANraragi::Utils::I18NInitializer;
 use LANraragi::Model::Search;
 use LANraragi::Model::Config;
 
+use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );
+
 # This method will run once at server start
 sub startup {
     my $self = shift;
@@ -159,7 +161,7 @@ sub startup {
     }
 
     # Enable Minion capabilities in the app
-    if ( $Config{osname} ne 'MSWin32') {
+    if ( IS_UNIX ) {
         shutdown_from_pid( get_temp . "/minion.pid" );
     }
 
@@ -186,7 +188,7 @@ sub startup {
     start_minion($self);
 
     # Start File Watcher
-    if ( $Config{osname} ne 'MSWin32') {
+    if ( IS_UNIX ) {
         shutdown_from_pid( get_temp . "/shinobu.pid" );
     }
     start_shinobu($self);
@@ -200,7 +202,7 @@ sub startup {
     $self->hook(
         before_dispatch => sub {
             my $c = shift;
-            if ( $Config{osname} ne 'MSWin32') {
+            if ( IS_UNIX ) {
                 state $unused = add_sigint_handler();
             }
 

--- a/lib/LANraragi.pm
+++ b/lib/LANraragi.pm
@@ -159,7 +159,9 @@ sub startup {
     }
 
     # Enable Minion capabilities in the app
-    shutdown_from_pid( get_temp . "/minion.pid" );
+    if ( $Config{osname} ne 'MSWin32') {
+        shutdown_from_pid( get_temp . "/minion.pid" );
+    }
 
     my $miniondb      = $self->LRR_CONF->get_redisad . "/" . $self->LRR_CONF->get_miniondb;
     my $redispassword = $self->LRR_CONF->get_redispassword;
@@ -181,10 +183,20 @@ sub startup {
     $self->minion->enqueue('build_stat_hashes');
 
     # Start a Minion worker in a subprocess
-    start_minion($self);
+    if ( $Config{osname} ne 'MSWin32') {
+        start_minion($self);
+    } else {
+        # my $numcpus = Sys::CpuAffinity::getNumCpus();
+        # for my $num ( 1 .. $numcpus ) {
+        #     start_minion($self);
+        # }
+        start_minion($self);
+    }
 
     # Start File Watcher
-    shutdown_from_pid( get_temp . "/shinobu.pid" );
+    if ( $Config{osname} ne 'MSWin32') {
+        shutdown_from_pid( get_temp . "/shinobu.pid" );
+    }
     start_shinobu($self);
 
     # Check if this is a first-time installation.
@@ -196,7 +208,9 @@ sub startup {
     $self->hook(
         before_dispatch => sub {
             my $c = shift;
-            state $unused = add_sigint_handler();
+            if ( $Config{osname} ne 'MSWin32') {
+                state $unused = add_sigint_handler();
+            }
 
             my $prefix = $self->LRR_BASEURL;
             if ($prefix) {

--- a/lib/LANraragi.pm
+++ b/lib/LANraragi.pm
@@ -183,15 +183,7 @@ sub startup {
     $self->minion->enqueue('build_stat_hashes');
 
     # Start a Minion worker in a subprocess
-    if ( $Config{osname} ne 'MSWin32') {
-        start_minion($self);
-    } else {
-        # my $numcpus = Sys::CpuAffinity::getNumCpus();
-        # for my $num ( 1 .. $numcpus ) {
-        #     start_minion($self);
-        # }
-        start_minion($self);
-    }
+    start_minion($self);
 
     # Start File Watcher
     if ( $Config{osname} ne 'MSWin32') {

--- a/lib/LANraragi/Controller/Api/Shinobu.pm
+++ b/lib/LANraragi/Controller/Api/Shinobu.pm
@@ -1,11 +1,16 @@
 package LANraragi::Controller::Api::Shinobu;
 use Mojo::Base 'Mojolicious::Controller';
 use Storable;
-use Win32::Process;
 use Config;
 
 use LANraragi::Utils::Generic qw(start_shinobu render_api_response);
 use LANraragi::Utils::TempFolder qw(get_temp);
+
+BEGIN {
+    if ( $Config{osname} eq 'MSWin32') {
+        require Win32::Process;
+    }
+}
 
 sub shinobu_status {
     my $self    = shift;

--- a/lib/LANraragi/Controller/Api/Shinobu.pm
+++ b/lib/LANraragi/Controller/Api/Shinobu.pm
@@ -6,10 +6,10 @@ use Config;
 use LANraragi::Utils::Generic qw(start_shinobu render_api_response);
 use LANraragi::Utils::TempFolder qw(get_temp);
 
-use constant IS_WIN => ( $Config{osname} eq 'MSWin32' );
+use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );
 
 BEGIN {
-    if ( IS_WIN ) {
+    if ( !IS_UNIX ) {
         require Win32::Process;
         Win32::Process->import( qw(NORMAL_PRIORITY_CLASS) );
     }
@@ -18,7 +18,7 @@ BEGIN {
 sub shinobu_status {
     my $self    = shift;
 
-    if ( !IS_WIN ) {
+    if ( IS_UNIX ) {
         my $shinobu = ${ retrieve( get_temp . "/shinobu.pid" ) };
 
         $self->render(
@@ -60,7 +60,7 @@ sub reset_filemap {
     $redis->del("LRR_FILEMAP");
     $redis->quit();
 
-    if ( !IS_WIN ) {
+    if ( IS_UNIX ) {
         my $shinobu = ${ retrieve( get_temp . "/shinobu.pid" ) };
 
         #commit sudoku
@@ -75,7 +75,7 @@ sub reset_filemap {
     # Create a new Process, automatically stored in TEMP_FOLDER/shinobu.pid
     my $proc = start_shinobu($self);
 
-    if ( !IS_WIN ) {
+    if ( IS_UNIX ) {
         $self->render(
             json => {
                 operation => "shinobu_rescan",
@@ -99,7 +99,7 @@ sub reset_filemap {
 sub stop_shinobu {
     my $self    = shift;
 
-    if ( !IS_WIN ) {
+    if ( IS_UNIX ) {
         my $shinobu = ${ retrieve( get_temp . "/shinobu.pid" ) };
 
         #commit sudoku
@@ -117,7 +117,7 @@ sub stop_shinobu {
 sub restart_shinobu {
     my $self    = shift;
 
-    if ( !IS_WIN ) {
+    if ( IS_UNIX ) {
         my $shinobu = ${ retrieve( get_temp . "/shinobu.pid" ) };
 
         #commit sudoku
@@ -132,7 +132,7 @@ sub restart_shinobu {
     # Create a new Process, automatically stored in TEMP_FOLDER/shinobu.pid
     my $proc = start_shinobu($self);
 
-    if ( !IS_WIN ) {
+    if ( IS_UNIX ) {
         $self->render(
             json => {
                 operation => "shinobu_restart",

--- a/lib/LANraragi/Controller/Api/Shinobu.pm
+++ b/lib/LANraragi/Controller/Api/Shinobu.pm
@@ -1,22 +1,43 @@
 package LANraragi::Controller::Api::Shinobu;
 use Mojo::Base 'Mojolicious::Controller';
 use Storable;
+use Win32::Process;
+use Config;
 
 use LANraragi::Utils::Generic qw(start_shinobu render_api_response);
 use LANraragi::Utils::TempFolder qw(get_temp);
 
 sub shinobu_status {
     my $self    = shift;
-    my $shinobu = ${ retrieve( get_temp . "/shinobu.pid" ) };
 
-    $self->render(
-        json => {
-            operation => "shinobu_status",
-            success   => 1,
-            is_alive  => $shinobu->poll(),
-            pid       => $shinobu->pid
-        }
-    );
+    if ( $Config{osname} ne 'MSWin32') {
+        my $shinobu = ${ retrieve( get_temp . "/shinobu.pid" ) };
+
+        $self->render(
+            json => {
+                operation => "shinobu_status",
+                success   => 1,
+                is_alive  => $shinobu->poll(),
+                pid       => $shinobu->pid
+            }
+        );
+    } else {
+        open( my $fh, "<", get_temp() . "/shinobu.pid-s6" );
+        chomp(my $pid = <$fh>);
+        close($fh);
+
+        my $shinobu;
+        Win32::Process::Open($shinobu, $pid, 0);
+
+        $self->render(
+            json => {
+                operation => "shinobu_status",
+                success   => 1,
+                is_alive  => !$shinobu->Wait(1),
+                pid       => "" . $shinobu->GetProcessID()
+            }
+        );
+    }
 }
 
 sub reset_filemap {
@@ -29,49 +50,93 @@ sub reset_filemap {
     $redis->del("LRR_FILEMAP");
     $redis->quit();
 
-    my $shinobu = ${ retrieve( get_temp . "/shinobu.pid" ) };
+    if ( $Config{osname} ne 'MSWin32') {
+        my $shinobu = ${ retrieve( get_temp . "/shinobu.pid" ) };
 
-    #commit sudoku
-    $shinobu->kill();
+        #commit sudoku
+        $shinobu->kill();
+    } else {
+        open( my $fh, "<", get_temp() . "/shinobu.pid-s6" );
+        chomp(my $pid = <$fh>);
+        close($fh);
+        kill HUP => $pid;
+    }
 
     # Create a new Process, automatically stored in TEMP_FOLDER/shinobu.pid
     my $proc = start_shinobu($self);
 
-    $self->render(
-        json => {
-            operation => "shinobu_rescan",
-            success   => $proc->poll(),
-            new_pid   => $proc->pid
-        }
-    );
+    if ( $Config{osname} ne 'MSWin32') {
+        $self->render(
+            json => {
+                operation => "shinobu_rescan",
+                success   => $proc->poll(),
+                new_pid   => $proc->pid
+            }
+        );
+    } else {
+        $self->render(
+            json => {
+                operation => "shinobu_rescan",
+                success   => !$proc->Wait(1),
+                new_pid   => "" . $proc->GetProcessID()
+            }
+        );
+    }
 }
 
 sub stop_shinobu {
     my $self    = shift;
-    my $shinobu = ${ retrieve( get_temp . "/shinobu.pid" ) };
 
-    #commit sudoku
-    $shinobu->kill();
+    if ( $Config{osname} ne 'MSWin32') {
+        my $shinobu = ${ retrieve( get_temp . "/shinobu.pid" ) };
+
+        #commit sudoku
+        $shinobu->kill();
+    } else {
+        open( my $fh, "<", get_temp() . "/shinobu.pid-s6" );
+        chomp(my $pid = <$fh>);
+        close($fh);
+        kill HUP => $pid;
+    }
+
     render_api_response( $self, "shinobu_stop" );
 }
 
 sub restart_shinobu {
     my $self    = shift;
-    my $shinobu = ${ retrieve( get_temp . "/shinobu.pid" ) };
 
-    #commit sudoku
-    $shinobu->kill();
+    if ( $Config{osname} ne 'MSWin32') {
+        my $shinobu = ${ retrieve( get_temp . "/shinobu.pid" ) };
+
+        #commit sudoku
+        $shinobu->kill();
+    } else {
+        open( my $fh, "<", get_temp() . "/shinobu.pid-s6" );
+        chomp(my $pid = <$fh>);
+        close($fh);
+        kill HUP => $pid;
+    }
 
     # Create a new Process, automatically stored in TEMP_FOLDER/shinobu.pid
     my $proc = start_shinobu($self);
 
-    $self->render(
-        json => {
-            operation => "shinobu_restart",
-            success   => $proc->poll(),
-            new_pid   => $proc->pid
-        }
-    );
+    if ( $Config{osname} ne 'MSWin32') {
+        $self->render(
+            json => {
+                operation => "shinobu_restart",
+                success   => $proc->poll(),
+                new_pid   => $proc->pid
+            }
+        );
+    } else {
+        $self->render(
+            json => {
+                operation => "shinobu_restart",
+                success   => !$proc->Wait(1),
+                new_pid   => "" . $proc->GetProcessID()
+            }
+        );
+    }
 }
 
 1;

--- a/lib/LANraragi/Model/Search.pm
+++ b/lib/LANraragi/Model/Search.pm
@@ -12,7 +12,7 @@ use Redis;
 use Storable qw/ nfreeze thaw /;
 use Sort::Naturally;
 
-use LANraragi::Utils::Generic  qw(split_workload_by_cpu intersect_arrays);
+use LANraragi::Utils::Generic  qw(intersect_arrays);
 use LANraragi::Utils::String   qw(trim);
 use LANraragi::Utils::Database qw(redis_decode redis_encode);
 use LANraragi::Utils::Logging  qw(get_logger);

--- a/lib/LANraragi/Utils/Generic.pm
+++ b/lib/LANraragi/Utils/Generic.pm
@@ -14,12 +14,18 @@ use Mojo::IOLoop;
 use Logfile::Rotate;
 use Proc::Simple;
 use Sys::CpuAffinity;
-use Win32::Process;
 use Config;
 
 use LANraragi::Utils::TempFolder qw(get_temp);
 use LANraragi::Utils::String qw(trim);
 use LANraragi::Utils::Logging qw(get_logger);
+
+BEGIN {
+    if ( $Config{osname} eq 'MSWin32') {
+        require Win32::Process;
+        Win32::Process->import( qw(NORMAL_PRIORITY_CLASS) );
+    }
+}
 
 # Generic Utility Functions.
 use Exporter 'import';

--- a/lib/LANraragi/Utils/Generic.pm
+++ b/lib/LANraragi/Utils/Generic.pm
@@ -20,8 +20,10 @@ use LANraragi::Utils::TempFolder qw(get_temp);
 use LANraragi::Utils::String qw(trim);
 use LANraragi::Utils::Logging qw(get_logger);
 
+use constant IS_WIN => ( $Config{osname} eq 'MSWin32' );
+
 BEGIN {
-    if ( $Config{osname} eq 'MSWin32') {
+    if ( IS_WIN ) {
         require Win32::Process;
         Win32::Process->import( qw(NORMAL_PRIORITY_CLASS) );
     }
@@ -102,7 +104,7 @@ sub start_minion {
     my $mojo   = shift;
     my $logger = get_logger( "Minion", "minion" );
 
-    if ( $Config{osname} ne 'MSWin32') {
+    if ( !IS_WIN ) {
         my $numcpus = Sys::CpuAffinity::getNumCpus();
         $logger->info("Starting new Minion worker in subprocess with $numcpus parallel jobs.");
 
@@ -149,7 +151,7 @@ sub _spawn {
 # Start Shinobu and return its Proc::Background object.
 sub start_shinobu {
     my $mojo = shift;
-    if ( $Config{osname} ne 'MSWin32') {
+    if ( !IS_WIN ) {
         my $proc = Proc::Simple->new();
         $proc->start( $^X, "./lib/Shinobu.pm" );
         $proc->kill_on_destroy(0);

--- a/lib/LANraragi/Utils/Minion.pm
+++ b/lib/LANraragi/Utils/Minion.pm
@@ -21,6 +21,8 @@ use LANraragi::Model::Upload;
 use LANraragi::Model::Config;
 use LANraragi::Model::Stats;
 
+use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );
+
 # Add Tasks to the Minion instance.
 sub add_tasks {
     my $minion = shift;
@@ -77,7 +79,7 @@ sub add_tasks {
                 push @keys, $i;
             }
 
-            if ( $Config{osname} ne 'MSWin32') {
+            if ( IS_UNIX ) {
                 my $numCpus = Sys::CpuAffinity::getNumCpus();
                 my $pl      = Parallel::Loops->new($numCpus);
                 $pl->share( \@errors );
@@ -147,7 +149,7 @@ sub add_tasks {
             $logger->info("Starting thumbnail regen job (force = $force)");
             my @errors = ();
 
-            if ( $Config{osname} ne 'MSWin32') {
+            if ( IS_UNIX ) {
                 my $numCpus = Sys::CpuAffinity::getNumCpus();
                 my $pl      = Parallel::Loops->new($numCpus);
                 $pl->share( \@errors );
@@ -231,7 +233,7 @@ sub add_tasks {
             my %visited : shared;
             my @ids = keys %thumbhashes;    # List of IDs to check
 
-            if ( $Config{osname} ne 'MSWin32') {
+            if ( IS_UNIX ) {
                 my $numCpus = Sys::CpuAffinity::getNumCpus();
                 my $pl      = Parallel::Loops->new($numCpus);
 

--- a/lib/LANraragi/Utils/Minion.pm
+++ b/lib/LANraragi/Utils/Minion.pm
@@ -14,7 +14,6 @@ use LANraragi::Utils::Logging    qw(get_logger);
 use LANraragi::Utils::Database   qw(redis_decode);
 use LANraragi::Utils::Archive    qw(extract_thumbnail);
 use LANraragi::Utils::Plugins    qw(get_downloader_for_url get_plugin get_plugin_parameters use_plugin);
-use LANraragi::Utils::Generic    qw(split_workload_by_cpu);
 use LANraragi::Utils::String     qw(trim_url);
 use LANraragi::Utils::TempFolder qw(get_temp);
 
@@ -108,6 +107,7 @@ sub add_tasks {
                         $sub->(@{ $_ });
                     } \@keys;
                 } else {
+                    # libarchive does not support threading on Windows
                     $sub->(@keys);
                 }
             };
@@ -164,6 +164,7 @@ sub add_tasks {
                         $sub->(@{ $_ });
                     } \@keys;
                 } else {
+                    # libarchive does not support threading on Windows
                     $sub->(@keys);
                 }
             };

--- a/lib/LANraragi/Utils/PageCache.pm
+++ b/lib/LANraragi/Utils/PageCache.pm
@@ -13,6 +13,8 @@ use Config;
 use LANraragi::Utils::Logging  qw(get_logger);
 use LANraragi::Utils::TempFolder qw(get_temp);
 
+use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );
+
 # Contains all functions related to caching entire pages
 use Exporter 'import';
 our @EXPORT_OK = qw(fetch put);
@@ -28,7 +30,7 @@ sub initialize() {
     my $disk_size = calc_max_size."m";
     $logger->debug("Initializing cache, disk size: ".$disk_size);
 
-    if ( $Config{osname} ne 'MSWin32') {
+    if ( IS_UNIX ) {
         $cache = CHI->new(
             driver     => 'FastMmap',
             cache_size => $disk_size,

--- a/lib/LANraragi/Utils/PageCache.pm
+++ b/lib/LANraragi/Utils/PageCache.pm
@@ -6,10 +6,12 @@ use strict;
 use warnings;
 use utf8;
 
-use LANraragi::Utils::Logging  qw(get_logger);
-use CHI;
-use LANraragi::Utils::TempFolder qw(get_temp);
 use List::Util qw(min max);
+use CHI;
+use Config;
+
+use LANraragi::Utils::Logging  qw(get_logger);
+use LANraragi::Utils::TempFolder qw(get_temp);
 
 # Contains all functions related to caching entire pages
 use Exporter 'import';
@@ -26,11 +28,19 @@ sub initialize() {
     my $disk_size = calc_max_size."m";
     $logger->debug("Initializing cache, disk size: ".$disk_size);
 
-    $cache = CHI->new(
-        driver     => 'FastMmap',
-        cache_size => $disk_size,
-        root_dir => get_temp,
-    );
+    if ( $Config{osname} ne 'MSWin32') {
+        $cache = CHI->new(
+            driver     => 'FastMmap',
+            cache_size => $disk_size,
+            root_dir => get_temp,
+        );
+    } else {
+        $cache = CHI->new(
+            driver     => 'Memory',
+            global => 1,
+            max_size => $disk_size,
+        );
+    }
 }
 
 # Fetches data from cache if available. Returns undef if nothing is there

--- a/lib/LANraragi/Utils/Routing.pm
+++ b/lib/LANraragi/Utils/Routing.pm
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 use utf8;
 
-use Mojolicious::Plugin::Status;
 use Mojolicious::Plugin::Minion::Admin;
 
 #Contains all the routes used by the app, and applies them on boot.
@@ -56,7 +55,10 @@ sub apply_routes {
 
     # Mojo Status UI
     if ( $self->mode eq 'development' ) {
-        $self->plugin( 'Status' => { route => $logged_in->get('/debug') } );
+        eval {
+            require Mojolicious::Plugin::Status;
+            $self->plugin( 'Status' => { route => $logged_in->get('/debug') } );
+        };
     }
 
     # Those routes are only accessible if user is logged in

--- a/lib/LANraragi/Utils/Routing.pm
+++ b/lib/LANraragi/Utils/Routing.pm
@@ -55,6 +55,7 @@ sub apply_routes {
 
     # Mojo Status UI
     if ( $self->mode eq 'development' ) {
+        # Not supported on Windows
         eval {
             require Mojolicious::Plugin::Status;
             $self->plugin( 'Status' => { route => $logged_in->get('/debug') } );

--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -32,7 +32,7 @@ use Encode;
 use LANraragi::Utils::Archive    qw(extract_thumbnail);
 use LANraragi::Utils::Database   qw(redis_encode invalidate_cache compute_id change_archive_id);
 use LANraragi::Utils::Logging    qw(get_logger);
-use LANraragi::Utils::Generic    qw(is_archive split_workload_by_cpu);
+use LANraragi::Utils::Generic    qw(is_archive);
 
 use LANraragi::Model::Config;
 use LANraragi::Model::Plugins;
@@ -147,6 +147,7 @@ sub update_filemap {
                 add_new_files(@{ $_ });
             } \@newfiles;
         } else {
+            # libarchive does not support threading on Windows
             add_new_files(@newfiles);
         }
     };

--- a/lib/Worker.pm
+++ b/lib/Worker.pm
@@ -1,0 +1,73 @@
+package Worker;
+
+use strict;
+use warnings;
+use utf8;
+use feature qw(say signatures);
+no warnings 'experimental::signatures';
+
+use FindBin;
+use Minion;
+
+#As this is a new process, reloading the LRR libs into INC is needed.
+BEGIN { unshift @INC, "$FindBin::Bin/../lib"; }
+
+use Mojolicious;    # Needed by Model::Config to read the Redis address/port.
+use Mojo::Util qw(steady_time);
+
+use LANraragi::Utils::Logging    qw(get_logger);
+
+use LANraragi::Utils::Minion;
+use LANraragi::Model::Config;
+
+# Logger and Database objects
+my $logger = get_logger( "Minion Worker", "minion" );
+
+
+sub initialize_from_new_process {
+
+    $logger->info("Minion Worker started.");
+
+    my $userdir = LANraragi::Model::Config->get_userdir;
+
+    my $miniondb      = LANraragi::Model::Config->get_redisad . "/" . LANraragi::Model::Config->get_miniondb;
+    my $redispassword = LANraragi::Model::Config->get_redispassword;
+
+    # If the password is non-empty, add the required delimiters
+    if ($redispassword) { $redispassword = "x:" . $redispassword . "@"; }
+
+    say "Minion Worker will use the Redis database at $miniondb";
+
+    my $minion = Minion->new(Redis => "redis://$redispassword$miniondb");
+
+    LANraragi::Utils::Minion::add_tasks( $minion );
+    $logger->debug("Registered tasks with Minion.");
+
+    my $worker = $minion->worker->register;
+    my $running = 1;
+
+    my $last_heartbeat = 0; 
+    my $last_repair = 0;
+    while ($running) {
+        local $SIG{INT} = sub { $running = 0 };
+
+        while(my $job = $worker->dequeue(5)) {
+            if (defined(my $err = $job->execute)) {
+                $job->fail($err);
+            } else {
+                $job->finish;
+            }
+        }
+        $worker->register and $last_heartbeat = steady_time if ($last_heartbeat + 300) < steady_time;
+
+        if (($last_repair + 21600) < steady_time) {
+            $minion->repair;
+            $last_repair = steady_time;
+        }
+    }
+    $worker->unregister;
+}
+
+__PACKAGE__->initialize_from_new_process unless caller;
+
+1;

--- a/lib/Worker.pm
+++ b/lib/Worker.pm
@@ -43,7 +43,7 @@ sub initialize_from_new_process {
     LANraragi::Utils::Minion::add_tasks( $minion );
     $logger->debug("Registered tasks with Minion.");
 
-    my $worker = $minion->worker->register;
+    my $worker = $minion->repair->worker->register;
     my $running = 1;
 
     my $last_heartbeat = 0; 

--- a/lib/Worker.pm
+++ b/lib/Worker.pm
@@ -23,7 +23,7 @@ use LANraragi::Model::Config;
 # Logger and Database objects
 my $logger = get_logger( "Minion Worker", "minion" );
 
-
+# Windows-only worker. Single threaded and non-forking.
 sub initialize_from_new_process {
 
     $logger->info("Minion Worker started.");

--- a/script/launcher.pl
+++ b/script/launcher.pl
@@ -7,11 +7,13 @@ use Cwd 'abs_path';
 use Mojo::Base -strict;
 use Mojo::Server::Morbo;
 use Mojo::Server::Prefork;
+use Mojo::Server::Daemon;
 use Mojo::Util qw(extract_usage getopt);
 use File::Path qw(make_path);
 
 getopt
   'm|morbo'      => \my $morbo,
+  'd|daemon'     => \my $daemon,
   'f|foreground' => \$ENV{HYPNOTOAD_FOREGROUND},
   'h|help'       => \my $help,
   'v|verbose'    => \$ENV{MORBO_VERBOSE};
@@ -54,6 +56,15 @@ if ($morbo) {
     $ENV{MOJO_MODE} = "development";
     $backend->daemon->listen(@listen);
     $backend->run($app);
+} elsif ($daemon) {
+    $backend = Mojo::Server::Daemon->new( keep_alive_timeout => 30 );
+    $backend->listen(@listen);
+
+    $backend->load_app($app);
+
+    $backend->start;
+
+    $backend->run;
 } else {
     print "Server PID will be at " . $hypno_pid . "\n";
 

--- a/tools/build/msys2/create-dist.sh
+++ b/tools/build/msys2/create-dist.sh
@@ -16,10 +16,10 @@ mkdir -p ./win-dist/runtime/lib
 
 cp -R /ucrt64/lib/perl5 ./win-dist/runtime/lib
 cp -R /ucrt64/lib/p11-kit ./win-dist/runtime/lib
-cp -R /ucrt64/lib/ImageMagick-7.1.1 ./win-dist/runtime/lib
+cp -R /ucrt64/lib/ImageMagick-7.1.2 ./win-dist/runtime/lib
 
 # We don't need .a files, they are used only during compilation
-find ./win-dist/runtime/lib/ImageMagick-7.1.1/ -name "*.a" -type f -delete
+find ./win-dist/runtime/lib/ImageMagick-7.1.2/ -name "*.a" -type f -delete
 
 # Copy more openssl stuff
 mkdir -p ./win-dist/runtime/share

--- a/tools/build/msys2/create-dist.sh
+++ b/tools/build/msys2/create-dist.sh
@@ -2,33 +2,31 @@
 
 set -e
 
+# Create the root vfs, copy bin and etc as-is
 mkdir -p ./win-dist/runtime
 
 cp -R /ucrt64/bin ./win-dist/runtime
 cp -R /ucrt64/etc ./win-dist/runtime
 
+# Remove other exes
+find ./win-dist/runtime/bin -name "*.exe" -not -name "perl.exe" -not -name "gs.exe" -type f -delete
+
+# Copy perl, openssl and magick libs
 mkdir -p ./win-dist/runtime/lib
 
 cp -R /ucrt64/lib/perl5 ./win-dist/runtime/lib
 cp -R /ucrt64/lib/p11-kit ./win-dist/runtime/lib
 cp -R /ucrt64/lib/ImageMagick-7.1.1 ./win-dist/runtime/lib
 
+# We don't need .a files, they are used only during compilation
 find ./win-dist/runtime/lib/ImageMagick-7.1.1/ -name "*.a" -type f -delete
 
+# Copy more openssl stuff
 mkdir -p ./win-dist/runtime/share
 
 cp -R /ucrt64/share/pki ./win-dist/runtime/share
 
-cp ./package.json ./win-dist
-cp ./lrr.conf ./win-dist
-cp -R ./lib ./win-dist
-cp -R ./public ./win-dist
-cp -R ./script ./win-dist
-cp -R ./templates ./win-dist
-cp -R ./locales ./win-dist
-
-cp ./tools/build/msys2/run.ps1 ./win-dist
-
+# Inject redis into the vfs
 wget -q -O redis.zip https://github.com/redis-windows/redis-windows/releases/download/7.2.8/Redis-7.2.8-Windows-x64-msys2.zip
 unzip -qq redis.zip
 rm redis.zip
@@ -38,5 +36,16 @@ mkdir -p win-dist/runtime/redis
 mv ./Redis-7.2.8-Windows-x64-msys2/* ./win-dist/runtime/redis
 
 rm -rf ./Redis-7.2.8-Windows-x64-msys2
+
+# Copy the actual app
+cp ./package.json ./win-dist
+cp ./lrr.conf ./win-dist
+cp -R ./lib ./win-dist
+cp -R ./public ./win-dist
+cp -R ./script ./win-dist
+cp -R ./templates ./win-dist
+cp -R ./locales ./win-dist
+
+cp ./tools/build/msys2/run.ps1 ./win-dist
 
 cp ./tools/build/msys2/redis.conf ./win-dist/runtime/redis

--- a/tools/build/msys2/create-dist.sh
+++ b/tools/build/msys2/create-dist.sh
@@ -11,6 +11,10 @@ mkdir -p ./win-dist/runtime/lib
 
 cp -R /ucrt64/lib/perl5 ./win-dist/runtime/lib
 cp -R /ucrt64/lib/p11-kit ./win-dist/runtime/lib
+cp -R /ucrt64/lib/ImageMagick-7.1.1 ./win-dist/runtime/lib
+
+find ./win-dist/runtime/lib/ImageMagick-7.1.1/ -name "*.a" -type f -delete
+find ./win-dist/runtime/lib/ImageMagick-7.1.1/ -name "*.la" -type f -delete
 
 mkdir -p ./win-dist/runtime/share
 

--- a/tools/build/msys2/create-dist.sh
+++ b/tools/build/msys2/create-dist.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -e
+
+mkdir -p ./win-dist/runtime
+
+cp -R /ucrt64/bin ./win-dist/runtime
+cp -R /ucrt64/etc ./win-dist/runtime
+
+mkdir -p ./win-dist/runtime/lib
+
+cp -R /ucrt64/lib/perl5 ./win-dist/runtime/lib
+cp -R /ucrt64/lib/p11-kit ./win-dist/runtime/lib
+
+mkdir -p ./win-dist/runtime/share
+
+cp -R /ucrt64/share/pki ./win-dist/runtime/share
+
+cp ./package.json ./win-dist
+cp ./lrr.conf ./win-dist
+cp -R ./lib ./win-dist
+cp -R ./public ./win-dist
+cp -R ./script ./win-dist
+cp -R ./templates ./win-dist
+cp -R ./locales ./win-dist
+
+cp ./tools/build/msys2/run.ps1 ./win-dist
+
+wget -q -O redis.zip https://github.com/redis-windows/redis-windows/releases/download/7.2.8/Redis-7.2.8-Windows-x64-msys2.zip
+unzip -qq redis.zip
+rm redis.zip
+
+mkdir -p win-dist/runtime/redis
+
+mv ./Redis-7.2.8-Windows-x64-msys2/* ./win-dist/runtime/redis
+
+rm -rf ./Redis-7.2.8-Windows-x64-msys2
+
+cp ./tools/build/docker/redis.conf ./win-dist/runtime/redis

--- a/tools/build/msys2/create-dist.sh
+++ b/tools/build/msys2/create-dist.sh
@@ -36,4 +36,4 @@ mv ./Redis-7.2.8-Windows-x64-msys2/* ./win-dist/runtime/redis
 
 rm -rf ./Redis-7.2.8-Windows-x64-msys2
 
-cp ./tools/build/docker/redis.conf ./win-dist/runtime/redis
+cp ./tools/build/msys2/redis.conf ./win-dist/runtime/redis

--- a/tools/build/msys2/create-dist.sh
+++ b/tools/build/msys2/create-dist.sh
@@ -14,7 +14,6 @@ cp -R /ucrt64/lib/p11-kit ./win-dist/runtime/lib
 cp -R /ucrt64/lib/ImageMagick-7.1.1 ./win-dist/runtime/lib
 
 find ./win-dist/runtime/lib/ImageMagick-7.1.1/ -name "*.a" -type f -delete
-find ./win-dist/runtime/lib/ImageMagick-7.1.1/ -name "*.la" -type f -delete
 
 mkdir -p ./win-dist/runtime/share
 

--- a/tools/build/msys2/install-everything.sh
+++ b/tools/build/msys2/install-everything.sh
@@ -3,10 +3,10 @@
 set -e
 
 # Install deps that will persist into the vfs
-pacman --needed -S mingw-w64-ucrt-x86_64-perl mingw-w64-ucrt-x86_64-openssl mingw-w64-ucrt-x86_64-imagemagick mingw-w64-ucrt-x86_64-libjxl mingw-w64-ucrt-x86_64-libheif mingw-w64-ucrt-x86_64-ghostscript mingw-w64-ucrt-x86_64-zlib mingw-w64-ucrt-x86_64-lzo2 mingw-w64-ucrt-x86_64-libarchive mingw-w64-ucrt-x86_64-ca-certificates libxcrypt --noconfirm
+pacman --needed -S mingw-w64-ucrt-x86_64-perl mingw-w64-ucrt-x86_64-openssl mingw-w64-ucrt-x86_64-imagemagick mingw-w64-ucrt-x86_64-libjxl mingw-w64-ucrt-x86_64-libheif mingw-w64-ucrt-x86_64-ghostscript mingw-w64-ucrt-x86_64-zlib mingw-w64-ucrt-x86_64-lzo2 mingw-w64-ucrt-x86_64-libarchive mingw-w64-ucrt-x86_64-ca-certificates libxcrypt unzip --noconfirm
 
 # Install temporary deps for compilation
-pacman --needed -S mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-make make mingw-w64-ucrt-x86_64-diffutils libbz2-devel patch mingw-w64-ucrt-x86_64-nodejs mingw-w64-ucrt-x86_64-tools-git unzip --noconfirm
+pacman --needed -S mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-make make mingw-w64-ucrt-x86_64-diffutils libbz2-devel patch mingw-w64-ucrt-x86_64-nodejs mingw-w64-ucrt-x86_64-tools-git --noconfirm
 
 # Install cpanm
 curl -L https://cpanmin.us | perl - App::cpanminus
@@ -45,7 +45,7 @@ cd ..
 perl ./tools/install.pl install-full
 
 # Remove compilation deps
-pacman -Rs mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-make make mingw-w64-ucrt-x86_64-diffutils libbz2-devel patch mingw-w64-ucrt-x86_64-nodejs mingw-w64-ucrt-x86_64-tools-git unzip --noconfirm
+pacman -Rs mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-make make mingw-w64-ucrt-x86_64-diffutils libbz2-devel patch mingw-w64-ucrt-x86_64-nodejs mingw-w64-ucrt-x86_64-tools-git --noconfirm
 
 # Cleanup
 rm -rf ./public/js/vendor/*.map ./public/css/vendor/*.map

--- a/tools/build/msys2/install-everything.sh
+++ b/tools/build/msys2/install-everything.sh
@@ -2,11 +2,13 @@
 
 set -e
 
-pacman --needed -S mingw-w64-ucrt-x86_64-perl mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-make mingw-w64-ucrt-x86_64-diffutils mingw-w64-ucrt-x86_64-openssl mingw-w64-ucrt-x86_64-imagemagick mingw-w64-ucrt-x86_64-libjxl mingw-w64-ucrt-x86_64-ghostscript mingw-w64-ucrt-x86_64-zlib mingw-w64-ucrt-x86_64-lzo2 mingw-w64-ucrt-x86_64-libarchive make libxcrypt libbz2-devel patch mingw-w64-ucrt-x86_64-nodejs mingw-w64-ucrt-x86_64-tools-git
+pacman --needed -S mingw-w64-ucrt-x86_64-perl mingw-w64-ucrt-x86_64-openssl mingw-w64-ucrt-x86_64-imagemagick mingw-w64-ucrt-x86_64-libjxl mingw-w64-ucrt-x86_64-libheif mingw-w64-ucrt-x86_64-ghostscript mingw-w64-ucrt-x86_64-zlib mingw-w64-ucrt-x86_64-lzo2 mingw-w64-ucrt-x86_64-libarchive mingw-w64-ucrt-x86_64-ca-certificates libxcrypt --noconfirm
+
+pacman --needed -S mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-make make mingw-w64-ucrt-x86_64-diffutils libbz2-devel patch mingw-w64-ucrt-x86_64-nodejs mingw-w64-ucrt-x86_64-tools-git unzip --noconfirm
 
 curl -L https://cpanmin.us | perl - App::cpanminus
 
-cd /home/koyomi/lanraragi/tools
+cd ./tools
 
 cpanm --notest --installdeps Crypt::DES -M https://cpan.metacpan.org
 curl -L -s https://cpan.metacpan.org/authors/id/D/DP/DPARIS/Crypt-DES-2.07.tar.gz | tar -xz
@@ -34,3 +36,6 @@ cd ..
 
 perl ./tools/install.pl install-full
 
+pacman -Rs mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-make make mingw-w64-ucrt-x86_64-diffutils libbz2-devel patch mingw-w64-ucrt-x86_64-nodejs mingw-w64-ucrt-x86_64-tools-git unzip --noconfirm
+
+rm -rf ./public/js/vendor/*.map ./public/css/vendor/*.map

--- a/tools/build/msys2/install-everything.sh
+++ b/tools/build/msys2/install-everything.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+set -e
+
+pacman --needed -S mingw-w64-ucrt-x86_64-perl mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-make mingw-w64-ucrt-x86_64-diffutils mingw-w64-ucrt-x86_64-openssl mingw-w64-ucrt-x86_64-imagemagick mingw-w64-ucrt-x86_64-libjxl mingw-w64-ucrt-x86_64-ghostscript mingw-w64-ucrt-x86_64-zlib mingw-w64-ucrt-x86_64-lzo2 mingw-w64-ucrt-x86_64-libarchive make libxcrypt libbz2-devel patch mingw-w64-ucrt-x86_64-nodejs mingw-w64-ucrt-x86_64-tools-git
+
+curl -L https://cpanmin.us | perl - App::cpanminus
+
+cd /home/koyomi/lanraragi/tools
+
+cpanm --notest --installdeps Crypt::DES -M https://cpan.metacpan.org
+curl -L -s https://cpan.metacpan.org/authors/id/D/DP/DPARIS/Crypt-DES-2.07.tar.gz | tar -xz
+cd Crypt-DES-2.07
+patch -p1 < ../build/msys2/perl-Crypt-DES-fedora-c99.patch
+perl Makefile.PL && mingw32-make install
+cd ../ && rm -rf Crypt-DES-2.07
+
+cpanm --notest --installdeps Minion -M https://cpan.metacpan.org
+curl -L -s https://cpan.metacpan.org/authors/id/S/SR/SRI/Minion-10.31.tar.gz | tar -xz
+cd Minion-10.31
+sed -i "s/croak 'Minion workers do not support fork emulation'/#croak 'Minion workers do not support fork emulation'/" lib/Minion.pm
+perl Makefile.PL && mingw32-make install
+cd ../ && rm -rf Minion-10.31
+
+cpanm --notest --installdeps Image::Magick -M https://cpan.metacpan.org
+curl -L -s https://cpan.metacpan.org/authors/id/J/JC/JCRISTY/Image-Magick-7.1.1-28.tar.gz | tar -xz
+cd Image-Magick-7.1.1
+patch -p1 < ../build/msys2/perl-Image-Magic-fix-msys2.patch
+perl Makefile.PL && mingw32-make install
+cd ../ && rm -rf Image-Magick-7.1.1
+
+cpanm --notest --installdeps . -M https://cpan.metacpan.org
+cd ..
+
+perl ./tools/install.pl install-full
+

--- a/tools/build/msys2/install-everything.sh
+++ b/tools/build/msys2/install-everything.sh
@@ -2,13 +2,18 @@
 
 set -e
 
+# Install deps that will persist into the vfs
 pacman --needed -S mingw-w64-ucrt-x86_64-perl mingw-w64-ucrt-x86_64-openssl mingw-w64-ucrt-x86_64-imagemagick mingw-w64-ucrt-x86_64-libjxl mingw-w64-ucrt-x86_64-libheif mingw-w64-ucrt-x86_64-ghostscript mingw-w64-ucrt-x86_64-zlib mingw-w64-ucrt-x86_64-lzo2 mingw-w64-ucrt-x86_64-libarchive mingw-w64-ucrt-x86_64-ca-certificates libxcrypt --noconfirm
 
+# Install temporary deps for compilation
 pacman --needed -S mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-make make mingw-w64-ucrt-x86_64-diffutils libbz2-devel patch mingw-w64-ucrt-x86_64-nodejs mingw-w64-ucrt-x86_64-tools-git unzip --noconfirm
 
+# Install cpanm
 curl -L https://cpanmin.us | perl - App::cpanminus
 
 cd ./tools
+
+# Manually download and patch modules
 
 cpanm --notest --installdeps Crypt::DES -M https://cpan.metacpan.org
 curl -L -s https://cpan.metacpan.org/authors/id/D/DP/DPARIS/Crypt-DES-2.07.tar.gz | tar -xz
@@ -31,11 +36,16 @@ patch -p1 < ../build/msys2/perl-Image-Magic-fix-msys2.patch
 perl Makefile.PL && mingw32-make install
 cd ../ && rm -rf Image-Magick-7.1.1
 
+# Install remaining modules
 cpanm --notest --installdeps . -M https://cpan.metacpan.org
+
 cd ..
 
+# Run installer
 perl ./tools/install.pl install-full
 
+# Remove compilation deps
 pacman -Rs mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-make make mingw-w64-ucrt-x86_64-diffutils libbz2-devel patch mingw-w64-ucrt-x86_64-nodejs mingw-w64-ucrt-x86_64-tools-git unzip --noconfirm
 
+# Cleanup
 rm -rf ./public/js/vendor/*.map ./public/css/vendor/*.map

--- a/tools/build/msys2/perl-Crypt-DES-fedora-c99.patch
+++ b/tools/build/msys2/perl-Crypt-DES-fedora-c99.patch
@@ -1,0 +1,33 @@
+https://src.fedoraproject.org/rpms/perl-Crypt-DES/raw/0a4557f6b118387730b895037e4a17c90f212e68/f/perl-Crypt-DES-fedora-c99.patch
+https://rt.cpan.org/Public/Bug/Display.html?id=133363
+https://rt.cpan.org/Public/Bug/Display.html?id=133412
+https://bugs.gentoo.org/870427
+--- a/DES.xs
++++ b/DES.xs
+@@ -36,7 +36,7 @@ _des_expand_key(key)
+ 		if (key_len != sizeof(des_user_key))
+ 			croak("Invalid key");
+ 
+-		perl_des_expand_key((i8 *)key, ks);
++		perl_des_expand_key((unsigned char *)key, ks);
+ 
+ 		ST(0) = sv_2mortal(newSVpv((char *)ks, sizeof(ks)));
+ 	}
+@@ -66,7 +66,8 @@ _des_crypt(input, output, ks, enc_flag)
+ 
+ 		(SvUPGRADE(output, SVt_PV));
+ 
+-		perl_des_crypt(input, SvGROW(output, output_len), (i32 *)ks, enc_flag);
++		perl_des_crypt((unsigned char *)input, (unsigned char *)SvGROW(output, output_len),
++			       (unsigned long *)ks, enc_flag);
+ 
+ 		SvCUR_set(output, output_len);
+ 		*SvEND(output) = '\0';
+--- a/_des.h
++++ b/_des.h
+@@ -5,3 +5,5 @@ typedef unsigned long des_ks[32];
+ void _des_crypt( des_cblock in, des_cblock out, des_ks key, int encrypt );
+ void _des_expand_key( des_user_key userKey, des_ks key );
+ 
++void perl_des_expand_key(des_user_key userKey, des_ks ks);
++void perl_des_crypt( des_cblock input, des_cblock output, des_ks ks, int encrypt );

--- a/tools/build/msys2/perl-Image-Magic-fix-msys2.patch
+++ b/tools/build/msys2/perl-Image-Magic-fix-msys2.patch
@@ -1,0 +1,64 @@
+--- a/Makefile.PL
++++ b/Makefile.PL
+@@ -63,35 +63,35 @@
+
+       # try to detect 'include' dir
+       push @i, catfile($dirpath,'include');
+-      push @i, catfile($dirpath,'include','ImageMagick');
++      push @i, catfile($dirpath,'include','ImageMagick-7');
+       push @i, catfile($dirpath,'..','include');
+-      push @i, catfile($dirpath,'..','include','ImageMagick');
++      push @i, catfile($dirpath,'..','include','ImageMagick-7');
+       push @i, catfile($dirpath,'..','..','include');
+-      push @i, catfile($dirpath,'..','..','include','ImageMagick');
++      push @i, catfile($dirpath,'..','..','include','ImageMagick-7');
+       push @i, catfile($dirpath,'..','..','..','include');
+-      push @i, catfile($dirpath,'..','..','..','include','ImageMagick');
++      push @i, catfile($dirpath,'..','..','..','include','ImageMagick-7');
+       foreach (@i) { push @incdir, $_ if (-e "$_/MagickCore/MagickCore.h") };
+     }
+   };
+
+   foreach my $bin (@bindir) {
+     opendir(my $bindir, $bin) or die qq{Cannot opendir $bin: $!};
+-    my @dlls = map {catfile($bin, $_)} grep /^\S*magick[^\+]\S*?\.dll$/i, readdir $bindir;
++    my @dlls = map {catfile($bin, $_)} grep /^\S*magickc[^\+]\S*?\.dll$/i, readdir $bindir;
+     foreach my $d (@dlls) {
+-      unlink "$wrkdir/libMagickCore.def", "$wrkdir/libMagickCore.a";
+-      system("pexports \"$d\" >\"$wrkdir/libMagickCore.def\" 2>$devnull");
+-      open(DEF, "<$wrkdir/libMagickCore.def");
++      unlink "$wrkdir/libMagickCore-7.Q16HDRI-10.def", "$wrkdir/libMagickCore-7.Q16HDRI-10.a";
++      system("gendef \"$d\"");
++      open(DEF, "<$wrkdir/libMagickCore-7.Q16HDRI-10.def");
+       my @found = grep(/MagickCoreGenesis/, <DEF>); #checking if we have taken the right DLL
+       close(DEF);
+       next unless(@found);
+-      print STDERR "Gonna create 'libMagickCore.a' from '$d'\n";
+-      system("dlltool -D \"$d\" -d \"$wrkdir/libMagickCore.def\" -l \"$wrkdir/libMagickCore.a\" 2>$devnull");
+-      last if -s "$wrkdir/libMagickCore.a";
++      print STDERR "Gonna create 'libMagickCore-7.Q16HDRI-10.a' from '$d'\n";
++      system("dlltool -D \"$d\" -d \"$wrkdir/libMagickCore-7.Q16HDRI-10.def\" -l \"$wrkdir/libMagickCore-7.Q16HDRI-10.a\" 2>$devnull");
++      last if -s "$wrkdir/libMagickCore-7.Q16HDRI-10.a";
+     }
+-    last if -s "$wrkdir/libMagickCore.a";
++    last if -s "$wrkdir/libMagickCore-7.Q16HDRI-10.a";
+   }
+
+-  unless(@incdir && @libdir && @bindir && (-s "$wrkdir/libMagickCore.a")) {
++  unless(@incdir && @libdir && @bindir && (-s "$wrkdir/libMagickCore-7.Q16HDRI-10.a")) {
+     print STDERR <<EOF
+ ################################### WARNING! ###################################
+ # It seems that you are trying to install Perl::Magick on a MS Windows box with
+@@ -173,9 +173,9 @@
+   #
+   # Setup for strawberry perl.
+   #
+-  $INC_magick       = "$Ipaths";
+-  $LIBS_magick      = "-lMagickCore"; # use here just plain 'MagickCore' no version info
+-  $CCFLAGS_magick   = "$Config{'ccflags'}";
++  $INC_magick       = "$Ipaths  -DMAGICKCORE_HDRI_ENABLE=1 -DMAGICKCORE_QUANTUM_DEPTH=16";
++  $LIBS_magick      = "-lMagickCore-7.Q16HDRI-10"; # use here just plain 'MagickCore' no version info
++  $CCFLAGS_magick   = "$Config{'ccflags'} -O2 -Wall -pthread -DMAGICKCORE_HDRI_ENABLE=1 -DMAGICKCORE_QUANTUM_DEPTH=16";
+   $LDFLAGS_magick   = "$Config{'ldflags'} $Lpaths ";
+   $LDDLFLAGS_magick = "$Config{'lddlflags'} $Lpaths ";
+ }

--- a/tools/build/msys2/perl.exe.manifest
+++ b/tools/build/msys2/perl.exe.manifest
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity type="win32" name="perl" version="1.0.0.0" />
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+  
+  <application>
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/tools/build/msys2/redis.conf
+++ b/tools/build/msys2/redis.conf
@@ -1,0 +1,1370 @@
+# Redis configuration file example.
+#
+# Note that in order to read the configuration file, Redis must be
+# started with the file path as first argument:
+#
+# ./redis-server /path/to/redis.conf
+
+# Note on units: when memory size is needed, it is possible to specify
+# it in the usual form of 1k 5GB 4M and so forth:
+#
+# 1k => 1000 bytes
+# 1kb => 1024 bytes
+# 1m => 1000000 bytes
+# 1mb => 1024*1024 bytes
+# 1g => 1000000000 bytes
+# 1gb => 1024*1024*1024 bytes
+#
+# units are case insensitive so 1GB 1Gb 1gB are all the same.
+
+################################## INCLUDES ###################################
+
+# Include one or more other config files here.  This is useful if you
+# have a standard template that goes to all Redis servers but also need
+# to customize a few per-server settings.  Include files can include
+# other files, so use this wisely.
+#
+# Notice option "include" won't be rewritten by command "CONFIG REWRITE"
+# from admin or Redis Sentinel. Since Redis always uses the last processed
+# line as value of a configuration directive, you'd better put includes
+# at the beginning of this file to avoid overwriting config change at runtime.
+#
+# If instead you are interested in using includes to override configuration
+# options, it is better to use include as the last line.
+#
+# include /path/to/local.conf
+# include /path/to/other.conf
+
+################################## MODULES #####################################
+
+# Load modules at startup. If the server is not able to load modules
+# it will abort. It is possible to use multiple loadmodule directives.
+#
+# loadmodule /path/to/my_module.so
+# loadmodule /path/to/other_module.so
+
+################################## NETWORK #####################################
+
+# By default, if no "bind" configuration directive is specified, Redis listens
+# for connections from all the network interfaces available on the server.
+# It is possible to listen to just one or multiple selected interfaces using
+# the "bind" configuration directive, followed by one or more IP addresses.
+#
+# Examples:
+#
+# bind 192.168.1.100 10.0.0.1
+# bind 127.0.0.1 ::1
+#
+# ~~~ WARNING ~~~ If the computer running Redis is directly exposed to the
+# internet, binding to all the interfaces is dangerous and will expose the
+# instance to everybody on the internet. So by default we uncomment the
+# following bind directive, that will force Redis to listen only into
+# the IPv4 loopback interface address (this means Redis will be able to
+# accept connections only from clients running into the same computer it
+# is running).
+#
+# IF YOU ARE SURE YOU WANT YOUR INSTANCE TO LISTEN TO ALL THE INTERFACES
+# JUST COMMENT THE FOLLOWING LINE.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+bind 127.0.0.1
+
+# Protected mode is a layer of security protection, in order to avoid that
+# Redis instances left open on the internet are accessed and exploited.
+#
+# When protected mode is on and if:
+#
+# 1) The server is not binding explicitly to a set of addresses using the
+#    "bind" directive.
+# 2) No password is configured.
+#
+# The server only accepts connections from clients connecting from the
+# IPv4 and IPv6 loopback addresses 127.0.0.1 and ::1, and from Unix domain
+# sockets.
+#
+# By default protected mode is enabled. You should disable it only if
+# you are sure you want clients from other hosts to connect to Redis
+# even if no authentication is configured, nor a specific set of interfaces
+# are explicitly listed using the "bind" directive.
+protected-mode yes
+
+# Accept connections on the specified port, default is 6379 (IANA #815344).
+# If port 0 is specified Redis will not listen on a TCP socket.
+port 6379
+
+# TCP listen() backlog.
+#
+# In high requests-per-second environments you need an high backlog in order
+# to avoid slow clients connections issues. Note that the Linux kernel
+# will silently truncate it to the value of /proc/sys/net/core/somaxconn so
+# make sure to raise both the value of somaxconn and tcp_max_syn_backlog
+# in order to get the desired effect.
+tcp-backlog 511
+
+# Unix socket.
+#
+# Specify the path for the Unix socket that will be used to listen for
+# incoming connections. There is no default, so Redis will not listen
+# on a unix socket when not specified.
+#
+# unixsocket /tmp/redis.sock
+# unixsocketperm 700
+
+# Close the connection after a client is idle for N seconds (0 to disable)
+timeout 0
+
+# TCP keepalive.
+#
+# If non-zero, use SO_KEEPALIVE to send TCP ACKs to clients in absence
+# of communication. This is useful for two reasons:
+#
+# 1) Detect dead peers.
+# 2) Take the connection alive from the point of view of network
+#    equipment in the middle.
+#
+# On Linux, the specified value (in seconds) is the period used to send ACKs.
+# Note that to close the connection the double of the time is needed.
+# On other kernels the period depends on the kernel configuration.
+#
+# A reasonable value for this option is 300 seconds, which is the new
+# Redis default starting with Redis 3.2.1.
+tcp-keepalive 300
+
+################################# GENERAL #####################################
+
+# By default Redis does not run as a daemon. Use 'yes' if you need it.
+# Note that Redis will write a pid file in /var/run/redis.pid when daemonized.
+daemonize no
+
+# If you run Redis from upstart or systemd, Redis can interact with your
+# supervision tree. Options:
+#   supervised no      - no supervision interaction
+#   supervised upstart - signal upstart by putting Redis into SIGSTOP mode
+#   supervised systemd - signal systemd by writing READY=1 to $NOTIFY_SOCKET
+#   supervised auto    - detect upstart or systemd method based on
+#                        UPSTART_JOB or NOTIFY_SOCKET environment variables
+# Note: these supervision methods only signal "process is ready."
+#       They do not enable continuous liveness pings back to your supervisor.
+supervised no
+
+# If a pid file is specified, Redis writes it where specified at startup
+# and removes it at exit.
+#
+# When the server runs non daemonized, no pid file is created if none is
+# specified in the configuration. When the server is daemonized, the pid file
+# is used even if not specified, defaulting to "/var/run/redis.pid".
+#
+# Creating a pid file is best effort: if Redis is not able to create it
+# nothing bad happens, the server will start and run normally.
+pidfile ./temp/redis.pid
+
+# Specify the server verbosity level.
+# This can be one of:
+# debug (a lot of information, useful for development/testing)
+# verbose (many rarely useful info, but not a mess like the debug level)
+# notice (moderately verbose, what you want in production probably)
+# warning (only very important / critical messages are logged)
+loglevel notice
+
+# Specify the log file name. Also the empty string can be used to force
+# Redis to log on the standard output. Note that if you use standard
+# output for logging but daemonize, logs will be sent to /dev/null
+logfile ./log/redis.log
+
+# To enable logging to the system logger, just set 'syslog-enabled' to yes,
+# and optionally update the other syslog parameters to suit your needs.
+# syslog-enabled no
+
+# Specify the syslog identity.
+# syslog-ident redis
+
+# Specify the syslog facility. Must be USER or between LOCAL0-LOCAL7.
+# syslog-facility local0
+
+# Set the number of databases. The default database is DB 0, you can select
+# a different one on a per-connection basis using SELECT <dbid> where
+# dbid is a number between 0 and 'databases'-1
+databases 16
+
+# By default Redis shows an ASCII art logo only when started to log to the
+# standard output and if the standard output is a TTY. Basically this means
+# that normally a logo is displayed only in interactive sessions.
+#
+# However it is possible to force the pre-4.0 behavior and always show a
+# ASCII art logo in startup logs by setting the following option to yes.
+always-show-logo yes
+
+################################ SNAPSHOTTING  ################################
+#
+# Save the DB on disk:
+#
+#   save <seconds> <changes>
+#
+#   Will save the DB if both the given number of seconds and the given
+#   number of write operations against the DB occurred.
+#
+#   In the example below the behaviour will be to save:
+#   after 900 sec (15 min) if at least 1 key changed
+#   after 300 sec (5 min) if at least 10 keys changed
+#   after 60 sec if at least 10000 keys changed
+#
+#   Note: you can disable saving completely by commenting out all "save" lines.
+#
+#   It is also possible to remove all the previously configured save
+#   points by adding a save directive with a single empty string argument
+#   like in the following example:
+#
+#   save ""
+
+save 900 1
+save 60 500
+
+# By default Redis will stop accepting writes if RDB snapshots are enabled
+# (at least one save point) and the latest background save failed.
+# This will make the user aware (in a hard way) that data is not persisting
+# on disk properly, otherwise chances are that no one will notice and some
+# disaster will happen.
+#
+# If the background saving process will start working again Redis will
+# automatically allow writes again.
+#
+# However if you have setup your proper monitoring of the Redis server
+# and persistence, you may want to disable this feature so that Redis will
+# continue to work as usual even if there are problems with disk,
+# permissions, and so forth.
+stop-writes-on-bgsave-error yes
+
+# Compress string objects using LZF when dump .rdb databases?
+# For default that's set to 'yes' as it's almost always a win.
+# If you want to save some CPU in the saving child set it to 'no' but
+# the dataset will likely be bigger if you have compressible values or keys.
+rdbcompression yes
+
+# Since version 5 of RDB a CRC64 checksum is placed at the end of the file.
+# This makes the format more resistant to corruption but there is a performance
+# hit to pay (around 10%) when saving and loading RDB files, so you can disable it
+# for maximum performances.
+#
+# RDB files created with checksum disabled have a checksum of zero that will
+# tell the loading code to skip the check.
+rdbchecksum yes
+
+# The filename where to dump the DB
+dbfilename database.rdb
+
+# The working directory.
+#
+# The DB will be written inside this directory, with the filename specified
+# above using the 'dbfilename' configuration directive.
+#
+# The Append Only File will also be created inside this directory.
+#
+# Note that you must specify a directory here, not a file name.
+dir ./
+
+################################# REPLICATION #################################
+
+# Master-Replica replication. Use replicaof to make a Redis instance a copy of
+# another Redis server. A few things to understand ASAP about Redis replication.
+#
+#   +------------------+      +---------------+
+#   |      Master      | ---> |    Replica    |
+#   | (receive writes) |      |  (exact copy) |
+#   +------------------+      +---------------+
+#
+# 1) Redis replication is asynchronous, but you can configure a master to
+#    stop accepting writes if it appears to be not connected with at least
+#    a given number of replicas.
+# 2) Redis replicas are able to perform a partial resynchronization with the
+#    master if the replication link is lost for a relatively small amount of
+#    time. You may want to configure the replication backlog size (see the next
+#    sections of this file) with a sensible value depending on your needs.
+# 3) Replication is automatic and does not need user intervention. After a
+#    network partition replicas automatically try to reconnect to masters
+#    and resynchronize with them.
+#
+# replicaof <masterip> <masterport>
+
+# If the master is password protected (using the "requirepass" configuration
+# directive below) it is possible to tell the replica to authenticate before
+# starting the replication synchronization process, otherwise the master will
+# refuse the replica request.
+#
+# masterauth <master-password>
+
+# When a replica loses its connection with the master, or when the replication
+# is still in progress, the replica can act in two different ways:
+#
+# 1) if replica-serve-stale-data is set to 'yes' (the default) the replica will
+#    still reply to client requests, possibly with out of date data, or the
+#    data set may just be empty if this is the first synchronization.
+#
+# 2) if replica-serve-stale-data is set to 'no' the replica will reply with
+#    an error "SYNC with master in progress" to all the kind of commands
+#    but to INFO, replicaOF, AUTH, PING, SHUTDOWN, REPLCONF, ROLE, CONFIG,
+#    SUBSCRIBE, UNSUBSCRIBE, PSUBSCRIBE, PUNSUBSCRIBE, PUBLISH, PUBSUB,
+#    COMMAND, POST, HOST: and LATENCY.
+#
+replica-serve-stale-data yes
+
+# You can configure a replica instance to accept writes or not. Writing against
+# a replica instance may be useful to store some ephemeral data (because data
+# written on a replica will be easily deleted after resync with the master) but
+# may also cause problems if clients are writing to it because of a
+# misconfiguration.
+#
+# Since Redis 2.6 by default replicas are read-only.
+#
+# Note: read only replicas are not designed to be exposed to untrusted clients
+# on the internet. It's just a protection layer against misuse of the instance.
+# Still a read only replica exports by default all the administrative commands
+# such as CONFIG, DEBUG, and so forth. To a limited extent you can improve
+# security of read only replicas using 'rename-command' to shadow all the
+# administrative / dangerous commands.
+replica-read-only yes
+
+# Replication SYNC strategy: disk or socket.
+#
+# -------------------------------------------------------
+# WARNING: DISKLESS REPLICATION IS EXPERIMENTAL CURRENTLY
+# -------------------------------------------------------
+#
+# New replicas and reconnecting replicas that are not able to continue the replication
+# process just receiving differences, need to do what is called a "full
+# synchronization". An RDB file is transmitted from the master to the replicas.
+# The transmission can happen in two different ways:
+#
+# 1) Disk-backed: The Redis master creates a new process that writes the RDB
+#                 file on disk. Later the file is transferred by the parent
+#                 process to the replicas incrementally.
+# 2) Diskless: The Redis master creates a new process that directly writes the
+#              RDB file to replica sockets, without touching the disk at all.
+#
+# With disk-backed replication, while the RDB file is generated, more replicas
+# can be queued and served with the RDB file as soon as the current child producing
+# the RDB file finishes its work. With diskless replication instead once
+# the transfer starts, new replicas arriving will be queued and a new transfer
+# will start when the current one terminates.
+#
+# When diskless replication is used, the master waits a configurable amount of
+# time (in seconds) before starting the transfer in the hope that multiple replicas
+# will arrive and the transfer can be parallelized.
+#
+# With slow disks and fast (large bandwidth) networks, diskless replication
+# works better.
+repl-diskless-sync no
+
+# When diskless replication is enabled, it is possible to configure the delay
+# the server waits in order to spawn the child that transfers the RDB via socket
+# to the replicas.
+#
+# This is important since once the transfer starts, it is not possible to serve
+# new replicas arriving, that will be queued for the next RDB transfer, so the server
+# waits a delay in order to let more replicas arrive.
+#
+# The delay is specified in seconds, and by default is 5 seconds. To disable
+# it entirely just set it to 0 seconds and the transfer will start ASAP.
+repl-diskless-sync-delay 5
+
+# Replicas send PINGs to server in a predefined interval. It's possible to change
+# this interval with the repl_ping_replica_period option. The default value is 10
+# seconds.
+#
+# repl-ping-replica-period 10
+
+# The following option sets the replication timeout for:
+#
+# 1) Bulk transfer I/O during SYNC, from the point of view of replica.
+# 2) Master timeout from the point of view of replicas (data, pings).
+# 3) Replica timeout from the point of view of masters (REPLCONF ACK pings).
+#
+# It is important to make sure that this value is greater than the value
+# specified for repl-ping-replica-period otherwise a timeout will be detected
+# every time there is low traffic between the master and the replica.
+#
+# repl-timeout 60
+
+# Disable TCP_NODELAY on the replica socket after SYNC?
+#
+# If you select "yes" Redis will use a smaller number of TCP packets and
+# less bandwidth to send data to replicas. But this can add a delay for
+# the data to appear on the replica side, up to 40 milliseconds with
+# Linux kernels using a default configuration.
+#
+# If you select "no" the delay for data to appear on the replica side will
+# be reduced but more bandwidth will be used for replication.
+#
+# By default we optimize for low latency, but in very high traffic conditions
+# or when the master and replicas are many hops away, turning this to "yes" may
+# be a good idea.
+repl-disable-tcp-nodelay no
+
+# Set the replication backlog size. The backlog is a buffer that accumulates
+# replica data when replicas are disconnected for some time, so that when a replica
+# wants to reconnect again, often a full resync is not needed, but a partial
+# resync is enough, just passing the portion of data the replica missed while
+# disconnected.
+#
+# The bigger the replication backlog, the longer the time the replica can be
+# disconnected and later be able to perform a partial resynchronization.
+#
+# The backlog is only allocated once there is at least a replica connected.
+#
+# repl-backlog-size 1mb
+
+# After a master has no longer connected replicas for some time, the backlog
+# will be freed. The following option configures the amount of seconds that
+# need to elapse, starting from the time the last replica disconnected, for
+# the backlog buffer to be freed.
+#
+# Note that replicas never free the backlog for timeout, since they may be
+# promoted to masters later, and should be able to correctly "partially
+# resynchronize" with the replicas: hence they should always accumulate backlog.
+#
+# A value of 0 means to never release the backlog.
+#
+# repl-backlog-ttl 3600
+
+# The replica priority is an integer number published by Redis in the INFO output.
+# It is used by Redis Sentinel in order to select a replica to promote into a
+# master if the master is no longer working correctly.
+#
+# A replica with a low priority number is considered better for promotion, so
+# for instance if there are three replicas with priority 10, 100, 25 Sentinel will
+# pick the one with priority 10, that is the lowest.
+#
+# However a special priority of 0 marks the replica as not able to perform the
+# role of master, so a replica with priority of 0 will never be selected by
+# Redis Sentinel for promotion.
+#
+# By default the priority is 100.
+replica-priority 100
+
+# It is possible for a master to stop accepting writes if there are less than
+# N replicas connected, having a lag less or equal than M seconds.
+#
+# The N replicas need to be in "online" state.
+#
+# The lag in seconds, that must be <= the specified value, is calculated from
+# the last ping received from the replica, that is usually sent every second.
+#
+# This option does not GUARANTEE that N replicas will accept the write, but
+# will limit the window of exposure for lost writes in case not enough replicas
+# are available, to the specified number of seconds.
+#
+# For example to require at least 3 replicas with a lag <= 10 seconds use:
+#
+# min-replicas-to-write 3
+# min-replicas-max-lag 10
+#
+# Setting one or the other to 0 disables the feature.
+#
+# By default min-replicas-to-write is set to 0 (feature disabled) and
+# min-replicas-max-lag is set to 10.
+
+# A Redis master is able to list the address and port of the attached
+# replicas in different ways. For example the "INFO replication" section
+# offers this information, which is used, among other tools, by
+# Redis Sentinel in order to discover replica instances.
+# Another place where this info is available is in the output of the
+# "ROLE" command of a master.
+#
+# The listed IP and address normally reported by a replica is obtained
+# in the following way:
+#
+#   IP: The address is auto detected by checking the peer address
+#   of the socket used by the replica to connect with the master.
+#
+#   Port: The port is communicated by the replica during the replication
+#   handshake, and is normally the port that the replica is using to
+#   listen for connections.
+#
+# However when port forwarding or Network Address Translation (NAT) is
+# used, the replica may be actually reachable via different IP and port
+# pairs. The following two options can be used by a replica in order to
+# report to its master a specific set of IP and port, so that both INFO
+# and ROLE will report those values.
+#
+# There is no need to use both the options if you need to override just
+# the port or the IP address.
+#
+# replica-announce-ip 5.5.5.5
+# replica-announce-port 1234
+
+################################## SECURITY ###################################
+
+# Require clients to issue AUTH <PASSWORD> before processing any other
+# commands.  This might be useful in environments in which you do not trust
+# others with access to the host running redis-server.
+#
+# This should stay commented out for backward compatibility and because most
+# people do not need auth (e.g. they run their own servers).
+#
+# Warning: since Redis is pretty fast an outside user can try up to
+# 150k passwords per second against a good box. This means that you should
+# use a very strong password otherwise it will be very easy to break.
+#
+# requirepass foobared
+
+# Command renaming.
+#
+# It is possible to change the name of dangerous commands in a shared
+# environment. For instance the CONFIG command may be renamed into something
+# hard to guess so that it will still be available for internal-use tools
+# but not available for general clients.
+#
+# Example:
+#
+# rename-command CONFIG b840fc02d524045429941cc15f59e41cb7be6c52
+#
+# It is also possible to completely kill a command by renaming it into
+# an empty string:
+#
+# rename-command CONFIG ""
+#
+# Please note that changing the name of commands that are logged into the
+# AOF file or transmitted to replicas may cause problems.
+
+################################### CLIENTS ####################################
+
+# Set the max number of connected clients at the same time. By default
+# this limit is set to 10000 clients, however if the Redis server is not
+# able to configure the process file limit to allow for the specified limit
+# the max number of allowed clients is set to the current file limit
+# minus 32 (as Redis reserves a few file descriptors for internal uses).
+#
+# Once the limit is reached Redis will close all the new connections sending
+# an error 'max number of clients reached'.
+#
+# maxclients 10000
+
+############################## MEMORY MANAGEMENT ################################
+
+# Set a memory usage limit to the specified amount of bytes.
+# When the memory limit is reached Redis will try to remove keys
+# according to the eviction policy selected (see maxmemory-policy).
+#
+# If Redis can't remove keys according to the policy, or if the policy is
+# set to 'noeviction', Redis will start to reply with errors to commands
+# that would use more memory, like SET, LPUSH, and so on, and will continue
+# to reply to read-only commands like GET.
+#
+# This option is usually useful when using Redis as an LRU or LFU cache, or to
+# set a hard memory limit for an instance (using the 'noeviction' policy).
+#
+# WARNING: If you have replicas attached to an instance with maxmemory on,
+# the size of the output buffers needed to feed the replicas are subtracted
+# from the used memory count, so that network problems / resyncs will
+# not trigger a loop where keys are evicted, and in turn the output
+# buffer of replicas is full with DELs of keys evicted triggering the deletion
+# of more keys, and so forth until the database is completely emptied.
+#
+# In short... if you have replicas attached it is suggested that you set a lower
+# limit for maxmemory so that there is some free RAM on the system for replica
+# output buffers (but this is not needed if the policy is 'noeviction').
+#
+# maxmemory <bytes>
+
+# MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
+# is reached. You can select among five behaviors:
+#
+# volatile-lru -> Evict using approximated LRU among the keys with an expire set.
+# allkeys-lru -> Evict any key using approximated LRU.
+# volatile-lfu -> Evict using approximated LFU among the keys with an expire set.
+# allkeys-lfu -> Evict any key using approximated LFU.
+# volatile-random -> Remove a random key among the ones with an expire set.
+# allkeys-random -> Remove a random key, any key.
+# volatile-ttl -> Remove the key with the nearest expire time (minor TTL)
+# noeviction -> Don't evict anything, just return an error on write operations.
+#
+# LRU means Least Recently Used
+# LFU means Least Frequently Used
+#
+# Both LRU, LFU and volatile-ttl are implemented using approximated
+# randomized algorithms.
+#
+# Note: with any of the above policies, Redis will return an error on write
+#       operations, when there are no suitable keys for eviction.
+#
+#       At the date of writing these commands are: set setnx setex append
+#       incr decr rpush lpush rpushx lpushx linsert lset rpoplpush sadd
+#       sinter sinterstore sunion sunionstore sdiff sdiffstore zadd zincrby
+#       zunionstore zinterstore hset hsetnx hmset hincrby incrby decrby
+#       getset mset msetnx exec sort
+#
+# The default is:
+#
+# maxmemory-policy noeviction
+
+# LRU, LFU and minimal TTL algorithms are not precise algorithms but approximated
+# algorithms (in order to save memory), so you can tune it for speed or
+# accuracy. For default Redis will check five keys and pick the one that was
+# used less recently, you can change the sample size using the following
+# configuration directive.
+#
+# The default of 5 produces good enough results. 10 Approximates very closely
+# true LRU but costs more CPU. 3 is faster but not very accurate.
+#
+# maxmemory-samples 5
+
+# Starting from Redis 5, by default a replica will ignore its maxmemory setting
+# (unless it is promoted to master after a failover or manually). It means
+# that the eviction of keys will be just handled by the master, sending the
+# DEL commands to the replica as keys evict in the master side.
+#
+# This behavior ensures that masters and replicas stay consistent, and is usually
+# what you want, however if your replica is writable, or you want the replica to have
+# a different memory setting, and you are sure all the writes performed to the
+# replica are idempotent, then you may change this default (but be sure to understand
+# what you are doing).
+#
+# Note that since the replica by default does not evict, it may end using more
+# memory than the one set via maxmemory (there are certain buffers that may
+# be larger on the replica, or data structures may sometimes take more memory and so
+# forth). So make sure you monitor your replicas and make sure they have enough
+# memory to never hit a real out-of-memory condition before the master hits
+# the configured maxmemory setting.
+#
+# replica-ignore-maxmemory yes
+
+############################# LAZY FREEING ####################################
+
+# Redis has two primitives to delete keys. One is called DEL and is a blocking
+# deletion of the object. It means that the server stops processing new commands
+# in order to reclaim all the memory associated with an object in a synchronous
+# way. If the key deleted is associated with a small object, the time needed
+# in order to execute the DEL command is very small and comparable to most other
+# O(1) or O(log_N) commands in Redis. However if the key is associated with an
+# aggregated value containing millions of elements, the server can block for
+# a long time (even seconds) in order to complete the operation.
+#
+# For the above reasons Redis also offers non blocking deletion primitives
+# such as UNLINK (non blocking DEL) and the ASYNC option of FLUSHALL and
+# FLUSHDB commands, in order to reclaim memory in background. Those commands
+# are executed in constant time. Another thread will incrementally free the
+# object in the background as fast as possible.
+#
+# DEL, UNLINK and ASYNC option of FLUSHALL and FLUSHDB are user-controlled.
+# It's up to the design of the application to understand when it is a good
+# idea to use one or the other. However the Redis server sometimes has to
+# delete keys or flush the whole database as a side effect of other operations.
+# Specifically Redis deletes objects independently of a user call in the
+# following scenarios:
+#
+# 1) On eviction, because of the maxmemory and maxmemory policy configurations,
+#    in order to make room for new data, without going over the specified
+#    memory limit.
+# 2) Because of expire: when a key with an associated time to live (see the
+#    EXPIRE command) must be deleted from memory.
+# 3) Because of a side effect of a command that stores data on a key that may
+#    already exist. For example the RENAME command may delete the old key
+#    content when it is replaced with another one. Similarly SUNIONSTORE
+#    or SORT with STORE option may delete existing keys. The SET command
+#    itself removes any old content of the specified key in order to replace
+#    it with the specified string.
+# 4) During replication, when a replica performs a full resynchronization with
+#    its master, the content of the whole database is removed in order to
+#    load the RDB file just transferred.
+#
+# In all the above cases the default is to delete objects in a blocking way,
+# like if DEL was called. However you can configure each case specifically
+# in order to instead release memory in a non-blocking way like if UNLINK
+# was called, using the following configuration directives:
+
+lazyfree-lazy-eviction no
+lazyfree-lazy-expire no
+lazyfree-lazy-server-del no
+replica-lazy-flush no
+
+############################## APPEND ONLY MODE ###############################
+
+# By default Redis asynchronously dumps the dataset on disk. This mode is
+# good enough in many applications, but an issue with the Redis process or
+# a power outage may result into a few minutes of writes lost (depending on
+# the configured save points).
+#
+# The Append Only File is an alternative persistence mode that provides
+# much better durability. For instance using the default data fsync policy
+# (see later in the config file) Redis can lose just one second of writes in a
+# dramatic event like a server power outage, or a single write if something
+# wrong with the Redis process itself happens, but the operating system is
+# still running correctly.
+#
+# AOF and RDB persistence can be enabled at the same time without problems.
+# If the AOF is enabled on startup Redis will load the AOF, that is the file
+# with the better durability guarantees.
+#
+# Please check http://redis.io/topics/persistence for more information.
+
+appendonly yes
+
+# The name of the append only file (default: "appendonly.aof")
+
+appendfilename "appendonly.aof"
+
+# The fsync() call tells the Operating System to actually write data on disk
+# instead of waiting for more data in the output buffer. Some OS will really flush
+# data on disk, some other OS will just try to do it ASAP.
+#
+# Redis supports three different modes:
+#
+# no: don't fsync, just let the OS flush the data when it wants. Faster.
+# always: fsync after every write to the append only log. Slow, Safest.
+# everysec: fsync only one time every second. Compromise.
+#
+# The default is "everysec", as that's usually the right compromise between
+# speed and data safety. It's up to you to understand if you can relax this to
+# "no" that will let the operating system flush the output buffer when
+# it wants, for better performances (but if you can live with the idea of
+# some data loss consider the default persistence mode that's snapshotting),
+# or on the contrary, use "always" that's very slow but a bit safer than
+# everysec.
+#
+# More details please check the following article:
+# http://antirez.com/post/redis-persistence-demystified.html
+#
+# If unsure, use "everysec".
+
+# appendfsync always
+appendfsync everysec
+# appendfsync no
+
+# When the AOF fsync policy is set to always or everysec, and a background
+# saving process (a background save or AOF log background rewriting) is
+# performing a lot of I/O against the disk, in some Linux configurations
+# Redis may block too long on the fsync() call. Note that there is no fix for
+# this currently, as even performing fsync in a different thread will block
+# our synchronous write(2) call.
+#
+# In order to mitigate this problem it's possible to use the following option
+# that will prevent fsync() from being called in the main process while a
+# BGSAVE or BGREWRITEAOF is in progress.
+#
+# This means that while another child is saving, the durability of Redis is
+# the same as "appendfsync none". In practical terms, this means that it is
+# possible to lose up to 30 seconds of log in the worst scenario (with the
+# default Linux settings).
+#
+# If you have latency problems turn this to "yes". Otherwise leave it as
+# "no" that is the safest pick from the point of view of durability.
+
+no-appendfsync-on-rewrite no
+
+# Automatic rewrite of the append only file.
+# Redis is able to automatically rewrite the log file implicitly calling
+# BGREWRITEAOF when the AOF log size grows by the specified percentage.
+#
+# This is how it works: Redis remembers the size of the AOF file after the
+# latest rewrite (if no rewrite has happened since the restart, the size of
+# the AOF at startup is used).
+#
+# This base size is compared to the current size. If the current size is
+# bigger than the specified percentage, the rewrite is triggered. Also
+# you need to specify a minimal size for the AOF file to be rewritten, this
+# is useful to avoid rewriting the AOF file even if the percentage increase
+# is reached but it is still pretty small.
+#
+# Specify a percentage of zero in order to disable the automatic AOF
+# rewrite feature.
+
+auto-aof-rewrite-percentage 100
+auto-aof-rewrite-min-size 64mb
+
+# An AOF file may be found to be truncated at the end during the Redis
+# startup process, when the AOF data gets loaded back into memory.
+# This may happen when the system where Redis is running
+# crashes, especially when an ext4 filesystem is mounted without the
+# data=ordered option (however this can't happen when Redis itself
+# crashes or aborts but the operating system still works correctly).
+#
+# Redis can either exit with an error when this happens, or load as much
+# data as possible (the default now) and start if the AOF file is found
+# to be truncated at the end. The following option controls this behavior.
+#
+# If aof-load-truncated is set to yes, a truncated AOF file is loaded and
+# the Redis server starts emitting a log to inform the user of the event.
+# Otherwise if the option is set to no, the server aborts with an error
+# and refuses to start. When the option is set to no, the user requires
+# to fix the AOF file using the "redis-check-aof" utility before to restart
+# the server.
+#
+# Note that if the AOF file will be found to be corrupted in the middle
+# the server will still exit with an error. This option only applies when
+# Redis will try to read more data from the AOF file but not enough bytes
+# will be found.
+aof-load-truncated yes
+
+# When rewriting the AOF file, Redis is able to use an RDB preamble in the
+# AOF file for faster rewrites and recoveries. When this option is turned
+# on the rewritten AOF file is composed of two different stanzas:
+#
+#   [RDB file][AOF tail]
+#
+# When loading Redis recognizes that the AOF file starts with the "REDIS"
+# string and loads the prefixed RDB file, and continues loading the AOF
+# tail.
+aof-use-rdb-preamble yes
+
+################################ LUA SCRIPTING  ###############################
+
+# Max execution time of a Lua script in milliseconds.
+#
+# If the maximum execution time is reached Redis will log that a script is
+# still in execution after the maximum allowed time and will start to
+# reply to queries with an error.
+#
+# When a long running script exceeds the maximum execution time only the
+# SCRIPT KILL and SHUTDOWN NOSAVE commands are available. The first can be
+# used to stop a script that did not yet called write commands. The second
+# is the only way to shut down the server in the case a write command was
+# already issued by the script but the user doesn't want to wait for the natural
+# termination of the script.
+#
+# Set it to 0 or a negative value for unlimited execution without warnings.
+lua-time-limit 5000
+
+################################ REDIS CLUSTER  ###############################
+
+# Normal Redis instances can't be part of a Redis Cluster; only nodes that are
+# started as cluster nodes can. In order to start a Redis instance as a
+# cluster node enable the cluster support uncommenting the following:
+#
+# cluster-enabled yes
+
+# Every cluster node has a cluster configuration file. This file is not
+# intended to be edited by hand. It is created and updated by Redis nodes.
+# Every Redis Cluster node requires a different cluster configuration file.
+# Make sure that instances running in the same system do not have
+# overlapping cluster configuration file names.
+#
+# cluster-config-file nodes-6379.conf
+
+# Cluster node timeout is the amount of milliseconds a node must be unreachable
+# for it to be considered in failure state.
+# Most other internal time limits are multiple of the node timeout.
+#
+# cluster-node-timeout 15000
+
+# A replica of a failing master will avoid to start a failover if its data
+# looks too old.
+#
+# There is no simple way for a replica to actually have an exact measure of
+# its "data age", so the following two checks are performed:
+#
+# 1) If there are multiple replicas able to failover, they exchange messages
+#    in order to try to give an advantage to the replica with the best
+#    replication offset (more data from the master processed).
+#    Replicas will try to get their rank by offset, and apply to the start
+#    of the failover a delay proportional to their rank.
+#
+# 2) Every single replica computes the time of the last interaction with
+#    its master. This can be the last ping or command received (if the master
+#    is still in the "connected" state), or the time that elapsed since the
+#    disconnection with the master (if the replication link is currently down).
+#    If the last interaction is too old, the replica will not try to failover
+#    at all.
+#
+# The point "2" can be tuned by user. Specifically a replica will not perform
+# the failover if, since the last interaction with the master, the time
+# elapsed is greater than:
+#
+#   (node-timeout * replica-validity-factor) + repl-ping-replica-period
+#
+# So for example if node-timeout is 30 seconds, and the replica-validity-factor
+# is 10, and assuming a default repl-ping-replica-period of 10 seconds, the
+# replica will not try to failover if it was not able to talk with the master
+# for longer than 310 seconds.
+#
+# A large replica-validity-factor may allow replicas with too old data to failover
+# a master, while a too small value may prevent the cluster from being able to
+# elect a replica at all.
+#
+# For maximum availability, it is possible to set the replica-validity-factor
+# to a value of 0, which means, that replicas will always try to failover the
+# master regardless of the last time they interacted with the master.
+# (However they'll always try to apply a delay proportional to their
+# offset rank).
+#
+# Zero is the only value able to guarantee that when all the partitions heal
+# the cluster will always be able to continue.
+#
+# cluster-replica-validity-factor 10
+
+# Cluster replicas are able to migrate to orphaned masters, that are masters
+# that are left without working replicas. This improves the cluster ability
+# to resist to failures as otherwise an orphaned master can't be failed over
+# in case of failure if it has no working replicas.
+#
+# Replicas migrate to orphaned masters only if there are still at least a
+# given number of other working replicas for their old master. This number
+# is the "migration barrier". A migration barrier of 1 means that a replica
+# will migrate only if there is at least 1 other working replica for its master
+# and so forth. It usually reflects the number of replicas you want for every
+# master in your cluster.
+#
+# Default is 1 (replicas migrate only if their masters remain with at least
+# one replica). To disable migration just set it to a very large value.
+# A value of 0 can be set but is useful only for debugging and dangerous
+# in production.
+#
+# cluster-migration-barrier 1
+
+# By default Redis Cluster nodes stop accepting queries if they detect there
+# is at least an hash slot uncovered (no available node is serving it).
+# This way if the cluster is partially down (for example a range of hash slots
+# are no longer covered) all the cluster becomes, eventually, unavailable.
+# It automatically returns available as soon as all the slots are covered again.
+#
+# However sometimes you want the subset of the cluster which is working,
+# to continue to accept queries for the part of the key space that is still
+# covered. In order to do so, just set the cluster-require-full-coverage
+# option to no.
+#
+# cluster-require-full-coverage yes
+
+# This option, when set to yes, prevents replicas from trying to failover its
+# master during master failures. However the master can still perform a
+# manual failover, if forced to do so.
+#
+# This is useful in different scenarios, especially in the case of multiple
+# data center operations, where we want one side to never be promoted if not
+# in the case of a total DC failure.
+#
+# cluster-replica-no-failover no
+
+# In order to setup your cluster make sure to read the documentation
+# available at http://redis.io web site.
+
+########################## CLUSTER DOCKER/NAT support  ########################
+
+# In certain deployments, Redis Cluster nodes address discovery fails, because
+# addresses are NAT-ted or because ports are forwarded (the typical case is
+# Docker and other containers).
+#
+# In order to make Redis Cluster working in such environments, a static
+# configuration where each node knows its public address is needed. The
+# following two options are used for this scope, and are:
+#
+# * cluster-announce-ip
+# * cluster-announce-port
+# * cluster-announce-bus-port
+#
+# Each instruct the node about its address, client port, and cluster message
+# bus port. The information is then published in the header of the bus packets
+# so that other nodes will be able to correctly map the address of the node
+# publishing the information.
+#
+# If the above options are not used, the normal Redis Cluster auto-detection
+# will be used instead.
+#
+# Note that when remapped, the bus port may not be at the fixed offset of
+# clients port + 10000, so you can specify any port and bus-port depending
+# on how they get remapped. If the bus-port is not set, a fixed offset of
+# 10000 will be used as usually.
+#
+# Example:
+#
+# cluster-announce-ip 10.1.1.5
+# cluster-announce-port 6379
+# cluster-announce-bus-port 6380
+
+################################## SLOW LOG ###################################
+
+# The Redis Slow Log is a system to log queries that exceeded a specified
+# execution time. The execution time does not include the I/O operations
+# like talking with the client, sending the reply and so forth,
+# but just the time needed to actually execute the command (this is the only
+# stage of command execution where the thread is blocked and can not serve
+# other requests in the meantime).
+#
+# You can configure the slow log with two parameters: one tells Redis
+# what is the execution time, in microseconds, to exceed in order for the
+# command to get logged, and the other parameter is the length of the
+# slow log. When a new command is logged the oldest one is removed from the
+# queue of logged commands.
+
+# The following time is expressed in microseconds, so 1000000 is equivalent
+# to one second. Note that a negative number disables the slow log, while
+# a value of zero forces the logging of every command.
+slowlog-log-slower-than 10000
+
+# There is no limit to this length. Just be aware that it will consume memory.
+# You can reclaim memory used by the slow log with SLOWLOG RESET.
+slowlog-max-len 128
+
+################################ LATENCY MONITOR ##############################
+
+# The Redis latency monitoring subsystem samples different operations
+# at runtime in order to collect data related to possible sources of
+# latency of a Redis instance.
+#
+# Via the LATENCY command this information is available to the user that can
+# print graphs and obtain reports.
+#
+# The system only logs operations that were performed in a time equal or
+# greater than the amount of milliseconds specified via the
+# latency-monitor-threshold configuration directive. When its value is set
+# to zero, the latency monitor is turned off.
+#
+# By default latency monitoring is disabled since it is mostly not needed
+# if you don't have latency issues, and collecting data has a performance
+# impact, that while very small, can be measured under big load. Latency
+# monitoring can easily be enabled at runtime using the command
+# "CONFIG SET latency-monitor-threshold <milliseconds>" if needed.
+latency-monitor-threshold 0
+
+############################# EVENT NOTIFICATION ##############################
+
+# Redis can notify Pub/Sub clients about events happening in the key space.
+# This feature is documented at http://redis.io/topics/notifications
+#
+# For instance if keyspace events notification is enabled, and a client
+# performs a DEL operation on key "foo" stored in the Database 0, two
+# messages will be published via Pub/Sub:
+#
+# PUBLISH __keyspace@0__:foo del
+# PUBLISH __keyevent@0__:del foo
+#
+# It is possible to select the events that Redis will notify among a set
+# of classes. Every class is identified by a single character:
+#
+#  K     Keyspace events, published with __keyspace@<db>__ prefix.
+#  E     Keyevent events, published with __keyevent@<db>__ prefix.
+#  g     Generic commands (non-type specific) like DEL, EXPIRE, RENAME, ...
+#  $     String commands
+#  l     List commands
+#  s     Set commands
+#  h     Hash commands
+#  z     Sorted set commands
+#  x     Expired events (events generated every time a key expires)
+#  e     Evicted events (events generated when a key is evicted for maxmemory)
+#  A     Alias for g$lshzxe, so that the "AKE" string means all the events.
+#
+#  The "notify-keyspace-events" takes as argument a string that is composed
+#  of zero or multiple characters. The empty string means that notifications
+#  are disabled.
+#
+#  Example: to enable list and generic events, from the point of view of the
+#           event name, use:
+#
+#  notify-keyspace-events Elg
+#
+#  Example 2: to get the stream of the expired keys subscribing to channel
+#             name __keyevent@0__:expired use:
+#
+#  notify-keyspace-events Ex
+#
+#  By default all notifications are disabled because most users don't need
+#  this feature and the feature has some overhead. Note that if you don't
+#  specify at least one of K or E, no events will be delivered.
+notify-keyspace-events ""
+
+############################### ADVANCED CONFIG ###############################
+
+# Hashes are encoded using a memory efficient data structure when they have a
+# small number of entries, and the biggest entry does not exceed a given
+# threshold. These thresholds can be configured using the following directives.
+hash-max-ziplist-entries 512
+hash-max-ziplist-value 64
+
+# Lists are also encoded in a special way to save a lot of space.
+# The number of entries allowed per internal list node can be specified
+# as a fixed maximum size or a maximum number of elements.
+# For a fixed maximum size, use -5 through -1, meaning:
+# -5: max size: 64 Kb  <-- not recommended for normal workloads
+# -4: max size: 32 Kb  <-- not recommended
+# -3: max size: 16 Kb  <-- probably not recommended
+# -2: max size: 8 Kb   <-- good
+# -1: max size: 4 Kb   <-- good
+# Positive numbers mean store up to _exactly_ that number of elements
+# per list node.
+# The highest performing option is usually -2 (8 Kb size) or -1 (4 Kb size),
+# but if your use case is unique, adjust the settings as necessary.
+list-max-ziplist-size -2
+
+# Lists may also be compressed.
+# Compress depth is the number of quicklist ziplist nodes from *each* side of
+# the list to *exclude* from compression.  The head and tail of the list
+# are always uncompressed for fast push/pop operations.  Settings are:
+# 0: disable all list compression
+# 1: depth 1 means "don't start compressing until after 1 node into the list,
+#    going from either the head or tail"
+#    So: [head]->node->node->...->node->[tail]
+#    [head], [tail] will always be uncompressed; inner nodes will compress.
+# 2: [head]->[next]->node->node->...->node->[prev]->[tail]
+#    2 here means: don't compress head or head->next or tail->prev or tail,
+#    but compress all nodes between them.
+# 3: [head]->[next]->[next]->node->node->...->node->[prev]->[prev]->[tail]
+# etc.
+list-compress-depth 0
+
+# Sets have a special encoding in just one case: when a set is composed
+# of just strings that happen to be integers in radix 10 in the range
+# of 64 bit signed integers.
+# The following configuration setting sets the limit in the size of the
+# set in order to use this special memory saving encoding.
+set-max-intset-entries 512
+
+# Similarly to hashes and lists, sorted sets are also specially encoded in
+# order to save a lot of space. This encoding is only used when the length and
+# elements of a sorted set are below the following limits:
+zset-max-ziplist-entries 128
+zset-max-ziplist-value 64
+
+# HyperLogLog sparse representation bytes limit. The limit includes the
+# 16 bytes header. When an HyperLogLog using the sparse representation crosses
+# this limit, it is converted into the dense representation.
+#
+# A value greater than 16000 is totally useless, since at that point the
+# dense representation is more memory efficient.
+#
+# The suggested value is ~ 3000 in order to have the benefits of
+# the space efficient encoding without slowing down too much PFADD,
+# which is O(N) with the sparse encoding. The value can be raised to
+# ~ 10000 when CPU is not a concern, but space is, and the data set is
+# composed of many HyperLogLogs with cardinality in the 0 - 15000 range.
+hll-sparse-max-bytes 3000
+
+# Streams macro node max size / items. The stream data structure is a radix
+# tree of big nodes that encode multiple items inside. Using this configuration
+# it is possible to configure how big a single node can be in bytes, and the
+# maximum number of items it may contain before switching to a new node when
+# appending new stream entries. If any of the following settings are set to
+# zero, the limit is ignored, so for instance it is possible to set just a
+# max entires limit by setting max-bytes to 0 and max-entries to the desired
+# value.
+stream-node-max-bytes 4096
+stream-node-max-entries 100
+
+# Active rehashing uses 1 millisecond every 100 milliseconds of CPU time in
+# order to help rehashing the main Redis hash table (the one mapping top-level
+# keys to values). The hash table implementation Redis uses (see dict.c)
+# performs a lazy rehashing: the more operation you run into a hash table
+# that is rehashing, the more rehashing "steps" are performed, so if the
+# server is idle the rehashing is never complete and some more memory is used
+# by the hash table.
+#
+# The default is to use this millisecond 10 times every second in order to
+# actively rehash the main dictionaries, freeing memory when possible.
+#
+# If unsure:
+# use "activerehashing no" if you have hard latency requirements and it is
+# not a good thing in your environment that Redis can reply from time to time
+# to queries with 2 milliseconds delay.
+#
+# use "activerehashing yes" if you don't have such hard requirements but
+# want to free memory asap when possible.
+activerehashing yes
+
+# The client output buffer limits can be used to force disconnection of clients
+# that are not reading data from the server fast enough for some reason (a
+# common reason is that a Pub/Sub client can't consume messages as fast as the
+# publisher can produce them).
+#
+# The limit can be set differently for the three different classes of clients:
+#
+# normal -> normal clients including MONITOR clients
+# replica  -> replica clients
+# pubsub -> clients subscribed to at least one pubsub channel or pattern
+#
+# The syntax of every client-output-buffer-limit directive is the following:
+#
+# client-output-buffer-limit <class> <hard limit> <soft limit> <soft seconds>
+#
+# A client is immediately disconnected once the hard limit is reached, or if
+# the soft limit is reached and remains reached for the specified number of
+# seconds (continuously).
+# So for instance if the hard limit is 32 megabytes and the soft limit is
+# 16 megabytes / 10 seconds, the client will get disconnected immediately
+# if the size of the output buffers reach 32 megabytes, but will also get
+# disconnected if the client reaches 16 megabytes and continuously overcomes
+# the limit for 10 seconds.
+#
+# By default normal clients are not limited because they don't receive data
+# without asking (in a push way), but just after a request, so only
+# asynchronous clients may create a scenario where data is requested faster
+# than it can read.
+#
+# Instead there is a default limit for pubsub and replica clients, since
+# subscribers and replicas receive data in a push fashion.
+#
+# Both the hard or the soft limit can be disabled by setting them to zero.
+client-output-buffer-limit normal 0 0 0
+client-output-buffer-limit replica 256mb 64mb 60
+client-output-buffer-limit pubsub 32mb 8mb 60
+
+# Client query buffers accumulate new commands. They are limited to a fixed
+# amount by default in order to avoid that a protocol desynchronization (for
+# instance due to a bug in the client) will lead to unbound memory usage in
+# the query buffer. However you can configure it here if you have very special
+# needs, such us huge multi/exec requests or alike.
+#
+# client-query-buffer-limit 1gb
+
+# In the Redis protocol, bulk requests, that are, elements representing single
+# strings, are normally limited ot 512 mb. However you can change this limit
+# here.
+#
+# proto-max-bulk-len 512mb
+
+# Redis calls an internal function to perform many background tasks, like
+# closing connections of clients in timeout, purging expired keys that are
+# never requested, and so forth.
+#
+# Not all tasks are performed with the same frequency, but Redis checks for
+# tasks to perform according to the specified "hz" value.
+#
+# By default "hz" is set to 10. Raising the value will use more CPU when
+# Redis is idle, but at the same time will make Redis more responsive when
+# there are many keys expiring at the same time, and timeouts may be
+# handled with more precision.
+#
+# The range is between 1 and 500, however a value over 100 is usually not
+# a good idea. Most users should use the default of 10 and raise this up to
+# 100 only in environments where very low latency is required.
+hz 10
+
+# Normally it is useful to have an HZ value which is proportional to the
+# number of clients connected. This is useful in order, for instance, to
+# avoid too many clients are processed for each background task invocation
+# in order to avoid latency spikes.
+#
+# Since the default HZ value by default is conservatively set to 10, Redis
+# offers, and enables by default, the ability to use an adaptive HZ value
+# which will temporary raise when there are many connected clients.
+#
+# When dynamic HZ is enabled, the actual configured HZ will be used as
+# as a baseline, but multiples of the configured HZ value will be actually
+# used as needed once more clients are connected. In this way an idle
+# instance will use very little CPU time while a busy instance will be
+# more responsive.
+dynamic-hz yes
+
+# When a child rewrites the AOF file, if the following option is enabled
+# the file will be fsync-ed every 32 MB of data generated. This is useful
+# in order to commit the file to the disk more incrementally and avoid
+# big latency spikes.
+aof-rewrite-incremental-fsync yes
+
+# When redis saves RDB file, if the following option is enabled
+# the file will be fsync-ed every 32 MB of data generated. This is useful
+# in order to commit the file to the disk more incrementally and avoid
+# big latency spikes.
+rdb-save-incremental-fsync yes
+
+# Redis LFU eviction (see maxmemory setting) can be tuned. However it is a good
+# idea to start with the default settings and only change them after investigating
+# how to improve the performances and how the keys LFU change over time, which
+# is possible to inspect via the OBJECT FREQ command.
+#
+# There are two tunable parameters in the Redis LFU implementation: the
+# counter logarithm factor and the counter decay time. It is important to
+# understand what the two parameters mean before changing them.
+#
+# The LFU counter is just 8 bits per key, it's maximum value is 255, so Redis
+# uses a probabilistic increment with logarithmic behavior. Given the value
+# of the old counter, when a key is accessed, the counter is incremented in
+# this way:
+#
+# 1. A random number R between 0 and 1 is extracted.
+# 2. A probability P is calculated as 1/(old_value*lfu_log_factor+1).
+# 3. The counter is incremented only if R < P.
+#
+# The default lfu-log-factor is 10. This is a table of how the frequency
+# counter changes with a different number of accesses with different
+# logarithmic factors:
+#
+# +--------+------------+------------+------------+------------+------------+
+# | factor | 100 hits   | 1000 hits  | 100K hits  | 1M hits    | 10M hits   |
+# +--------+------------+------------+------------+------------+------------+
+# | 0      | 104        | 255        | 255        | 255        | 255        |
+# +--------+------------+------------+------------+------------+------------+
+# | 1      | 18         | 49         | 255        | 255        | 255        |
+# +--------+------------+------------+------------+------------+------------+
+# | 10     | 10         | 18         | 142        | 255        | 255        |
+# +--------+------------+------------+------------+------------+------------+
+# | 100    | 8          | 11         | 49         | 143        | 255        |
+# +--------+------------+------------+------------+------------+------------+
+#
+# NOTE: The above table was obtained by running the following commands:
+#
+#   redis-benchmark -n 1000000 incr foo
+#   redis-cli object freq foo
+#
+# NOTE 2: The counter initial value is 5 in order to give new objects a chance
+# to accumulate hits.
+#
+# The counter decay time is the time, in minutes, that must elapse in order
+# for the key counter to be divided by two (or decremented if it has a value
+# less <= 10).
+#
+# The default value for the lfu-decay-time is 1. A Special value of 0 means to
+# decay the counter every time it happens to be scanned.
+#
+# lfu-log-factor 10
+# lfu-decay-time 1
+
+########################### ACTIVE DEFRAGMENTATION #######################
+#
+# WARNING THIS FEATURE IS EXPERIMENTAL. However it was stress tested
+# even in production and manually tested by multiple engineers for some
+# time.
+#
+# What is active defragmentation?
+# -------------------------------
+#
+# Active (online) defragmentation allows a Redis server to compact the
+# spaces left between small allocations and deallocations of data in memory,
+# thus allowing to reclaim back memory.
+#
+# Fragmentation is a natural process that happens with every allocator (but
+# less so with Jemalloc, fortunately) and certain workloads. Normally a server
+# restart is needed in order to lower the fragmentation, or at least to flush
+# away all the data and create it again. However thanks to this feature
+# implemented by Oran Agra for Redis 4.0 this process can happen at runtime
+# in an "hot" way, while the server is running.
+#
+# Basically when the fragmentation is over a certain level (see the
+# configuration options below) Redis will start to create new copies of the
+# values in contiguous memory regions by exploiting certain specific Jemalloc
+# features (in order to understand if an allocation is causing fragmentation
+# and to allocate it in a better place), and at the same time, will release the
+# old copies of the data. This process, repeated incrementally for all the keys
+# will cause the fragmentation to drop back to normal values.
+#
+# Important things to understand:
+#
+# 1. This feature is disabled by default, and only works if you compiled Redis
+#    to use the copy of Jemalloc we ship with the source code of Redis.
+#    This is the default with Linux builds.
+#
+# 2. You never need to enable this feature if you don't have fragmentation
+#    issues.
+#
+# 3. Once you experience fragmentation, you can enable this feature when
+#    needed with the command "CONFIG SET activedefrag yes".
+#
+# The configuration parameters are able to fine tune the behavior of the
+# defragmentation process. If you are not sure about what they mean it is
+# a good idea to leave the defaults untouched.
+
+# Enabled active defragmentation
+# activedefrag yes
+
+# Minimum amount of fragmentation waste to start active defrag
+# active-defrag-ignore-bytes 100mb
+
+# Minimum percentage of fragmentation to start active defrag
+# active-defrag-threshold-lower 10
+
+# Maximum percentage of fragmentation at which we use maximum effort
+# active-defrag-threshold-upper 100
+
+# Minimal effort for defrag in CPU percentage
+# active-defrag-cycle-min 5
+
+# Maximal effort for defrag in CPU percentage
+# active-defrag-cycle-max 75
+
+# Maximum number of set/hash/zset/list fields that will be processed from
+# the main dictionary scan
+# active-defrag-max-scan-fields 1000

--- a/tools/build/msys2/run.ps1
+++ b/tools/build/msys2/run.ps1
@@ -24,7 +24,10 @@ $Env:Path = "$PWD\runtime\bin;$PWD\runtime\redis;$($Env:Path)"
 [System.IO.Directory]::CreateDirectory("$PWD\log") | Out-Null
 [System.IO.Directory]::CreateDirectory("$PWD\temp") | Out-Null
 
-Start-Process -FilePath "redis-server" -ArgumentList "--pidfile", "$PWD\temp\redis.pid", "--dir", "$Database", "--logfile", "$PWD\log\redis.log"
+# redis on windows has broken absolute paths to config files so define it as relative instead
+# "$PWD\runtime\redis\redis.conf"
+
+Start-Process -FilePath "redis-server" -ArgumentList "./runtime/redis/redis.conf", "--pidfile", "$PWD\temp\redis.pid", "--dir", "$Database", "--logfile", "$PWD\log\redis.log"
 Start-Process -FilePath "perl" -ArgumentList "script\launcher.pl", "-d", "script\lanraragi"
 
 Pop-Location

--- a/tools/build/msys2/run.ps1
+++ b/tools/build/msys2/run.ps1
@@ -1,0 +1,30 @@
+[CmdletBinding()]
+Param(
+  [string]$Network,
+  [Parameter(Mandatory=$true)]
+  [string]$Data,
+  [Parameter(Mandatory=$true)]
+  [string]$Thumb,
+  [Parameter(Mandatory=$true)]
+  [string]$Database
+)
+
+Push-Location $([Environment]::CurrentDirectory)
+
+if ([string]::IsNullOrEmpty($Network)) {
+    $Env:LRR_NETWORK="http://0.0.0.0:3000"
+} else {
+    $Env:LRR_NETWORK=$Network
+}
+
+$Env:LRR_DATA_DIRECTORY = $Data
+$Env:LRR_THUMB_DIRECTORY = $Thumb
+$Env:Path = "$PWD\runtime\bin;$PWD\runtime\redis;$($Env:Path)"
+
+[System.IO.Directory]::CreateDirectory("$PWD\log") | Out-Null
+[System.IO.Directory]::CreateDirectory("$PWD\temp") | Out-Null
+
+Start-Process -FilePath "redis-server" -ArgumentList "--pidfile", "$PWD\temp\redis.pid", "--dir", "$Database", "--logfile", "$PWD\log\redis.log"
+Start-Process -FilePath "perl" -ArgumentList "script\launcher.pl", "-d", "script\lanraragi"
+
+Pop-Location

--- a/tools/build/msys2/utf8-support.ps1
+++ b/tools/build/msys2/utf8-support.ps1
@@ -1,0 +1,6 @@
+$vsPath = &"${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -property installationpath
+Import-Module (Join-Path $vsPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
+Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation
+
+Set-Location .\win-dist\runtime\bin\
+mt.exe -manifest ..\..\..\tools\build\msys2\perl.exe.manifest "-outputresource:perl.exe;#1"

--- a/tools/cpanfile
+++ b/tools/cpanfile
@@ -49,6 +49,8 @@ requires 'Minion::Backend::Redis', 0.002;
 # Background Worker (Shinobu)
 requires 'Proc::Simple',       1.32;
 requires 'Parallel::Loops',    0.10;
+requires 'MCE::Loop',          1.901;
+requires 'MCE::Shared',        1.893;
 requires 'Sys::CpuAffinity',   1.12;
 requires 'File::ChangeNotify', 0.31;
 

--- a/tools/cpanfile
+++ b/tools/cpanfile
@@ -13,9 +13,6 @@ requires 'List::MoreUtils',              0.430;
 # Not required by LRR itself but needs this version for Alpine support
 requires 'Crypt::Rijndael', 1.14;
 
-# Specifically use native DNS resolver to fix issues on WSL1+Alpine
-requires 'Net::DNS::Native', 0.22;
-
 # Web UI
 requires 'Sort::Naturally',     1.03;
 requires 'Authen::Passphrase',  0.008;
@@ -41,7 +38,6 @@ requires 'Test::Deep',       1.130;
 requires 'Mojolicious',                          9.39;
 requires 'Mojolicious::Plugin::TemplateToolkit', 0.005;
 requires 'Mojolicious::Plugin::RenderFile',      0.12;
-requires 'Mojolicious::Plugin::Status',          1.15;
 requires 'IO::Socket::Socks',                    0.74;
 requires 'IO::Socket::SSL',                      2.067;
 requires 'Cpanel::JSON::XS',                     4.06;

--- a/tools/install.pl
+++ b/tools/install.pl
@@ -99,11 +99,14 @@ require Config::AutoConf;
 
 say("\r\nWill now check if all LRR software dependencies are met. \r\n");
 
-#Check for Redis
-say("Checking for Redis...");
-can_run('redis-server')
-  or die 'NOT FOUND! Please install a Redis server before proceeding.';
-say("OK!");
+#Fails on win even if redis is in the path
+if ( $Config{osname} ne 'MSWin32') {
+    #Check for Redis
+    say("Checking for Redis...");
+    can_run('redis-server')
+    or die 'NOT FOUND! Please install a Redis server before proceeding.';
+    say("OK!");
+}
 
 #Check for GhostScript
 say("Checking for GhostScript...");
@@ -140,10 +143,17 @@ if ($@) {
 if ( $back || $full ) {
     say("\r\nInstalling Perl modules... This might take a while.\r\n");
 
-    if ( $Config{"osname"} ne "darwin" ) {
-        say("Installing Linux::Inotify2 for non-macOS systems... (This will do nothing if the package is there already)");
+    if ( $Config{"osname"} eq "linux" ) {
+        say("Installing Linux::Inotify2 for linux systems... (This will do nothing if the package is there already)");
 
         install_package( "Linux::Inotify2", $cpanopt );
+    }
+
+    if ( $Config{osname} ne 'MSWin32') {
+        say("Installing dependencies for non-windows systems... (This will do nothing if the package is there already)");
+
+        install_package( "Net::DNS::Native", $cpanopt );
+        install_package( "Mojolicious::Plugin::Status", $cpanopt );
     }
 
     if ( system( "cpanm --installdeps ./tools/. --notest" . $cpanopt ) != 0 ) {

--- a/tools/install.pl
+++ b/tools/install.pl
@@ -104,7 +104,7 @@ if ( $Config{osname} ne 'MSWin32') {
     #Check for Redis
     say("Checking for Redis...");
     can_run('redis-server')
-    or die 'NOT FOUND! Please install a Redis server before proceeding.';
+      or die 'NOT FOUND! Please install a Redis server before proceeding.';
     say("OK!");
 }
 

--- a/tools/install.pl
+++ b/tools/install.pl
@@ -10,6 +10,8 @@ use Config;
 use feature    qw(say);
 use File::Path qw(make_path);
 
+use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );
+
 #Vendor dependencies
 my @vendor_css = (
     "/blueimp-file-upload/css/jquery.fileupload.css",      "/\@fortawesome/fontawesome-free/css/all.min.css",
@@ -100,7 +102,7 @@ require Config::AutoConf;
 say("\r\nWill now check if all LRR software dependencies are met. \r\n");
 
 #Fails on win even if redis is in the path
-if ( $Config{osname} ne 'MSWin32') {
+if ( IS_UNIX ) {
     #Check for Redis
     say("Checking for Redis...");
     can_run('redis-server')
@@ -149,8 +151,8 @@ if ( $back || $full ) {
         install_package( "Linux::Inotify2", $cpanopt );
     }
 
-    if ( $Config{osname} ne 'MSWin32') {
-        say("Installing dependencies for non-windows systems... (This will do nothing if the package is there already)");
+    if ( IS_UNIX ) {
+        say("Installing dependencies for unix-like systems... (This will do nothing if the package is there already)");
 
         install_package( "Net::DNS::Native", $cpanopt );
         install_package( "Mojolicious::Plugin::Status", $cpanopt );

--- a/tools/install.pl
+++ b/tools/install.pl
@@ -154,6 +154,10 @@ if ( $back || $full ) {
 
         install_package( "Net::DNS::Native", $cpanopt );
         install_package( "Mojolicious::Plugin::Status", $cpanopt );
+    } else {
+        say("Installing dependencies for windows systems... (This will do nothing if the package is there already)");
+
+        install_package( "Win32::Process", $cpanopt );
     }
 
     if ( system( "cpanm --installdeps ./tools/. --notest" . $cpanopt ) != 0 ) {


### PR DESCRIPTION
This involved mostly changing process management code and not using any code that uses forks.

A minion replacement worker has been added that does exactly the same but without forking for each task.

Some dependencies have been moved to the perl install script, as they do not compile on Windows and I don't know if you can add conditions on the cpanfile.

The following perl modules needed to be patched for them to compile or behave correctly:

- Crypt::Des    - Fails to compile with newer GCC.
- Minion        - Removed check regarding fork emulation, which is avoided.
- Image::Magick - It is set up for compilation with Strawberry Perl, so it breaks on MSYS2.

This has been tested on MSYS2 UCRT64 environment and a script that does all of this is included ~~and the script for generating an end-user installable version will be added later~~.

A new workflow job has been added that generates a zip with everything needed to run it.

~~EDIT: I don't know how to make it load conditionally 🙃 help~~