### PR TITLE
Actually remove Parallel::Loops from dependency list

### DIFF
--- a/tools/Documentation/installing-lanraragi/jail.md
+++ b/tools/Documentation/installing-lanraragi/jail.md
@@ -39,7 +39,6 @@ pkg install libressl
 pkg install npm
 pkg install p5-mojolicious
 pkg install git
-cpan Parallel::Loops
 ```
 
 {% hint style="info" %}

--- a/tools/cpanfile
+++ b/tools/cpanfile
@@ -48,7 +48,6 @@ requires 'Minion::Backend::Redis', 0.002;
 
 # Background Worker (Shinobu)
 requires 'Proc::Simple',       1.32;
-requires 'Parallel::Loops',    0.10;
 requires 'MCE::Loop',          1.901;
 requires 'MCE::Shared',        1.893;
 requires 'Sys::CpuAffinity',   1.12;


### PR DESCRIPTION
In https://github.com/Difegue/LANraragi/commit/30999af5ca1a625ff2a65497d40f412b8549a51d (part of https://github.com/Difegue/LANraragi/pull/1266) `Parallel::Loops` was replaced with `MCE`.
I noticed that it is still mentioned in the `cpanfile`.

I also found another mention of `Parallel::Loops` in the OpenBSD/jail docs. The file I changed hasn't been updated for like 4 years, so it is probably not up-to-date anyways.
In any case, I removed it from there too.
