### PR TITLE
Add Nginx documentation for large file downloads

### DIFF
--- a/tools/Documentation/advanced-usage/proxy-setup.md
+++ b/tools/Documentation/advanced-usage/proxy-setup.md
@@ -23,7 +23,8 @@ server {
     index index.php index.html index.htm;
     server_name lanraragi.[REDACTED].net;
 
-    client_max_body_size 0;   <----------------------- And this line here
+    client_max_body_size 0;           <---------- And this line here to disable upload limit
+    proxy_max_temp_file_size 0;       <---------- And this line here to support large downloads
 
     # Cert Stuff Omitted
 


### PR DESCRIPTION
When downloading a file from LRR behind an nginx reverse proxy exceeding 1gb, it will fail if [proxy_max_temp_file_size](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_max_temp_file_size) is not configured (which by default is 1024m), and this happens in both the API and UI. 

The simplest fix is to configure proxy_max_temp_file_size; see https://github.com/NginxProxyManager/nginx-proxy-manager/issues/643. There are 2 choices, 1) disable `proxy_max_temp_file_size`, or 2) set it to a higher value than the file downloaded (e.g. 4gb). For documentation I added the disable, but maybe setting a higher value is more appropriate.