### PR TITLE
Fix cookie path

### DIFF
--- a/lib/LANraragi.pm
+++ b/lib/LANraragi.pm
@@ -212,7 +212,7 @@ sub startup {
 
             # SameSite=Lax is the default behavior here; I set it
             # explicitly to get rid of a warning in the browser
-            $c->cookie( "lrr_baseurl" => $prefix, { samesite => "lax" } );
+            $c->cookie( "lrr_baseurl" => $prefix, { samesite => "lax", path => "/" } );
         }
     );
 


### PR DESCRIPTION
Per spec, if "path" isn't set, a session cookie is set for the current URL, meaning we get flooded with "lrr_baseurl" cookies for every path (eg, every image, every css file, every endpoint, etc).

This restricts cookies to "/", which ensures we only ever get one copy of it.

Browser cookie limits vary, and in the case of Firefox this would cause us to get logged out of other services sharing the base URL (Eg, when hosting on Unraid and viewing in Firefox, you would get logged out after a few page views)