### PR TITLE
Fix thumbnail cropping position

### DIFF
--- a/public/css/lrr.css
+++ b/public/css/lrr.css
@@ -69,7 +69,7 @@ div.id3.nocrop img {
 
 div.id3:not(.nocrop) img {
   object-fit: cover;
-  object-position: top;
+  object-position: left top;
   width: 95%;
   height: 100%;
 }


### PR DESCRIPTION
When showing thumbnails for wide images, the current style will crop the image to show the top center part of it. This behavior affects user experience with images that are made up by combining multiple images horizontally, and is inconsistent with the description of the crop option (_If enabled, thumbnails that don't fit a regular A4 page will be cropped to only show the **left** side_).  

This PR modifies lrr.css to show the top left part of the image. 