### PR TITLE
"/" to search and other keyboard shortcut features

### DIFF
--- a/public/js/edit.js
+++ b/public/js/edit.js
@@ -17,6 +17,7 @@ Edit.initializeAll = function () {
     $(document).on("click.tagger", ".tagger", Edit.focusTagInput);
     $(document).on("click.goback", "#goback", () => { window.location.href = new LRR.apiURL("/"); });
     $(document).on("paste.tagger", ".tagger-new", Edit.handlePaste);
+    $(document).on("keydown.run-plugin-enter", "#arg", Edit.runPluginByEnter);
 
     Edit.updateOneShotArg();
 
@@ -83,6 +84,16 @@ Edit.handlePaste = function (event) {
             Edit.addTag(tag);
         });
     }
+};
+
+/**
+ * Invoke plugin when Enter is pressed in the plugin argument input field.
+ * @param {KeyboardEvent} e - The keyboard event
+ */
+Edit.runPluginByEnter = function (e) {
+    if (e.key !== "Enter") return;
+    e.preventDefault();
+    Edit.runPlugin();
 };
 
 Edit.hideTags = function () {

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -32,6 +32,8 @@ Index.initializeAll = function () {
     $(document).on("click.close-overlay", "#overlay-shade", LRR.closeOverlay);
     $(document).on("click.thumbnail-bookmark-icon", ".thumbnail-bookmark-icon", Index.toggleBookmarkStatusByIcon);
     $(document).on("click.title-bookmark-icon", ".title-bookmark-icon", Index.toggleBookmarkStatusByIcon);
+    $(document).on("keydown.quick-search", Index.handleQuickSearch);
+    $(document).on("keydown.escape-overlay", Index.handleEscapeKey);
 
     // 0 = List view
     // 1 = Thumbnail view
@@ -174,6 +176,32 @@ Index.toggleBookmarkStatusByIcon = function (e) {
         Server.removeArchiveFromCategory(id, localStorage.getItem("bookmarkCategoryId"));
         Index.bookmarkIconOff(id);
     }
+};
+
+/**
+ * Handle quick search functionality. If user is in index page and
+ * presses "/" key, focus to search input. If the release overlay
+ * is open, closes it before focusing to search input.
+ * 
+ * @param {KeyboardEvent} e - The keyboard event
+ */
+Index.handleQuickSearch = function (e) {
+    if (e.key !== "/") return;
+    if (e.target.tagName === "INPUT") return;
+    if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) return;
+    e.preventDefault();
+    if ($("#overlay-shade").is(":visible")) LRR.closeOverlay();
+    $("#search-input")[0].focus();
+};
+
+/**
+ * Handle escape key to close overlays.
+ * @param {KeyboardEvent} e - The keyboard event
+ */
+Index.handleEscapeKey = function (e) {
+    if (e.key !== "Escape") return;
+    if (e.target.tagName === "INPUT") return;
+    LRR.closeOverlay();
 };
 
 Index.toggleMode = function () {


### PR DESCRIPTION
This PR implements 3 keyboard shortcut features I've wanted to have for some time. I feel these are natural enough behaviors to realize.

in the index page:
- "esc" to close release overlay
- "/" to focus to search bar (precedent: github and youtube)

in the metadata edit page:
- "enter" when in the plugin args textbox to automatically invoke plugin

Additionally, if release overlay is open, "/" will also automatically close the overlay before focusing to search.

Since there's no demand for this (afaik), I was considering writing an issue for this as a feature request then linking the branch, but a PR is just more direct, but let me know on thoughts, suggestions!