### PR TITLE
Fix filewatcher paths and implement a custom log rotator that works on windows

### DIFF
--- a/lib/LANraragi/Utils/Generic.pm
+++ b/lib/LANraragi/Utils/Generic.pm
@@ -11,7 +11,6 @@ use Digest::SHA qw(sha256_hex);
 use Mojo::Log;
 use Mojo::Util qw(xml_escape);
 use Mojo::IOLoop;
-use Logfile::Rotate;
 use Proc::Simple;
 use Sys::CpuAffinity;
 use Config;

--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -49,6 +49,12 @@ my $inotifysub = sub {
     my $e    = shift;
     my $name = $e->path;
     my $type = $e->type;
+
+    # Filewatcher on Windows returns backward slashes, convert them to forward slash to match everything else
+    if ( !IS_UNIX ) {
+        $name =~ s/\\/\//g;
+    }
+
     $logger->debug("Received inotify event $type on $name");
 
     if ( $type eq "create" || $type eq "modify" ) {

--- a/tools/cpanfile
+++ b/tools/cpanfile
@@ -25,7 +25,6 @@ requires 'URI',                 5.09;
 requires 'IPC::Cmd', 1.02;
 
 # Logfile rotation and compression
-requires 'Logfile::Rotate', 1.04;
 requires 'Compress::Zlib',  2.087;
 
 # Test Utils


### PR DESCRIPTION
Logfile::Rotate is unix only and would require patching, just replace it.