### PR TITLE
Remove build warning for install.pl

### DIFF
--- a/tools/install.pl
+++ b/tools/install.pl
@@ -81,7 +81,7 @@ unless ( @ARGV > 0 ) {
 my $front  = $ARGV[0] eq "install-front";
 my $back   = $ARGV[0] eq "install-back";
 my $full   = $ARGV[0] eq "install-full";
-my $legacy = $ARGV[1] eq "legacy";
+my $legacy = defined $ARGV[1] && $ARGV[1] eq "legacy";
 
 say( "Working Directory: " . getcwd );
 say("");


### PR DESCRIPTION
Remove `Use of uninitialized value $ARGV[1] in string eq at ./tools/install.pl line 84.` logs from docker builds.