### PR TITLE
Fix the Ehentai plugin search error issue

### DIFF
--- a/lib/LANraragi/Plugin/Metadata/EHentai.pm
+++ b/lib/LANraragi/Plugin/Metadata/EHentai.pm
@@ -195,7 +195,12 @@ sub ehentai_parse ( $url, $ua ) {
     # Get the first row of the search results
     # The "glink" class is parented by a <a> tag containing the gallery link in href.
     # This works in Minimal, Minimal+ and Compact modes, which should be enough.
-    my $firstgal = $dom->at(".glink")->parent->attr('href');
+    my $glink_element = $dom->at(".glink");
+    if (!$glink_element) {
+        $logger->debug("No gallery found in search results");
+        return ("", "");
+    }
+    my $firstgal = $glink_element->parent->attr('href');
 
     # A EH link looks like xhentai.org/g/{gallery id}/{gallery token}
     $url = ( split( 'hentai.org/g/', $firstgal ) )[1];


### PR DESCRIPTION
Compatibility adjustments have been implemented to handle cases where no search results are found.

`[error] Can't call method "parent" on an undefined value at /home/koyomi/lanraragi/script/../lib/LANraragi/Plugin/Metadata/EHentai.pm line 198`