### PR TITLE
Bail if cpanm fails in install_package

### DIFF
--- a/tools/install.pl
+++ b/tools/install.pl
@@ -242,7 +242,9 @@ sub install_package {
 
     if ($@) {
         say("$package not installed! Trying to install now using cpanm$cpanopt");
-        system("cpanm --notest $package $cpanopt");
+        if ( system("cpanm --notest $package $cpanopt") != 0 ) {
+            die "Something went wrong while installing $package - Bailing out.";
+        }
     } else {
         say("$package package installed, proceeding...");
     }


### PR DESCRIPTION
This way, if you don't have internet access while running this script, you'll get an error if you don't already have the package installed.

Previously, even if the cpanm call failed, the script would continue running.

Note: The other `cpanm` call in the script already has similar bail logic.