### PR TITLE
Fix reader.js regex pattern

### DIFF
--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -131,7 +131,7 @@ Reader.initializeAll = function () {
             let { title } = data;
 
             // Regex look in tags for artist
-            const artist = data.tags.match(/.*artist:([^,]*),.*/i);
+            const artist = data.tags.match(/artist:([^,]+)(?:,|$)/i);
             if (artist) {
                 title = `${title} by ${artist[1]}`;
             }


### PR DESCRIPTION
When artist name is the last tag, the UI will not display "{title} by {artist}" because the previous regex requires the artist match to be followed by a ",".

Regex changes:
- enforce artist name to be nonempty
- artist name can end in comma or EOS

The leading `.*` is also removed, it makes no difference in practice.