### PR TITLE
Enable lazy loading for the quick thumbnail list

### DIFF
--- a/public/css/lrr.css
+++ b/public/css/lrr.css
@@ -286,6 +286,11 @@ p#nb {
   color: lightskyblue;
 }
 
+.quick-thumbnail {
+    /** This is only intended as a hint to allow loading="lazy" to do it's thing */
+    min-width: 100px;
+}
+
 .quick-thumbnail:hover>.page-number {
   z-index: 300;
   background-color: #000000;

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -1001,7 +1001,7 @@ Reader.initializeArchiveOverlay = function () {
         const thumbnail = `
             <div class='${thumbCss} quick-thumbnail' page='${index}' style='display: inline-block; cursor: pointer'>
                 <span class='page-number'>${I18N.ReaderPage(page)}</span>
-                <img src="${thumbnailUrl}" id="${index}_thumb" />
+                <img src="${thumbnailUrl}" id="${index}_thumb" loading="lazy" />
                 <i id="${index}_spinner" class="fa fa-4x fa-circle-notch fa-spin ttspinner" style="display:flex;justify-content: center; align-items: center;"></i>
             </div>`;
 


### PR DESCRIPTION
This PR enables lazy-loading for the thumbnails in the archive overview. This can cut down the request spam a metric fuck-ton for large archives, which hopefully makes things a bit less painful.