### PR TITLE
Updated FAKKU login Plugin to include Useragent field

### DIFF
--- a/lib/LANraragi/Plugin/Login/Fakku.pm
+++ b/lib/LANraragi/Plugin/Login/Fakku.pm
@@ -10,16 +10,13 @@ use LANraragi::Utils::Logging qw(get_logger);
 sub plugin_info {
 
     return (
-        name      => "Fakku",
-        type      => "login",
-        namespace => "fakkulogin",
-        author    => "Nodja",
-        version   => "0.1",
-        description =>
-          "Handles login to fakku. The cookie is only valid for 7 days so don't forget to update it.",
-        parameters => [
-            { type => "string", desc => "fakku_sid cookie value" }
-        ]
+        name        => "Fakku",
+        type        => "login",
+        namespace   => "fakkulogin",
+        author      => "Nodja, Nixis198",
+        version     => "0.2",
+        description => "Handles login to fakku.",
+        parameters  => [ { type => "string", desc => "fakku_sid cookie value" }, { type => "string", desc => 'Useragent value' } ]
     );
 
 }
@@ -27,12 +24,12 @@ sub plugin_info {
 sub do_login {
 
     shift;
-    my ( $fakku_sid ) = @_;
+    my ( $fakku_sid, $useragent ) = @_;
 
     my $logger = get_logger( "Fakku Login", "plugins" );
     my $ua     = Mojo::UserAgent->new;
 
-    if ( $fakku_sid ne "" ) {
+    if ( $fakku_sid ne "" && $useragent ne "" ) {
         $logger->info("Cookie provided ($fakku_sid)!");
         $ua->cookie_jar->add(
             Mojo::Cookie::Response->new(
@@ -42,6 +39,8 @@ sub do_login {
                 path   => '/'
             )
         );
+
+        $ua->transactor->name($useragent);
     } else {
         $logger->info("No cookies provided, returning blank UserAgent.");
     }

--- a/lib/LANraragi/Plugin/Login/Fakku.pm
+++ b/lib/LANraragi/Plugin/Login/Fakku.pm
@@ -15,8 +15,9 @@ sub plugin_info {
         namespace   => "fakkulogin",
         author      => "Nodja, Nixis198",
         version     => "0.2",
-        description => "Handles login to fakku.",
-        parameters  => [ { type => "string", desc => "fakku_sid cookie value" }, { type => "string", desc => 'Useragent value' } ]
+        description =>
+          "Handles login to FAKKU. If the FAKKU metadata plugin stops working, update your 'fakku_sid' cookie and add your own Useragent.",
+        parameters => [ { type => "string", desc => "fakku_sid cookie value" }, { type => "string", desc => 'Useragent value' } ]
     );
 
 }
@@ -24,10 +25,21 @@ sub plugin_info {
 sub do_login {
 
     shift;
-    my ( $fakku_sid, $useragent ) = @_;
+    my ( $fakku_sid, $useragentcustom ) = @_;
+
+    my $useragent;
+    my $useragentdefault =
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36';
 
     my $logger = get_logger( "Fakku Login", "plugins" );
     my $ua     = Mojo::UserAgent->new;
+
+    # If the user didn't provide a useragent use the default one
+    if ( $useragentcustom eq "" ) {
+        $useragent = $useragentdefault;
+    } else {
+        $useragent = $useragentcustom;
+    }
 
     if ( $fakku_sid ne "" && $useragent ne "" ) {
         $logger->info("Cookie provided ($fakku_sid)!");
@@ -40,6 +52,7 @@ sub do_login {
             )
         );
 
+        $logger->debug("Using Useragent: ($useragent)!");
         $ua->transactor->name($useragent);
     } else {
         $logger->info("No cookies provided, returning blank UserAgent.");


### PR DESCRIPTION
Either FAKKU or Cloudflare did some updating and broke the FAKKU metadata plugin.
When pulling the page data, the plugin would return the Cloudflare blocked page. After some testing, giving it a proper useragent fixes the issue.
Updated the login plugin to include a spot to add one.
Let's see how long this lasts until something breaks again.