### PR TITLE
Add context menu item for "copy URL"

### DIFF
--- a/locales/template/en.po
+++ b/locales/template/en.po
@@ -712,6 +712,9 @@ msgstr "Read"
 msgid "Download"
 msgstr "Download"
 
+msgid "Copy link"
+msgstr "Copy link"
+
 msgid "Edit Metadata"
 msgstr "Edit Metadata"
 
@@ -1417,6 +1420,12 @@ msgstr "Github API rate limit exceeded."
 
 msgid "Github API returned status: \${status}"
 msgstr "Github API returned status: ${status}"
+
+msgid "Link copied successfully."
+msgstr "Link copied successfully."
+
+msgid "Copy failed."
+msgstr "Copy failed."
 
 msgid "This archive isn't in any category."
 msgstr "This archive isn't in any category."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "lanraragi",
-    "version": "0.9.0",
+    "version": "0.9.50",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lanraragi",
-            "version": "0.9.0",
+            "version": "0.9.50",
             "license": "MIT",
             "dependencies": {
                 "@fortawesome/fontawesome-free": "^6.2.1",
@@ -14,6 +14,7 @@
                 "allcollapsible": "^1.1.0",
                 "awesomplete": "^1.1.5",
                 "blueimp-file-upload": "^10.32.0",
+                "clipboard": "^2.0.11",
                 "clsx": "^1.1.1",
                 "datatables.net": "^1.11.5",
                 "fscreen": "^1.2.0",
@@ -441,6 +442,16 @@
                 "node": ">=8"
             }
         },
+        "node_modules/clipboard": {
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
+            "integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
+            "dependencies": {
+                "good-listener": "^1.2.2",
+                "select": "^1.1.2",
+                "tiny-emitter": "^2.0.0"
+            }
+        },
         "node_modules/clsx": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
@@ -536,6 +547,11 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/delegate": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+            "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
         },
         "node_modules/doctrine": {
             "version": "3.0.0",
@@ -1136,6 +1152,14 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/good-listener": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+            "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
+            "dependencies": {
+                "delegate": "^3.1.2"
             }
         },
         "node_modules/has": {
@@ -1960,6 +1984,11 @@
                 "loose-envify": "^1.1.0"
             }
         },
+        "node_modules/select": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+            "integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA=="
+        },
         "node_modules/semver": {
             "version": "7.3.7",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
@@ -2243,6 +2272,11 @@
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
             "dev": true
+        },
+        "node_modules/tiny-emitter": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+            "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
         },
         "node_modules/tippy.js": {
             "version": "6.3.7",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "allcollapsible": "^1.1.0",
         "awesomplete": "^1.1.5",
         "blueimp-file-upload": "^10.32.0",
+        "clipboard": "^2.0.11",
         "clsx": "^1.1.1",
         "datatables.net": "^1.11.5",
         "fscreen": "^1.2.0",

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -11,6 +11,7 @@ Index.serverVersion = "";
 Index.debugMode = false;
 Index.isProgressLocal = true;
 Index.pageSize = 100;
+Index.pseudoCopyBtn = undefined;
 
 /**
  * Initialize the Archive Index.
@@ -136,6 +137,26 @@ Index.initializeAll = function () {
     
     Index.updateTableHeaders();
     Index.resizableColumns();
+
+    Index.pseudoCopyBtn = $("#pseudo-copy-btn")
+    Index.clipboard = new window.ClipboardJS("#pseudo-copy-btn");
+
+    Index.clipboard.on("success", function(e) {
+        LRR.toast({
+            heading: I18N.IndexCopyLinkSuccess,
+            icon: "info",
+            hideAfter: 3000,
+        });
+        e.clearSelection();
+    });
+
+    Index.clipboard.on("error", function(e) {
+        LRR.toast({
+            heading: I18N.IndexCopyLinkFail ,
+            icon: "error",
+            hideAfter: false,
+        });
+    });
 };
 
 // Turn bookmark icons to OFF for all archives.
@@ -756,6 +777,11 @@ Index.handleContextMenu = function (option, id) {
         break;
     case "download":
         LRR.openInNewTab(new LRR.apiURL(`/api/archives/${id}/download`));
+        break;
+    case "copy link":
+        const link = `${window.location.origin}/reader?id=${id}`;
+        Index.pseudoCopyBtn.attr('data-clipboard-text', link);
+        Index.pseudoCopyBtn.click()
         break;
     default:
         break;

--- a/templates/i18n.html.tt2
+++ b/templates/i18n.html.tt2
@@ -95,6 +95,8 @@ I18N.IndexUpdateError = "[% c.lh("Error getting changelog for new version") %]";
 I18N.IndexIdLoadError = (id) => `[% c.lh("Couldn't load data for \${id}!") %]`;
 I18N.IndexGithubRateLimitError = "[% c.lh("Github API rate limit exceeded.") %]";
 I18N.IndexGithubAPIError = (status) => `[% c.lh("Github API returned status: \${status}") %]`;
+I18N.IndexCopyLinkSuccess = "[% c.lh("Link copied successfully.") %]";
+I18N.IndexCopyLinkFail = "[% c.lh("Copy failed.") %]";
 I18N.IndexArcInNoCats = "[% c.lh("This archive isn't in any category.") %]";
 I18N.IndexNoCategories = "[% c.lh("No Categories yet...") %]";
 I18N.IndexRemoveRating = "[% c.lh("Remove rating") %]";

--- a/templates/index.html.tt2
+++ b/templates/index.html.tt2
@@ -40,6 +40,7 @@
 	<script src="[% c.url_for("/js/vendor/allcollapsible.min.js") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/vendor/swiper-bundle.min.js") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/vendor/sweetalert2.min.js") %]" type="text/JAVASCRIPT"></script>
+	<script src="[% c.url_for("/js/vendor/clipboard.min.js") %]" type="text/JAVASCRIPT"></script>
 
 	<script src="[% c.url_for("/js/i18n.js?$version") %]" type="text/JAVASCRIPT"></script>
 	<script src="[% c.url_for("/js/index.js?$version") %]" type="text/JAVASCRIPT"></script>
@@ -183,6 +184,8 @@
 
 	[% INCLUDE footer %]
 
+	<button id="pseudo-copy-btn" data-clipboard-text="" style="display: none">click me</button>
+
 	<script>
 
 		// Last few remains of JS using server-provided data
@@ -222,6 +225,7 @@
 						items: {
 							"read": { name: "[% c.lh('Read') %]", icon: "fas fa-book" },
 							"download": { name: "[% c.lh('Download') %]", icon: "fas fa-save" },
+							"copy link": { name: "[% c.lh('Copy link') %]", icon: "fas fa-link" },
 							[% IF userlogged %]
 							"sep1": "---------",
 							"edit": { name: "[% c.lh('Edit Metadata') %]", icon: "fas fa-pencil-alt" },

--- a/tools/install.pl
+++ b/tools/install.pl
@@ -33,7 +33,7 @@ my @vendor_js = (
     "/swiper/swiper-bundle.min.js",                       "/preact/dist/preact.umd.js",
     "/clsx/dist/clsx.min.js",                             "/preact/compat/dist/compat.umd.js",
     "/preact/hooks/dist/hooks.umd.js",                    "/sweetalert2/dist/sweetalert2.min.js",
-    "/fscreen/dist/fscreen.esm.js"
+    "/fscreen/dist/fscreen.esm.js",                       "/clipboard/dist/clipboard.min.js"
 );
 
 my @vendor_woff = (


### PR DESCRIPTION
I have implemented this QoL issue: #1215 .

<img width="277" height="158" alt="image" src="https://github.com/user-attachments/assets/fbbc6ffa-2b91-4651-95b5-b1cb048b5d95" />


I think it is enough to just implement the "copy link" button, because (A) the context menu should resemble that of the browser (take a look at the following image) for better UX; (B) the link already contains the archive ID; (C) listening to a key event and changing the content on the page is quite difficult. I have to break many things in the template file to achieve this, which is something I want to avoid doing.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/ac8f1ccf-5107-4e8b-8c96-d1ad8a461a1c" />


I used clipboard.js to implement the functionality of writing text to clipboard. I did not use the `navigator.clipboard.writeText()` API because [Chrome requires a secure context](https://stackoverflow.com/questions/51805395/navigator-clipboard-is-undefined), and many lrr users are self hosting docker containers with HTTP endpoints in their LAN. Of course, I would love to implement the feature without installing a 3rd-party library, but clipboard.js just makes life easier.

There's one thing I am not sure, which is i18n. I only updated `locales/template/en.po`. Is there an easier way to set these three new fields for all languages? Thanks.
