### PR TITLE
Fix content disposition regression when viewing images directly

### DIFF
--- a/lib/LANraragi/Model/Archive.pm
+++ b/lib/LANraragi/Model/Archive.pm
@@ -268,7 +268,9 @@ sub serve_page {
 
         # resize_image always converts the image to jpg
         $self->render_file(
-            data => $content
+            data                => $content,
+            content_disposition => "inline",
+            format              => "jpg"
         );
     } else {
 
@@ -278,8 +280,9 @@ sub serve_page {
         $logger->debug("Data size:".length($content));
         # Serve extracted file directly
         $self->render_file(
-            data   => $content,
-            format => substr( $file_ext, 1 )
+            data                => $content,
+            content_disposition => "inline",
+            format              => substr( $file_ext, 1 )
         );
     }
 }


### PR DESCRIPTION
Fixes the browser to trying to immediately save any images opened via right click or the view full-size button. (Regression from 34a9ac4)