### PR TITLE
Avoid dependency cycles

### DIFF
--- a/lib/LANraragi.pm
+++ b/lib/LANraragi.pm
@@ -22,6 +22,7 @@ use LANraragi::Utils::I18NInitializer;
 
 use LANraragi::Model::Search;
 use LANraragi::Model::Config;
+use LANraragi::Model::Setup qw(first_install_actions);
 
 use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );
 
@@ -194,7 +195,7 @@ sub startup {
     start_shinobu($self);
 
     # Check if this is a first-time installation.
-    LANraragi::Model::Config::first_install_actions();
+    LANraragi::Model::Setup::first_install_actions();
 
     # Hook to SIGTERM to cleanly kill minion+shinobu on server shutdown
     # As this is executed during before_dispatch, this code won't work if you SIGTERM without loading a single page!

--- a/lib/LANraragi.pm
+++ b/lib/LANraragi.pm
@@ -195,7 +195,7 @@ sub startup {
     start_shinobu($self);
 
     # Check if this is a first-time installation.
-    LANraragi::Model::Setup::first_install_actions();
+    first_install_actions();
 
     # Hook to SIGTERM to cleanly kill minion+shinobu on server shutdown
     # As this is executed during before_dispatch, this code won't work if you SIGTERM without loading a single page!

--- a/lib/LANraragi/Controller/Api/Tankoubon.pm
+++ b/lib/LANraragi/Controller/Api/Tankoubon.pm
@@ -66,7 +66,7 @@ sub delete_tankoubon {
     my $tankid = $self->stash('id');
 
     my $redis = LANraragi::Model::Config->get_redis;
-    
+
     return unless exec_with_lock( $self, $redis, "tankoubon-write:$tankid", "delete_tankoubon", $tankid, sub {
         my $result = LANraragi::Model::Tankoubon::delete_tankoubon($tankid);
 
@@ -85,7 +85,7 @@ sub update_tankoubon {
     my $data   = $self->req->json;
 
     my $redis = LANraragi::Model::Config->get_redis;
-    
+
     return unless exec_with_lock( $self, $redis, "tankoubon-write:$tankid", "update_tankoubon", $tankid, sub {
         my ( $result, $err ) = LANraragi::Model::Tankoubon::update_tankoubon( $tankid, $data );
 
@@ -107,7 +107,7 @@ sub add_to_tankoubon {
     my $arcid  = $self->stash('archive');
 
     my $redis = LANraragi::Model::Config->get_redis;
-    
+
     return unless exec_with_lock( $self, $redis, "tankoubon-write:$tankid", "add_to_tankoubon", $tankid, sub {
         my ( $result, $err ) = LANraragi::Model::Tankoubon::add_to_tankoubon( $tankid, $arcid );
 
@@ -134,7 +134,7 @@ sub remove_from_tankoubon {
     my $arcid  = $self->stash('archive');
 
     my $redis = LANraragi::Model::Config->get_redis;
-    
+
     return unless exec_with_lock( $self, $redis, "tankoubon-write:$tankid", "remove_from_tankoubon", $tankid, sub {
         my ( $result, $err ) = LANraragi::Model::Tankoubon::remove_from_tankoubon( $tankid, $arcid );
 

--- a/lib/LANraragi/Controller/Batch.pm
+++ b/lib/LANraragi/Controller/Batch.pm
@@ -7,9 +7,10 @@ use Mojo::JSON qw(decode_json);
 
 use LANraragi::Utils::Generic  qw(generate_themes_header);
 use LANraragi::Utils::Tags     qw(rewrite_tags build_tag_replace_hash split_tags_to_array restore_CRLF);
-use LANraragi::Utils::Database qw(redis_decode get_computed_tagrules set_tags set_title set_summary set_isnew invalidate_cache);
+use LANraragi::Utils::Database qw(get_computed_tagrules set_tags set_title set_summary set_isnew invalidate_cache);
 use LANraragi::Utils::Plugins  qw(get_plugins get_plugin get_plugin_parameters);
 use LANraragi::Utils::Logging  qw(get_logger);
+use LANraragi::Utils::Redis    qw(redis_decode);
 
 # This action will render a template
 sub index {

--- a/lib/LANraragi/Controller/Category.pm
+++ b/lib/LANraragi/Controller/Category.pm
@@ -8,7 +8,7 @@ use Encode;
 use Mojo::Util qw(xml_escape);
 
 use LANraragi::Utils::Generic qw(generate_themes_header);
-use LANraragi::Utils::Database qw(redis_decode);
+use LANraragi::Utils::Redis   qw(redis_decode);
 
 # Go through the archives in the content directory and build the template at the end.
 sub index {

--- a/lib/LANraragi/Controller/Config.pm
+++ b/lib/LANraragi/Controller/Config.pm
@@ -3,9 +3,10 @@ use Mojo::Base 'Mojolicious::Controller';
 
 use LANraragi::Utils::Generic    qw(generate_themes_header);
 use LANraragi::Utils::String     qw(trim trim_CRLF);
-use LANraragi::Utils::Database   qw(redis_encode save_computed_tagrules);
+use LANraragi::Utils::Database   qw(save_computed_tagrules);
 use LANraragi::Utils::Tags       qw(tags_rules_to_array replace_CRLF restore_CRLF);
 use Mojo::JSON                   qw(encode_json);
+use LANraragi::Utils::Redis      qw(redis_encode);
 
 use Authen::Passphrase::BlowfishCrypt;
 

--- a/lib/LANraragi/Controller/Duplicates.pm
+++ b/lib/LANraragi/Controller/Duplicates.pm
@@ -8,7 +8,7 @@ use Encode;
 
 use Mojo::JSON qw(decode_json encode_json);
 
-use LANraragi::Utils::Database qw(redis_decode);
+use LANraragi::Utils::Redis    qw(redis_decode);
 use LANraragi::Utils::Generic  qw(generate_themes_header);
 
 # Go through the archives in the content directory and build the template at the end.

--- a/lib/LANraragi/Controller/Edit.pm
+++ b/lib/LANraragi/Controller/Edit.pm
@@ -8,7 +8,7 @@ use Template;
 use Mojo::Util qw(xml_escape);
 
 use LANraragi::Utils::Generic qw(generate_themes_header);
-use LANraragi::Utils::Database qw(redis_decode);
+use LANraragi::Utils::Redis   qw(redis_decode);
 use LANraragi::Utils::Plugins qw(get_plugins);
 
 sub index {

--- a/lib/LANraragi/Controller/Reader.pm
+++ b/lib/LANraragi/Controller/Reader.pm
@@ -6,8 +6,6 @@ use Encode;
 
 use LANraragi::Utils::Generic qw(generate_themes_header);
 
-use LANraragi::Model::Reader;
-
 # This action will render a template
 sub index {
     my $self = shift;

--- a/lib/LANraragi/Controller/Tankoubon.pm
+++ b/lib/LANraragi/Controller/Tankoubon.pm
@@ -8,7 +8,7 @@ use Encode;
 use Mojo::Util qw(xml_escape);
 
 use LANraragi::Utils::Generic qw(generate_themes_header);
-use LANraragi::Utils::Database qw(redis_decode);
+use LANraragi::Utils::Redis   qw(redis_decode);
 
 # Go through the archives in the content directory and build the template at the end.
 sub index {

--- a/lib/LANraragi/Model/Archive.pm
+++ b/lib/LANraragi/Model/Archive.pm
@@ -8,7 +8,6 @@ use warnings;
 use utf8;
 
 use Cwd 'abs_path';
-use Redis;
 use Time::HiRes qw(usleep);
 use File::Path  qw(remove_tree);
 use File::Basename;

--- a/lib/LANraragi/Model/Archive.pm
+++ b/lib/LANraragi/Model/Archive.pm
@@ -21,8 +21,9 @@ use LANraragi::Utils::TempFolder qw(get_temp);
 use LANraragi::Utils::Logging    qw(get_logger);
 use LANraragi::Utils::Archive    qw(extract_single_file extract_single_file extract_thumbnail);
 use LANraragi::Utils::Database
-  qw(redis_encode redis_decode invalidate_cache set_title set_tags set_summary get_archive_json get_archive_json_multi);
+  qw(invalidate_cache set_title set_tags set_summary get_archive_json get_archive_json_multi);
 use LANraragi::Utils::PageCache  qw(fetch put);
+use LANraragi::Utils::Redis      qw(redis_decode redis_encode);
 
 # get_title(id)
 #   Returns the title for the archive matching the given id.

--- a/lib/LANraragi/Model/Backup.pm
+++ b/lib/LANraragi/Model/Backup.pm
@@ -9,10 +9,10 @@ use Mojo::JSON qw(decode_json encode_json);
 
 use LANraragi::Model::Category;
 use LANraragi::Model::Tankoubon;
-use LANraragi::Utils::Database;
 use LANraragi::Utils::String   qw(trim_CRLF);
-use LANraragi::Utils::Database qw(redis_encode redis_decode invalidate_cache set_title set_tags set_summary);
+use LANraragi::Utils::Database qw(invalidate_cache set_title set_tags set_summary);
 use LANraragi::Utils::Logging  qw(get_logger);
+use LANraragi::Utils::Redis    qw(redis_decode redis_encode);
 
 #build_backup_JSON()
 #Goes through the Redis archive IDs and builds a JSON string containing their metadata.

--- a/lib/LANraragi/Model/Category.pm
+++ b/lib/LANraragi/Model/Category.pm
@@ -7,8 +7,9 @@ use utf8;
 use Redis;
 use Mojo::JSON qw(decode_json encode_json);
 
-use LANraragi::Utils::Database qw(redis_encode redis_decode invalidate_cache);
-use LANraragi::Utils::Logging qw(get_logger);
+use LANraragi::Utils::Database qw(invalidate_cache);
+use LANraragi::Utils::Logging  qw(get_logger);
+use LANraragi::Utils::Redis    qw(redis_decode);
 
 # get_category_list()
 #   Returns a list of all the category objects.

--- a/lib/LANraragi/Model/Config.pm
+++ b/lib/LANraragi/Model/Config.pm
@@ -4,16 +4,16 @@ use strict;
 use warnings;
 use utf8;
 use Cwd 'abs_path';
-use Redis;
-use Encode;
+
 use Mojo::Util qw(xml_escape);
 use Minion;
+use Mojolicious;
 use Mojolicious::Plugin::Config;
 use Mojo::Home;
 use Mojo::JSON qw(decode_json);
 
-use LANraragi::Utils::Logging    qw(get_logger);
-use LANraragi::Model::Category;
+# Be very careful about importing LANraragi stuff; this file is used almost everywhere and it's easy to introduce dependency cycles!
+use LANraragi::Utils::Redis      qw(redis_decode);
 
 # Find the project root directory to load the conf file
 my $home = Mojo::Home->new;
@@ -99,8 +99,7 @@ sub get_redis_conf {
 
     if ( $redis->hexists( "LRR_CONFIG", $param ) ) {
 
-        # Call Utils::Database directly as importing it with use; would cause circular dependencies...
-        my $value = LANraragi::Utils::Database::redis_decode( $redis->hget( "LRR_CONFIG", $param ) );
+        my $value = redis_decode( $redis->hget( "LRR_CONFIG", $param ) );
 
         # Failsafe against blank config values
         unless ( $value =~ /^\s*$/ ) {
@@ -169,28 +168,6 @@ sub get_tagrules {
     return &get_redis_conf( "tagrules",
         "-already uploaded;-forbidden content;-incomplete;-ongoing;-complete;-various;-digital;-translated;-russian;-chinese;-portuguese;-french;-spanish;-italian;-vietnamese;-german;-indonesian"
     );
-}
-
-# first_install_actions()
-# Setup tasks for first-time installations. New installs are checked by confirming updated
-# user settings. On first installation, create default 'Favorites' category link it to the bookmark
-# button. Returns 1 if is first-time installation, else 0.
-sub first_install_actions {
-    my $redis = get_redis_config();
-    my $logger = get_logger( "Config", "lanraragi" );
-    unless ( $redis->hexists('LRR_CONFIG', 'htmltitle') ) {
-        $logger->info("First-time installation detected!");
-        $redis->hset('LRR_CONFIG', 'htmltitle', 'LANraragi');
-
-        $logger->debug("Creating first category...");
-        my $default_category_id = LANraragi::Model::Category::create_category("🔖 Favorites", "", 0, "");
-        LANraragi::Model::Category::update_bookmark_link($default_category_id);
-        $logger->info("Created default Favorites category.");
-        $redis->quit();
-        return 1;
-    }
-    $redis->quit();
-    return 0;
 }
 
 sub get_htmltitle        { return xml_escape( &get_redis_conf( "htmltitle", "LANraragi" ) ) }

--- a/lib/LANraragi/Model/Plugins.pm
+++ b/lib/LANraragi/Model/Plugins.pm
@@ -20,6 +20,7 @@ use LANraragi::Utils::Archive  qw(extract_thumbnail);
 use LANraragi::Utils::Logging  qw(get_logger);
 use LANraragi::Utils::Tags     qw(rewrite_tags split_tags_to_array);
 use LANraragi::Utils::Plugins  qw(get_plugin_parameters get_plugin);
+use LANraragi::Utils::Redis    qw(redis_decode);
 
 # Sub used by Auto-Plugin.
 sub exec_enabled_plugins_on_file ($id) {
@@ -204,7 +205,7 @@ sub exec_metadata_plugin ( $plugin, $id, %args ) {
 
     my ( $name, $title, $tags, $file, $thumbhash ) = @hash{qw(name title tags file thumbhash)};
 
-    ( $_ = LANraragi::Utils::Database::redis_decode($_) ) for ( $name, $title, $tags );
+    ( $_ = redis_decode($_) ) for ( $name, $title, $tags );
 
     # If the thumbnail hash is empty or undefined, we'll generate it here.
     unless ( length $thumbhash ) {
@@ -215,7 +216,7 @@ sub exec_metadata_plugin ( $plugin, $id, %args ) {
         try {
             extract_thumbnail( $thumbdir, $id, 1, 1, 1 );
             $thumbhash = $redis->hget( $id, "thumbhash" );
-            $thumbhash = LANraragi::Utils::Database::redis_decode($thumbhash);
+            $thumbhash = redis_decode($thumbhash);
         } catch ($e) {
             $logger->warn("Error building thumbnail: $e");
         }

--- a/lib/LANraragi/Model/Reader.pm
+++ b/lib/LANraragi/Model/Reader.pm
@@ -19,7 +19,7 @@ use URI::Escape;
 use LANraragi::Utils::Generic  qw(is_image);
 use LANraragi::Utils::Logging  qw(get_logger);
 use LANraragi::Utils::Archive  qw(get_filelist);
-use LANraragi::Utils::Database qw(redis_decode);
+use LANraragi::Utils::Redis    qw(redis_decode);
 
 # resize_image(image,quality, size_threshold)
 # Convert an image to a cheaper on bandwidth format through ImageMagick.

--- a/lib/LANraragi/Model/Search.pm
+++ b/lib/LANraragi/Model/Search.pm
@@ -16,7 +16,7 @@ use Time::HiRes qw(time);
 
 use LANraragi::Utils::Generic  qw(intersect_arrays);
 use LANraragi::Utils::String   qw(trim);
-use LANraragi::Utils::Database qw(redis_decode redis_encode);
+use LANraragi::Utils::Redis    qw(redis_decode redis_encode);
 use LANraragi::Utils::Logging  qw(get_logger);
 
 use LANraragi::Model::Archive;
@@ -404,7 +404,7 @@ sub compute_search_filter ($filter) {
 }
 
 sub sort_results ( $sortkey, $sortorder, @filtered ) {
-    
+
     my $start_time = time();
     my $redis = LANraragi::Model::Config->get_redis;
     my $logger = get_logger( "Search Sort", "lanraragi" );
@@ -438,7 +438,7 @@ LUA
         };
         if ($@) {
             $logger->error("Failed to load Lua script: $@");
-            # Fallback to running individual hget operations for each ID 
+            # Fallback to running individual hget operations for each ID
             %tmpfilter = map { $_ => $redis->hget( $_, "lastreadtime" ) } @filtered;
         } else {
             my $result = $redis->evalsha($sha, 0, @filtered);

--- a/lib/LANraragi/Model/Setup.pm
+++ b/lib/LANraragi/Model/Setup.pm
@@ -7,6 +7,9 @@ use LANraragi::Model::Config qw(get_redis_config);
 use LANraragi::Utils::Logging qw(get_logger);
 use LANraragi::Model::Category;
 
+use Exporter 'import';
+our @EXPORT_OK = qw(first_install_actions);
+
 # first_install_actions()
 # Setup tasks for first-time installations. New installs are checked by confirming updated
 # user settings. On first installation, create default 'Favorites' category link it to the bookmark

--- a/lib/LANraragi/Model/Setup.pm
+++ b/lib/LANraragi/Model/Setup.pm
@@ -1,0 +1,32 @@
+package LANraragi::Model::Setup;
+use strict;
+use warnings;
+use utf8;
+
+use LANraragi::Model::Config qw(get_redis_config);
+use LANraragi::Utils::Logging qw(get_logger);
+use LANraragi::Model::Category;
+
+# first_install_actions()
+# Setup tasks for first-time installations. New installs are checked by confirming updated
+# user settings. On first installation, create default 'Favorites' category link it to the bookmark
+# button. Returns 1 if is first-time installation, else 0.
+sub first_install_actions {
+    my $redis = LANraragi::Model::Config::get_redis_config();
+    my $logger = LANraragi::Utils::Logging::get_logger( "Config", "lanraragi" );
+    unless ( $redis->hexists('LRR_CONFIG', 'htmltitle') ) {
+        $logger->info("First-time installation detected!");
+        $redis->hset('LRR_CONFIG', 'htmltitle', 'LANraragi');
+
+        $logger->debug("Creating first category...");
+        my $default_category_id = LANraragi::Model::Category::create_category("🔖 Favorites", "", 0, "");
+        LANraragi::Model::Category::update_bookmark_link($default_category_id);
+        $logger->info("Created default Favorites category.");
+        $redis->quit();
+        return 1;
+    }
+    $redis->quit();
+    return 0;
+}
+
+1;

--- a/lib/LANraragi/Model/Setup.pm
+++ b/lib/LANraragi/Model/Setup.pm
@@ -13,7 +13,7 @@ use LANraragi::Model::Category;
 # button. Returns 1 if is first-time installation, else 0.
 sub first_install_actions {
     my $redis = LANraragi::Model::Config::get_redis_config();
-    my $logger = LANraragi::Utils::Logging::get_logger( "Config", "lanraragi" );
+    my $logger = get_logger( "Config", "lanraragi" );
     unless ( $redis->hexists('LRR_CONFIG', 'htmltitle') ) {
         $logger->info("First-time installation detected!");
         $redis->hset('LRR_CONFIG', 'htmltitle', 'LANraragi');

--- a/lib/LANraragi/Model/Stats.pm
+++ b/lib/LANraragi/Model/Stats.pm
@@ -14,7 +14,7 @@ use LANraragi::Model::Tankoubon;
 
 use LANraragi::Utils::Generic  qw(is_archive intersect_arrays);
 use LANraragi::Utils::String   qw(trim trim_CRLF trim_url);
-use LANraragi::Utils::Database qw(redis_decode redis_encode);
+use LANraragi::Utils::Redis    qw(redis_decode redis_encode);
 use LANraragi::Utils::Logging  qw(get_logger);
 
 sub get_archive_count {

--- a/lib/LANraragi/Model/Stats.pm
+++ b/lib/LANraragi/Model/Stats.pm
@@ -16,6 +16,7 @@ use LANraragi::Utils::Generic  qw(is_archive intersect_arrays);
 use LANraragi::Utils::String   qw(trim trim_CRLF trim_url);
 use LANraragi::Utils::Redis    qw(redis_decode redis_encode);
 use LANraragi::Utils::Logging  qw(get_logger);
+use LANraragi::Utils::Database qw(get_arcsize);
 
 sub get_archive_count {
     my $redis = LANraragi::Model::Config->get_redis_search;
@@ -243,7 +244,7 @@ sub compute_content_size {
 
     $redis_db->multi;
     foreach my $id (@keys) {
-        LANraragi::Utils::Database::get_arcsize( $redis_db, $id );
+        get_arcsize( $redis_db, $id );
     }
     my @result = $redis_db->exec;
     $redis_db->quit;

--- a/lib/LANraragi/Model/Tankoubon.pm
+++ b/lib/LANraragi/Model/Tankoubon.pm
@@ -11,9 +11,10 @@ use Redis;
 use Mojo::JSON qw(decode_json encode_json);
 use List::Util qw(min);
 
-use LANraragi::Utils::Database qw(redis_encode redis_decode invalidate_cache get_archive_json_multi get_tankoubons_by_file);
+use LANraragi::Utils::Database qw(invalidate_cache get_archive_json_multi get_tankoubons_by_file);
 use LANraragi::Utils::Generic  qw(array_difference filter_hash_by_keys);
 use LANraragi::Utils::Logging  qw(get_logger);
+use LANraragi::Utils::Redis    qw(redis_decode redis_encode);
 
 my %TANK_METADATA = ( "name", 0, "summary", -1, "tags", -2 );
 

--- a/lib/LANraragi/Model/Upload.pm
+++ b/lib/LANraragi/Model/Upload.pm
@@ -15,11 +15,11 @@ use File::Copy qw(move);
 use LANraragi::Utils::Archive  qw(extract_thumbnail);
 use LANraragi::Utils::Database qw(invalidate_cache compute_id set_title set_summary);
 use LANraragi::Utils::Logging  qw(get_logger);
-use LANraragi::Utils::Database qw(redis_encode);
+use LANraragi::Utils::Redis    qw(redis_encode);
 use LANraragi::Utils::Generic  qw(is_archive get_bytelength);
 use LANraragi::Utils::String   qw(trim trim_CRLF trim_url);
 
-use LANraragi::Model::Config;
+use LANraragi::Model::Config   qw(get_userdir);
 use LANraragi::Model::Plugins;
 use LANraragi::Model::Category;
 

--- a/lib/LANraragi/Model/Upload.pm
+++ b/lib/LANraragi/Model/Upload.pm
@@ -13,7 +13,7 @@ use File::Find qw(find);
 use File::Copy qw(move);
 
 use LANraragi::Utils::Archive  qw(extract_thumbnail);
-use LANraragi::Utils::Database qw(invalidate_cache compute_id set_title set_summary);
+use LANraragi::Utils::Database qw(invalidate_cache compute_id set_title set_summary add_archive_to_redis add_timestamp_tag add_pagecount add_arcsize);
 use LANraragi::Utils::Logging  qw(get_logger);
 use LANraragi::Utils::Redis    qw(redis_encode);
 use LANraragi::Utils::Generic  qw(is_archive get_bytelength);
@@ -84,7 +84,7 @@ sub handle_incoming_file ( $tempfile, $catid, $tags, $title, $summary ) {
 
     # Add the file to the database ourselves so Shinobu doesn't do it
     # This allows autoplugin to be ran ASAP.
-    my $name = LANraragi::Utils::Database::add_archive_to_redis( $id, $output_file, $output_file, $redis, $redis_search );
+    my $name = add_archive_to_redis( $id, $output_file, $output_file, $redis, $redis_search );
 
     # If additional tags were given to the sub, add them now.
     if ($tags) {
@@ -138,9 +138,9 @@ sub handle_incoming_file ( $tempfile, $catid, $tags, $title, $summary ) {
 
     # Now that the file has been copied, we can add the timestamp tag and calculate pagecount.
     # (The file being physically present is necessary in case last modified time is used)
-    LANraragi::Utils::Database::add_timestamp_tag( $redis, $id );
-    LANraragi::Utils::Database::add_pagecount( $redis, $id );
-    LANraragi::Utils::Database::add_arcsize( $redis, $id );
+    add_timestamp_tag( $redis, $id );
+    add_pagecount( $redis, $id );
+    add_arcsize( $redis, $id );
     $redis->quit();
     $redis_search->quit();
 

--- a/lib/LANraragi/Plugin/Metadata/RegexParse.pm
+++ b/lib/LANraragi/Plugin/Metadata/RegexParse.pm
@@ -8,7 +8,7 @@ use warnings;
 use File::Basename;
 
 use LANraragi::Model::Plugins;
-use LANraragi::Utils::Database qw(redis_encode redis_decode);
+use LANraragi::Utils::Redis    qw(redis_encode redis_decode);
 use LANraragi::Utils::Logging  qw(get_plugin_logger);
 use LANraragi::Utils::String   qw(trim);
 use Scalar::Util               qw(looks_like_number);

--- a/lib/LANraragi/Plugin/Metadata/nHentai.pm
+++ b/lib/LANraragi/Plugin/Metadata/nHentai.pm
@@ -13,7 +13,7 @@ use File::Basename;
 #You can also use the LRR Internal API when fitting.
 use LANraragi::Model::Plugins;
 use LANraragi::Utils::Logging qw(get_plugin_logger);
-use LANraragi::Utils::Database qw(redis_decode);
+use LANraragi::Utils::Redis qw(redis_decode);
 
 #Meta-information about your plugin.
 sub plugin_info {

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -26,6 +26,7 @@ use File::Temp qw(tempdir);
 use LANraragi::Utils::TempFolder qw(get_temp);
 use LANraragi::Utils::Logging    qw(get_logger);
 use LANraragi::Utils::Generic    qw(is_image shasum_str);
+use LANraragi::Utils::Redis      qw(redis_decode);
 
 # Utilitary functions for handling Archives.
 # Relies on Libarchive, ImageMagick and GhostScript for PDFs.
@@ -319,7 +320,7 @@ sub extract_single_file ( $archive, $filepath ) {
         my @files    = $peek->files;
 
         for my $name (@files) {
-            my $decoded_name = LANraragi::Utils::Database::redis_decode($name);
+            my $decoded_name = redis_decode($name);
 
             # This sub can receive either encoded or raw filenames, so we have to test for both.
             if ( $decoded_name eq $filepath || $name eq $filepath ) {

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -11,6 +11,8 @@ use FindBin;
 use Encode;
 use File::ReadBackwards;
 use Compress::Zlib;
+use LANraragi::Model::Config;
+use LANraragi::Utils::Redis qw(redis_decode);
 
 # Contains all functions related to logging.
 use Exporter 'import';
@@ -105,7 +107,7 @@ sub get_logger {
 
             # We'd like to make sure we always show proper UTF-8.
             # redis_decode, while not initially designed for this, does the job.
-            $logstring = LANraragi::Utils::Database::redis_decode($logstring);
+            $logstring = redis_decode($logstring);
 
             return "[$time2] [$pgname] [$level] $logstring\n";
         }

--- a/lib/LANraragi/Utils/Minion.pm
+++ b/lib/LANraragi/Utils/Minion.pm
@@ -12,7 +12,7 @@ use MCE::Shared;
 use Config;
 
 use LANraragi::Utils::Logging    qw(get_logger);
-use LANraragi::Utils::Database   qw(redis_decode);
+use LANraragi::Utils::Redis      qw(redis_decode);
 use LANraragi::Utils::Archive    qw(extract_thumbnail);
 use LANraragi::Utils::Plugins    qw(get_downloader_for_url get_plugin get_plugin_parameters use_plugin);
 use LANraragi::Utils::String     qw(trim_url);
@@ -214,7 +214,7 @@ sub add_tasks {
                             my $node = pop @stack;
                             next if $visited->get( $node );
 
-                            # Mark the node as visited   
+                            # Mark the node as visited
                             $visited->set( $node, 1 );
                             push @group, $node;
 
@@ -357,20 +357,20 @@ sub add_tasks {
                     );
                     return;
                 }
-                
+
                 # Check if the plugin provided a direct file path instead of a URL to download
                 if ( exists $plugin_result->{file_path} ) {
                     my $tempfile = $plugin_result->{file_path};
                     $logger->info("Plugin directly provided file at: $tempfile");
-                    
+
                     # Add the url as a source: tag
                     my $tag = "source:$og_url";
-                    
+
                     # Hand off the result to handle_incoming_file
                     my ( $status_code, $id, $title, $message ) =
                       LANraragi::Model::Upload::handle_incoming_file( $tempfile, $catid, $tag, "", "" );
                     my $status = $status_code == 200 ? 1 : 0;
-                    
+
                     $job->finish(
                         {   success  => $status,
                             url      => $og_url,

--- a/lib/LANraragi/Utils/Plugins.pm
+++ b/lib/LANraragi/Utils/Plugins.pm
@@ -5,7 +5,7 @@ use warnings;
 use utf8;
 
 use Mojo::JSON                 qw(decode_json);
-use LANraragi::Utils::Database qw(redis_decode);
+use LANraragi::Utils::Redis    qw(redis_decode);
 use LANraragi::Utils::Logging  qw(get_logger);
 
 # Plugin system ahoy - this makes the LANraragi::Utils::Plugins::plugins method available

--- a/lib/LANraragi/Utils/Redis.pm
+++ b/lib/LANraragi/Utils/Redis.pm
@@ -1,0 +1,39 @@
+package LANraragi::Utils::Redis;
+
+use v5.36;
+
+use strict;
+use warnings;
+use utf8;
+
+use Encode qw(decode_utf8 encode_utf8);
+use Unicode::Normalize qw(NFC);
+
+# Don't import anything from LANraragi here, this is used by Config and thus cycles are likely
+
+
+use Exporter 'import';
+our @EXPORT_OK = qw(redis_encode redis_decode);
+
+# Normalize the string to Unicode NFC, then layer on redis_encode for Redis-safe serialization.
+sub redis_encode ($data) {
+
+    my $NFC_data = NFC($data);
+    return encode_utf8($NFC_data);
+}
+
+# Final Solution to the Unicode glitches -- Eval'd double-decode for data obtained from Redis.
+# This should be a one size fits-all function.
+sub redis_decode ($data) {
+
+    # Setting FB_CROAK tells encode to die instantly if it encounters any errors.
+    # Without this setting, it typically tries to replace characters... which might already be valid UTF8!
+    eval { $data = decode_utf8( $data, Encode::FB_CROAK ) };
+
+    # Do another UTF-8 decode just in case the data was double-encoded
+    eval { $data = decode_utf8( $data, Encode::FB_CROAK ) };
+
+    return $data;
+}
+
+1;


### PR DESCRIPTION
This PR cleans up some imports with the main focus to avoid a dependency cycle between Config and Logger. It also moves some stuff away from Database to vastly reduce the risk of new cycles.

As a treat, there's also some more explicit imports!