### PR TITLE
Explicitly use raw mode when calculating archive IDs

### DIFF
--- a/lib/LANraragi/Utils/Database.pm
+++ b/lib/LANraragi/Utils/Database.pm
@@ -536,7 +536,7 @@ sub update_indexes ( $id, $oldtags, $newtags ) {
 sub compute_id ($file) {
 
     #Read the first 512 KBs only (allows for faster disk speeds )
-    open( my $handle, '<', $file ) or die "Couldn't open $file :" . $!;
+    open( my $handle, '<:raw', $file ) or die "Couldn't open $file :" . $!;
     my $data;
     my $len = read $handle, $data, 512000;
     close $handle;


### PR DESCRIPTION
Turns out Perl on Windows and only on Windows defaults to some special mode when you *open* archives leading to ID mismatches. This change tells *open* to use raw mode which is the default everywhere else.

I was doing some migration tests and found this.