### PR TITLE
Add "auto next page" feature

### DIFF
--- a/locales/template/en.po
+++ b/locales/template/en.po
@@ -968,6 +968,9 @@ msgstr "F: toggle fullscreen mode"
 msgid "B: toggle bookmark"
 msgstr "B: toggle bookmark"
 
+msgid "N: toggle auto next page"
+msgstr "N: toggle auto next page"
+
 msgid "To return to the archive index, touch the arrow pointing down or use Backspace."
 msgstr "To return to the archive index, touch the arrow pointing down or use Backspace."
 
@@ -1055,6 +1058,12 @@ msgstr "Infinite Scrolling"
 msgid "Display all images in a vertical view in the same page."
 msgstr "Display all images in a vertical view in the same page."
 
+msgid "Auto next page interval in seconds"
+msgstr "Auto next page interval in seconds"
+
+msgid "The default is 10 seconds."
+msgstr "The default is 10 seconds."
+
 msgid "Reader Settings"
 msgstr "Reader Settings"
 
@@ -1063,6 +1072,9 @@ msgstr "Help"
 
 msgid "Reading Direction"
 msgstr "Reading Direction"
+
+msgid "Auto Next Page"
+msgstr "Auto Next Page"
 
 msgid "Archive Overview"
 msgstr "Archive Overview"
@@ -1504,6 +1516,12 @@ msgstr "Page ${page}"
 
 msgid "The page thumbnailing job didn't conclude properly. Your archive might be corrupted."
 msgstr "The page thumbnailing job didn't conclude properly. Your archive might be corrupted."
+
+msgid "Starting auto next page failed!"
+msgstr "Starting auto next page failed!"
+
+msgid "Please set the auto next page interval to a positive number."
+msgstr "Please set the auto next page interval to a positive number."
 
 msgid "A script is already running."
 msgstr "A script is already running."

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -909,7 +909,8 @@ Reader.startAutoNextPage = function() {
         if (Reader.autoNextPageCountdown <= 0) {
             clearInterval(Reader.autoNextPageCountdownTaskId);
             Reader.changePage(1);
-            if (Reader.currentPage < Reader.maxPage) {
+            const continueNextPage = Reader.mangaMode ? Reader.currentPage > 0 : Reader.currentPage < Reader.maxPage;
+            if (continueNextPage) {
                 Reader.startAutoNextPage();
             } else {
                 Reader.stopAutoNextPage();

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -20,11 +20,15 @@ Reader.scrollConfig = {
     holdDelay: 350,      // Delay time in ms before continuous scroll starts on keydown
     scrollSpeed: 22      // Speed % to scroll when spacebar is held
 };
+Reader.autoNextPage = false;
+Reader.autoNextPageCountdownTaskId = undefined;
+Reader.autoNextPageCountdown = 0;
 
 Reader.initializeAll = function () {
     Reader.initializeSettings();
     Reader.applyContainerWidth();
     Reader.registerPreload();
+    Reader.registerAutoNextPage();
     document.documentElement.style.scrollBehavior = 'smooth';
 
     // Bind events to DOM
@@ -45,9 +49,12 @@ Reader.initializeAll = function () {
     $(document).on("submit.preload", "#preload-input", Reader.registerPreload);
     $(document).on("click.preload", "#preload-apply", Reader.registerPreload);
     $(document).on("click.pagination-change-pages", ".page-link", Reader.handlePaginator);
+    $(document).on("submit.auto-next-page", "#auto-next-page-input", Reader.registerAutoNextPage);
+    $(document).on("click.auto-next-page", "#auto-next-page-apply", Reader.registerAutoNextPage);
 
     $(document).on("click.close-overlay", "#overlay-shade", LRR.closeOverlay);
     $(document).on("click.toggle-full-screen", "#toggle-full-screen", () => Reader.handleFullScreen(true));
+    $(document).on("click.toggle-auto-next-page", ".toggle-auto-next-page", Reader.toggleAutoNextPage);
     $(document).on("click.toggle-archive-overlay", "#toggle-archive-overlay", Reader.toggleArchiveOverlay);
     $(document).on("click.toggle-settings-overlay", "#toggle-settings-overlay", Reader.toggleSettingsOverlay);
     $(document).on("click.toggle-help", "#toggle-help", Reader.toggleHelp);
@@ -485,6 +492,9 @@ Reader.handleShortcuts = function (e) {
     case 77: // m
         Reader.toggleMangaMode();
         break;
+    case 78: // n
+        Reader.toggleAutoNextPage();
+        break;
     case 79: // o
         Reader.toggleSettingsOverlay();
         break;
@@ -869,16 +879,72 @@ Reader.toggleInfiniteScroll = function () {
     window.location.reload();
 };
 
+Reader.registerAutoNextPage = function () {
+    Reader.AutoNextPageInterval = +$("#auto-next-page-input").val().trim() || +localStorage.AutoNextPageInterval || 10;
+    $("#auto-next-page-input").val(Reader.AutoNextPageInterval);
+    localStorage.AutoNextPageInterval = Reader.AutoNextPageInterval;
+
+    Reader.stopAutoNextPage();
+};
+
+Reader.startAutoNextPage = function() {
+    Reader.autoNextPageCountdown = Math.trunc(Reader.AutoNextPageInterval);
+    if (Reader.autoNextPageCountdown <= 0) {
+        LRR.toast({
+            heading: I18N.AutoNextPageFailHeader,
+            text: I18N.AutoNextPageFailBody,
+            icon: "error",
+            hideAfter: 5000,
+        });
+        return;
+    }
+
+    Reader.autoNextPage = true;
+    
+    const aEls = $(".toggle-auto-next-page");
+    aEls.removeClass('fa-arrows-rotate');
+    aEls.text(Reader.autoNextPageCountdown);
+
+    Reader.autoNextPageCountdownTaskId = setInterval(() => {
+        if (Reader.autoNextPageCountdown <= 0) {
+            clearInterval(Reader.autoNextPageCountdownTaskId);
+            Reader.changePage(1);
+            if (Reader.currentPage < Reader.maxPage) {
+                Reader.startAutoNextPage();
+            } else {
+                Reader.stopAutoNextPage();
+            }
+            return;
+        }
+        Reader.autoNextPageCountdown--;
+        aEls.text(Reader.autoNextPageCountdown);
+    }, 1000);
+}
+
+Reader.stopAutoNextPage = function() {
+    Reader.autoNextPage = false;
+    clearInterval(Reader.autoNextPageCountdownTaskId);
+    $(".toggle-auto-next-page").addClass('fa-arrows-rotate');
+    $(".toggle-auto-next-page").text('');
+}
+
+Reader.toggleAutoNextPage = function() {
+    Reader.autoNextPage ? Reader.stopAutoNextPage() : Reader.startAutoNextPage();
+    return false; // prevent scrolling to top
+}
+
 Reader.toggleOverlayByDefault = function () {
     Reader.overlayByDefault = localStorage.showOverlayByDefault = !Reader.showOverlayByDefault;
     $("#toggle-overlay input").toggleClass("toggled");
 };
 
 Reader.toggleSettingsOverlay = function () {
+    Reader.stopAutoNextPage();
     return LRR.toggleOverlay("#settingsOverlay");
 };
 
 Reader.toggleArchiveOverlay = function () {
+    Reader.stopAutoNextPage();
     return LRR.toggleOverlay("#archivePagesOverlay");
 };
 

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -902,7 +902,7 @@ Reader.startAutoNextPage = function() {
     Reader.autoNextPage = true;
     
     const aEls = $(".toggle-auto-next-page");
-    aEls.removeClass('fa-arrows-rotate');
+    aEls.removeClass('fa-stopwatch');
     aEls.text(Reader.autoNextPageCountdown);
 
     Reader.autoNextPageCountdownTaskId = setInterval(() => {
@@ -924,7 +924,7 @@ Reader.startAutoNextPage = function() {
 Reader.stopAutoNextPage = function() {
     Reader.autoNextPage = false;
     clearInterval(Reader.autoNextPageCountdownTaskId);
-    $(".toggle-auto-next-page").addClass('fa-arrows-rotate');
+    $(".toggle-auto-next-page").addClass('fa-stopwatch');
     $(".toggle-auto-next-page").text('');
 }
 

--- a/templates/i18n.html.tt2
+++ b/templates/i18n.html.tt2
@@ -125,7 +125,8 @@ I18N.ReaderNavHelp = "[% c.lh("Navigation Help") %]";
 I18N.ReaderErrorProgress = "[% c.lh("Error updating reading progression") %]";
 I18N.ReaderPage = (page) => `[% c.lh("Page \${page}") %]`;
 I18N.ThumbJobError = "[% c.lh("The page thumbnailing job didn't conclude properly. Your archive might be corrupted.") %]";
-I18N.ToggleBookmark = "[% c.lh("Toggle Bookmark") %]";
+I18N.AutoNextPageFailHeader = "[% c.lh("Starting auto next page failed!") %]";
+I18N.AutoNextPageFailBody = "[% c.lh("Please set the auto next page interval to a positive number.") %]";
 
 I18N.ScriptRunning = "[% c.lh("A script is already running.") %]";
 I18N.ScriptRunningDesc = "[% c.lh("Please wait for it to finish before starting a new one.") %]";

--- a/templates/i18n.html.tt2
+++ b/templates/i18n.html.tt2
@@ -125,6 +125,7 @@ I18N.ReaderNavHelp = "[% c.lh("Navigation Help") %]";
 I18N.ReaderErrorProgress = "[% c.lh("Error updating reading progression") %]";
 I18N.ReaderPage = (page) => `[% c.lh("Page \${page}") %]`;
 I18N.ThumbJobError = "[% c.lh("The page thumbnailing job didn't conclude properly. Your archive might be corrupted.") %]";
+I18N.ToggleBookmark = "[% c.lh("Toggle Bookmark") %]";
 I18N.AutoNextPageFailHeader = "[% c.lh("Starting auto next page failed!") %]";
 I18N.AutoNextPageFailBody = "[% c.lh("Please set the auto next page interval to a positive number.") %]";
 

--- a/templates/reader.html.tt2
+++ b/templates/reader.html.tt2
@@ -181,6 +181,7 @@
                 <li>[% c.lh("R: open a random archive.") %]</li>
                 <li>[% c.lh("F: toggle fullscreen mode") %]</li>
                 <li>[% c.lh("B: toggle bookmark") %]</li>
+                <li>[% c.lh("N: toggle auto next page") %]</li>
             </ul>
             <br>[% c.lh("To return to the archive index, touch the arrow pointing down or use Backspace.") %]
         </div>
@@ -266,6 +267,12 @@
     <input id="infinite-scroll-off" class="favtag-btn config-btn" type="button" value="[% c.lh('Disabled') %]">
 </div>
 
+<div id="auto-next-page">
+    <h2 class="config-panel"> [% c.lh("Auto next page interval in seconds") %]</h2>
+    <input id="auto-next-page-input" class="stdinput" style="display:inline" placeholder="[% c.lh('The default is 10 seconds.') %]">
+    <input id="auto-next-page-apply" class="favtag-btn config-btn" type="button" style="display:inline;" value="[% c.lh('Apply') %]">
+</div>
+
 [% END %]
 <!-- -->
 [% BLOCK arrows %]
@@ -291,6 +298,7 @@
 
 <div class="absolute-options absolute-right">
     <a class="fa fa-arrow-right fa-2x reading-direction" href="#" title="[% c.lh('Reading Direction') %]"></a>
+    <a class="fa fa-arrows-rotate fa-2x toggle-auto-next-page" href="#" title="[% c.lh('Auto Next Page') %]"></a>
     <a class="fa fa-th fa-2x" id="toggle-archive-overlay" href="#" title="[% c.lh('Archive Overview') %]"></a>
     <a class="fa fa-compress fa-2x" id="toggle-full-screen" href="#" title="[% c.lh('FullScreen') %]"></a>
 </div>

--- a/templates/reader.html.tt2
+++ b/templates/reader.html.tt2
@@ -298,7 +298,7 @@
 
 <div class="absolute-options absolute-right">
     <a class="fa fa-arrow-right fa-2x reading-direction" href="#" title="[% c.lh('Reading Direction') %]"></a>
-    <a class="fa fa-arrows-rotate fa-2x toggle-auto-next-page" href="#" title="[% c.lh('Auto Next Page') %]"></a>
+    <a class="fa fa-stopwatch fa-2x toggle-auto-next-page" href="#" title="[% c.lh('Auto Next Page') %]"></a>
     <a class="fa fa-th fa-2x" id="toggle-archive-overlay" href="#" title="[% c.lh('Archive Overview') %]"></a>
     <a class="fa fa-compress fa-2x" id="toggle-full-screen" href="#" title="[% c.lh('FullScreen') %]"></a>
 </div>


### PR DESCRIPTION
I have implemented this feature request: #768 

First, there is a new reader option:

<img width="589" height="130" alt="image" src="https://github.com/user-attachments/assets/33a25cec-a80b-4501-a45c-5a62d6a38aed" />

After configuring it, users can click the "auto next page" button to toggle this functionality:

- off state:
  <img width="210" height="77" alt="image" src="https://github.com/user-attachments/assets/ba682492-6ef2-408c-97c4-d0730ba96d5c" />
- on state:
  <img width="184" height="56" alt="image" src="https://github.com/user-attachments/assets/20178dac-1a80-4d77-a69c-3b8fdffc5640" />
  The number is an indicator of a countdown timer, which will decrement every second. When it reaches 0, the reader will automatically turn to the next page.

In addition, I added a keyboard shortcut `n` to toggle this functionality.

The biggest barrier for me when implementing this feature is a UI design decision: find a place to hold the countdown timer. I think we'd better place it near the "auto next page" button (to give a counter example, an absolute-positioning block floating above the manga image will make a bad reading experience). Since the text styles offered by the `fa fa-2x` classes are acceptable,  and we need to make a coherent look and feel of the buttons area, I think it is OK to just replace the button with the countdown number when the functionality is on.



