### PR TITLE
Fix/workaround excessively long archive names

### DIFF
--- a/lib/LANraragi/Model/Upload.pm
+++ b/lib/LANraragi/Model/Upload.pm
@@ -84,7 +84,7 @@ sub handle_incoming_file ( $tempfile, $catid, $tags, $title, $summary ) {
 
     # Add the file to the database ourselves so Shinobu doesn't do it
     # This allows autoplugin to be ran ASAP.
-    my $name = LANraragi::Utils::Database::add_archive_to_redis( $id, $output_file, $redis, $redis_search );
+    my $name = LANraragi::Utils::Database::add_archive_to_redis( $id, $output_file, $output_file, $redis, $redis_search );
 
     # If additional tags were given to the sub, add them now.
     if ($tags) {

--- a/tools/build/windows/install.sh
+++ b/tools/build/windows/install.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Run it with unlimited jobs to improve performance
+export MAKEFLAGS="-j"
+
 # Install cpanm
 curl -L https://cpanmin.us | perl - App::cpanminus
 

--- a/tools/build/windows/perl.exe.manifest
+++ b/tools/build/windows/perl.exe.manifest
@@ -1,15 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity type="win32" name="perl" version="1.0.0.0" />
-
+  <assemblyIdentity type="win32" name="Perl" version="0.0.0.0" />
+  <description>Perl</description>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+  <security>
+    <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+      <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+    </requestedPrivileges>
+  </security>
+</trustInfo>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
     </application>
   </compatibility>
-  
-  <application>
+  <dependency>
+    <dependentAssembly>
+        <assemblyIdentity type="Win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*" />
+    </dependentAssembly>
+  </dependency>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
       <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
     </windowsSettings>
   </application>

--- a/tools/install.pl
+++ b/tools/install.pl
@@ -160,6 +160,8 @@ if ( $back || $full ) {
         say("Installing dependencies for windows systems... (This will do nothing if the package is there already)");
 
         install_package( "Win32::Process", $cpanopt );
+        install_package( "Win32::FileSystemHelper", "https://github.com/Guerra24/Win32-FileSystemHelper/archive/8aa41c19e9cade280ebdac6dfc021071255b6310.zip " . $cpanopt );
+        install_package( "File::ChangeNotify::Watcher::Win32", "https://github.com/Guerra24/File-ChangeNotify-Watcher-Win32/archive/f5aeedb68d10c9dea02e2b184c7d5c341dbfe8e5.zip " .$cpanopt );
     }
 
     if ( system( "cpanm --installdeps ./tools/. --notest" . $cpanopt ) != 0 ) {


### PR DESCRIPTION
Allows LRR to handle super extra long paths. This is more of a workaround using 8.3 filenames rather than a proper fix but said fix would involve a more invasive change as perl is hardcoded to paths of 260 characters max.

This PR adds 2 dependencies Windows:
- [Guerra24/Win32-FileSystemHelper](https://github.com/Guerra24/Win32-FileSystemHelper)
  C# lib and FFI layer.
- [Guerra24/File-ChangeNotify-Watcher-Win32](https://github.com/Guerra24/File-ChangeNotify-Watcher-Win32)
  File watcher implementation.

The helper has some limitations (single directory only and [hardcoded list](https://github.com/Guerra24/Win32-FileSystemHelper/blob/master/csharp/NativeExports.cs#L32) of file types) as I don't expect other projects to use it.

Both dependencies can be installed using cpanm as long as a dotnet sdk is installed in the default location.
