### PR TITLE
Fix macOS metadata worker crashing due to Objective-C fork safety

### DIFF
--- a/tools/build/homebrew/lanraragi
+++ b/tools/build/homebrew/lanraragi
@@ -48,6 +48,11 @@ mkdir -p "${LRR_DATABASE_DIRECTORY}"
 mkdir -p "${LRR_LOG_DIRECTORY}"
 mkdir -p "${LRR_TEMP_DIRECTORY}"
 
+# macOS-specific fixes -- unsafe forking needs to be allowed or some metadata plugins crash on creation
+if [[ ${OSTYPE} == "darwin"* ]]; then
+  export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+fi
+
 # @INC export
 export PERL5LIB="${workdir}/lib/perl5"
 


### PR DESCRIPTION
So this took me a lot of troubleshooting to find as it produced no errors in the Lanraragi logs. Certain metadata agents, such as FAKKU or e-hentai would crash upon making their HTTP API calls. 
Lanraragi just showed me "Error while fetching tagsTypeError: Failed to fetch" which didn't tell me a lot. 
Through a lot of troubleshooting I found out that the Objective-C runtime aborts child processes if class initialization is in progress during fork(). By setting OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES we prevent objc_initializeAfterForkError and allow workers to run. A much more involved fix would be to change to a non-forking worker implementation which would render this workaround obsolete, but this works fine without major codebase changes by only changing the brew wrapper to allow unsafe forking for Lanraragi child processes.