### PR TITLE
Embed search link to artist name for archives

### DIFF
--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -144,7 +144,6 @@ Reader.initializeAll = function () {
                 const artistSearchUrl = `/?sort=0&q=artist%3A${encodeURIComponent(artistName)}%24&`;
                 const link = $('<a></a>')
                     .attr('href', artistSearchUrl)
-                    .attr('style', 'color: inherit; text-decoration: underline;')
                     .text(artistName);
                 const titleContainer = $('<span></span>')
                     .text(`${title} by `)

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -141,7 +141,7 @@ Reader.initializeAll = function () {
             const artist = data.tags.match(/artist:([^,]+)(?:,|$)/i);
             if (artist) {
                 const artistName = artist[1];
-                const artistSearchUrl = `/?sort=0&q=artist%3A${encodeURIComponent(artistName)}&`;
+                const artistSearchUrl = `/?sort=0&q=artist%3A${encodeURIComponent(artistName)}%24&`;
                 const link = $('<a></a>')
                     .attr('href', artistSearchUrl)
                     .attr('style', 'color: inherit; text-decoration: underline;')

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -135,9 +135,15 @@ Reader.initializeAll = function () {
             if (artist) {
                 const artistName = artist[1];
                 const artistSearchUrl = `/?sort=0&q=artist%3A${encodeURIComponent(artistName)}&`;
-                const titleWithArtist = `${title} by <a href="${artistSearchUrl}" style="color: inherit; text-decoration: underline;">${artistName}</a>`;
-                $("#archive-title").html(titleWithArtist);
-                $("#archive-title-overlay").html(titleWithArtist);
+                const link = $('<a></a>')
+                    .attr('href', artistSearchUrl)
+                    .attr('style', 'color: inherit; text-decoration: underline;')
+                    .text(artistName);
+                const titleContainer = $('<span></span>')
+                    .text(`${title} by `)
+                    .append(link);
+                $("#archive-title").empty().append(titleContainer);
+                $("#archive-title-overlay").empty().append(titleContainer.clone());
             } else {
                 $("#archive-title").text(title);
                 $("#archive-title-overlay").text(title);

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -133,11 +133,15 @@ Reader.initializeAll = function () {
             // Regex look in tags for artist
             const artist = data.tags.match(/.*artist:([^,]*),.*/i);
             if (artist) {
-                title = `${title} by ${artist[1]}`;
+                const artistName = artist[1];
+                const artistSearchUrl = `/?sort=0&q=artist%3A${encodeURIComponent(artistName)}&`;
+                const titleWithArtist = `${title} by <a href="${artistSearchUrl}" style="color: inherit; text-decoration: underline;">${artistName}</a>`;
+                $("#archive-title").html(titleWithArtist);
+                $("#archive-title-overlay").html(titleWithArtist);
+            } else {
+                $("#archive-title").text(title);
+                $("#archive-title-overlay").text(title);
             }
-
-            $("#archive-title").text(title);
-            $("#archive-title-overlay").text(title);
             if (data.pagecount) { $(".max-page").text(data.pagecount); }
             document.title = title;
 


### PR DESCRIPTION
> "Oh, this is from *this* artist, would be nice if I had a quick way to get all their works..."

Turns the artist name (if exists for an archive) to a link in reader mode.

<img width="802" height="94" alt="image" src="https://github.com/user-attachments/assets/337fda77-e655-43d6-b887-f1c1869cd620" />

When clicked, opens search by the exact artist name.

<img width="1031" height="172" alt="image" src="https://github.com/user-attachments/assets/b6061c7d-d8aa-4fc7-aa35-1c63dae30f8c" />

Seems to still work with special characters as well:

<img width="1031" height="83" alt="image" src="https://github.com/user-attachments/assets/6381b00f-0e9f-42f3-b7af-b75afb3ebeed" />
