### PR TITLE
Better handling of double-wide characters in paths that are longer than 260 bytes

### DIFF
--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -44,7 +44,6 @@ use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );
 
 BEGIN {
     if ( !IS_UNIX ) {
-        require Win32;
         require Win32::FileSystemHelper;
     }
 }
@@ -58,13 +57,10 @@ my $inotifysub = sub {
     my $name = $e->path;
     my $type = $e->type;
 
-    # Filewatcher on Windows returns backward slashes, convert them to forward slash to match everything else
     if ( !IS_UNIX ) {
-        $name =~ s/\\/\//g;
-
-        # If this is a super long file convert it to short name
+        # If this is a super long file or uses a lot of double-wide characters convert it to short name
         if ( length($name) >= 260 ) {
-            $name = Win32::GetShortPathName($name);
+            $name = Win32::FileSystemHelper::get_short_path($name);
         }
     }
 
@@ -140,9 +136,9 @@ sub update_filemap {
                 return if -d $_;    #Directories are excluded on the spot
                 return unless is_archive($_);
                 if ( !IS_UNIX ) {
-                    # If this is a super long file convert it to short name
+                    # If this is a super long file or uses a lot of double-wide characters convert it to short name
                     if ( length($_) >= 260 ) {
-                        $_ = Win32::GetShortPathName($_);
+                        $_ = Win32::FileSystemHelper::get_short_path($_);
                     }
                 }
                 push @files, $_;    #Push files to array

--- a/tools/install.pl
+++ b/tools/install.pl
@@ -160,8 +160,8 @@ if ( $back || $full ) {
         say("Installing dependencies for windows systems... (This will do nothing if the package is there already)");
 
         install_package( "Win32::Process", $cpanopt );
-        install_package( "Win32::FileSystemHelper", "https://github.com/Guerra24/Win32-FileSystemHelper/archive/8aa41c19e9cade280ebdac6dfc021071255b6310.zip " . $cpanopt );
-        install_package( "File::ChangeNotify::Watcher::Win32", "https://github.com/Guerra24/File-ChangeNotify-Watcher-Win32/archive/f5aeedb68d10c9dea02e2b184c7d5c341dbfe8e5.zip " .$cpanopt );
+        install_package( "Win32::FileSystemHelper", "https://github.com/Guerra24/Win32-FileSystemHelper/archive/f7843f6b0b4f4e95f308db2ab558445079ec2de6.zip " . $cpanopt );
+        install_package( "File::ChangeNotify::Watcher::Win32", "https://github.com/Guerra24/File-ChangeNotify-Watcher-Win32/archive/7cb4e60823569cca8e7652d19b1ba5b5cac00a16.zip " .$cpanopt );
     }
 
     if ( system( "cpanm --installdeps ./tools/. --notest" . $cpanopt ) != 0 ) {


### PR DESCRIPTION
- Fixes an issue where paths with double-wide characters were less than 260 characters but byte-wise were longer breaking perl.
- Fixes an issue with shortname paths not being returned correctly for the same case above when files got deleted from the content folder.
- Path normalization is now done in C# land instead.

Fixes #1345 