### PR TITLE
Bump Cache::FastMmap to 1.60

### DIFF
--- a/tools/cpanfile
+++ b/tools/cpanfile
@@ -74,6 +74,4 @@ requires 'Locale::Maketext::Lexicon', 1.00;
 # Cache
 requires 'CHI',                   0.61;
 requires 'CHI::Driver::FastMmap', 0.61;
-requires 'Cache::FastMmap',       '>= 1.57, < 1.59';
-
-# 1.59 locks up in preforking environments (https://github.com/robmueller/cache-fastmmap/issues/28)
+requires 'Cache::FastMmap',       1.60;


### PR DESCRIPTION
Install 1.60 since cpanm refuses to install other versions. This version fixes the locking issue on forking envs so it should be fine.