### PR TITLE
Ignore MacOS garbage files

### DIFF
--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -181,8 +181,8 @@ sub get_filelist ($archive) {
             die $r->error_string;
         }
 
-        my $e = Archive::Libarchive::Entry->new;
-        my $peek_for_signatures = Archive::Libarchive::Peek->new( filename => create_path( $archive ) );
+        my $e       = Archive::Libarchive::Entry->new;
+        my $peek    = Archive::Libarchive::Peek->new( filename => create_path( $archive ) );
         while ( $r->next_header($e) == ARCHIVE_OK ) {
 
             my $filesize = ( $e->size_is_set eq 64 ) ? $e->size : 0;
@@ -194,7 +194,7 @@ sub get_filelist ($archive) {
             }
 
             if ( is_apple_signature_like_path( $filename ) ) {
-                if (is_apple_signature($peek_for_signatures, $filename) ) {
+                if (is_apple_signature($peek, $filename) ) {
                     $r->read_data_skip;
                     next;
                 }

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -137,7 +137,13 @@ sub extract_thumbnail ( $thumbdir, $id, $page, $set_cover, $use_hq ) {
     }
 
     # Thumbnail generation
-    generate_thumbnail( $arcimg, $thumbname, $use_hq, $use_jxl );
+    no warnings 'experimental::try';
+    try {
+        generate_thumbnail( $arcimg, $thumbname, $use_hq, $use_jxl );
+    } catch ($e) {
+        $logger->error("Thumbnail generation failed for archive '$file' entry '$requested_image' -> '$thumbname': $e");
+        die $e;
+    }
 
     return $thumbname;
 }

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -182,14 +182,26 @@ sub get_filelist ($archive) {
         }
 
         my $e = Archive::Libarchive::Entry->new;
+        my $peek_for_signatures = Archive::Libarchive::Peek->new( filename => create_path( $archive ) );
         while ( $r->next_header($e) == ARCHIVE_OK ) {
 
             my $filesize = ( $e->size_is_set eq 64 ) ? $e->size : 0;
             my $filename = $e->pathname;
-            if ( is_image($filename) ) {
-                push @files, $filename;
-                push @sizes, $filesize;
+
+            unless ( is_image($filename) ) {
+                $r->read_data_skip;
+                next;
             }
+
+            if ( is_appledouble_like_path( $filename ) ) {
+                if (is_appledouble_signature($peek_for_signatures, $filename) ) {
+                    $r->read_data_skip;
+                    next;
+                }
+            }
+
+            push @files, $filename;
+            push @sizes, $filesize;
             $r->read_data_skip;
         }
 
@@ -209,6 +221,50 @@ sub get_filelist ($archive) {
 
     # Return files and sizes in a hashref
     return ( \@files, \@sizes );
+}
+
+# is_appledouble_signature(peek, path)
+# Uses libarchive::peek to check AppleDouble magic.
+# return 0 if not ignore, 1 if ignore.
+sub is_appledouble_signature ( $peek, $path ) {
+    my $logger = get_logger( "Archive", "lanraragi" );
+    unless (defined $peek && defined $path) {
+        $logger->warn("path or peek are undefined. Skipping.");
+        return 0;
+    }
+
+    $logger->info("Checking AppleDouble magic for: $path");
+    my $data = eval {
+        $peek->file($path)
+    };
+    if (!$data) {
+        $logger->info("Peek returned no data for $path; not ignoring by signature");
+        return 0;
+    }
+    if ( length($data) < 8 ) {
+        $logger->info("Data too short (<8 bytes) for $path; not ignoring by signature");
+        return 0;
+    }
+
+    # is_appledouble_magic(prefix)
+    # AppleDouble header: 00 05 16 07 00 02 00 00
+    my $prefix = substr($data, 0, 8);
+    if ( defined $prefix && length($prefix) >= 8 && $prefix eq "\x00\x05\x16\x07\x00\x02\x00\x00" ) {
+        $logger->info("AppleDouble magic matched for $path");
+        return 1;
+    }
+    $logger->info("AppleDouble magic not matched for $path");
+    return 0;
+}
+
+
+# check if image file is garbage or should be ignored.
+sub is_appledouble_like_path ( $path ) {
+    my $p = $path // '';
+    return 1 if $p =~ m{(^|/)__MACOSX/};
+    my ( $name ) = fileparse( $p );
+    return 1 if defined $name && $name =~ /^\._/;
+    return 0;
 }
 
 # Uses libarchive::peek to figure out if $archive contains $file.

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -193,8 +193,8 @@ sub get_filelist ($archive) {
                 next;
             }
 
-            if ( is_appledouble_like_path( $filename ) ) {
-                if (is_applefork_signature($peek_for_signatures, $filename) ) {
+            if ( is_apple_signature_like_path( $filename ) ) {
+                if (is_apple_signature($peek_for_signatures, $filename) ) {
                     $r->read_data_skip;
                     next;
                 }
@@ -223,26 +223,26 @@ sub get_filelist ($archive) {
     return ( \@files, \@sizes );
 }
 
-# is_applefork_signature(peek, path)
+# is_apple_signature(peek, path)
 # Uses libarchive::peek to check AppleDouble/AppleSingle magic.
 # Returns 1 if the file header matches a known Apple fork format, else 0.
-sub is_applefork_signature ( $peek, $path ) {
+sub is_apple_signature ( $peek, $path ) {
     my $logger = get_logger( "Archive", "lanraragi" );
     unless (defined $peek && defined $path) {
         $logger->warn("path or peek are undefined. Skipping.");
         return 0;
     }
 
-    $logger->info("Checking Apple fork magic for: $path");
+    $logger->debug("Checking Apple fork magic for: $path");
     my $data = eval {
         $peek->file($path)
     };
     if (!$data) {
-        $logger->info("Peek returned no data for $path; not ignoring by signature");
+        $logger->debug("Peek returned no data for $path; not ignoring by signature");
         return 0;
     }
     if ( length($data) < 8 ) {
-        $logger->info("Data too short (<8 bytes) for $path; not ignoring by signature");
+        $logger->debug("Data too short (<8 bytes) for $path; not ignoring by signature");
         return 0;
     }
 
@@ -255,21 +255,21 @@ sub is_applefork_signature ( $peek, $path ) {
     my $is_appledouble = substr($prefix, 0, 4) eq "\x00\x05\x16\x07";
 
     if ($is_appledouble) {
-        $logger->info("AppleDouble magic matched for $path");
+        $logger->debug("AppleDouble magic matched for $path");
         return 1;
     }
     if ($is_applesingle) {
-        $logger->info("AppleSingle magic matched for $path");
+        $logger->debug("AppleSingle magic matched for $path");
         return 1;
     }
 
-    $logger->info("Apple fork magic not matched for $path");
+    $logger->debug("Apple fork magic not matched for $path");
     return 0;
 }
 
 
 # check if image file is garbage or should be ignored.
-sub is_appledouble_like_path ( $path ) {
+sub is_apple_signature_like_path ( $path ) {
     my $p = $path // '';
     return 1 if $p =~ m{(^|/)__MACOSX/};
     my ( $name ) = fileparse( $p );

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -181,8 +181,7 @@ sub get_filelist ($archive) {
             die $r->error_string;
         }
 
-        my $e       = Archive::Libarchive::Entry->new;
-        my $peek    = Archive::Libarchive::Peek->new( filename => create_path( $archive ) );
+        my $e = Archive::Libarchive::Entry->new;
         while ( $r->next_header($e) == ARCHIVE_OK ) {
 
             my $filesize = ( $e->size_is_set eq 64 ) ? $e->size : 0;
@@ -194,6 +193,7 @@ sub get_filelist ($archive) {
             }
 
             if ( is_apple_signature_like_path( $filename ) ) {
+                my $peek = Archive::Libarchive::Peek->new( filename => create_path( $archive ) );
                 if (is_apple_signature($peek, $filename) ) {
                     $r->read_data_skip;
                     next;

--- a/tests/LANraragi/Utils/Archive.t
+++ b/tests/LANraragi/Utils/Archive.t
@@ -6,15 +6,15 @@ use Test::More;
 
 BEGIN { use_ok('LANraragi::Utils::Archive'); }
 
-subtest 'testing is_appledouble_like_path on macos junk files' => sub {
-    ok( LANraragi::Utils::Archive::is_appledouble_like_path('__MACOSX/test.png'), '__MACOSX/ image matched' );
-    ok( LANraragi::Utils::Archive::is_appledouble_like_path('folder/._image.png'), 'AppleDouble file matched' );
+subtest 'testing is_apple_signature_like_path on macos junk files' => sub {
+    ok( LANraragi::Utils::Archive::is_apple_signature_like_path('__MACOSX/test.png'), '__MACOSX/ image matched' );
+    ok( LANraragi::Utils::Archive::is_apple_signature_like_path('folder/._image.png'), 'AppleDouble file matched' );
 };
 
-subtest 'testing is_appledouble_like_path on valid files' => sub {
-    ok( !LANraragi::Utils::Archive::is_appledouble_like_path('folder/image.png'), 'PNG not matched' );
-    ok( !LANraragi::Utils::Archive::is_appledouble_like_path('folder/sub/cover.jpg'), 'JPG not matched 1' );
-    ok( !LANraragi::Utils::Archive::is_appledouble_like_path('folder._cover.jpg'), 'JPG not matched 2' );
+subtest 'testing is_apple_signature_like_path on valid files' => sub {
+    ok( !LANraragi::Utils::Archive::is_apple_signature_like_path('folder/image.png'), 'PNG not matched' );
+    ok( !LANraragi::Utils::Archive::is_apple_signature_like_path('folder/sub/cover.jpg'), 'JPG not matched 1' );
+    ok( !LANraragi::Utils::Archive::is_apple_signature_like_path('folder._cover.jpg'), 'JPG not matched 2' );
 };
 
 done_testing();

--- a/tests/LANraragi/Utils/Archive.t
+++ b/tests/LANraragi/Utils/Archive.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use utf8;
+
+use Test::More;
+
+BEGIN { use_ok('LANraragi::Utils::Archive'); }
+
+subtest 'testing is_appledouble_like_path on macos junk files' => sub {
+    ok( LANraragi::Utils::Archive::is_appledouble_like_path('__MACOSX/test.png'), '__MACOSX/ image matched' );
+    ok( LANraragi::Utils::Archive::is_appledouble_like_path('folder/._image.png'), 'AppleDouble file matched' );
+};
+
+subtest 'testing is_appledouble_like_path on valid files' => sub {
+    ok( !LANraragi::Utils::Archive::is_appledouble_like_path('folder/image.png'), 'PNG not matched' );
+    ok( !LANraragi::Utils::Archive::is_appledouble_like_path('folder/sub/cover.jpg'), 'JPG not matched 1' );
+    ok( !LANraragi::Utils::Archive::is_appledouble_like_path('folder._cover.jpg'), 'JPG not matched 2' );
+};
+
+done_testing();

--- a/tests/LANraragi/Utils/Archive.t
+++ b/tests/LANraragi/Utils/Archive.t
@@ -6,15 +6,45 @@ use Test::More;
 
 BEGIN { use_ok('LANraragi::Utils::Archive'); }
 
-subtest 'testing is_apple_signature_like_path on macos junk files' => sub {
-    ok( LANraragi::Utils::Archive::is_apple_signature_like_path('__MACOSX/test.png'), '__MACOSX/ image matched' );
-    ok( LANraragi::Utils::Archive::is_apple_signature_like_path('folder/._image.png'), 'AppleDouble file matched' );
-};
+note('testing is_apple_signature_like_path...');
+{
+    my $input    = '__MACOSX/test.png';
+    my $expected = 1;
+    my $result   = LANraragi::Utils::Archive::is_apple_signature_like_path($input);
 
-subtest 'testing is_apple_signature_like_path on valid files' => sub {
-    ok( !LANraragi::Utils::Archive::is_apple_signature_like_path('folder/image.png'), 'PNG not matched' );
-    ok( !LANraragi::Utils::Archive::is_apple_signature_like_path('folder/sub/cover.jpg'), 'JPG not matched 1' );
-    ok( !LANraragi::Utils::Archive::is_apple_signature_like_path('folder._cover.jpg'), 'JPG not matched 2' );
-};
+    is ( $result, $expected, "File pattern should match apple signature" );
+}
+
+{
+    my $input    = 'folder/._image.png';
+    my $expected = 1;
+    my $result   = LANraragi::Utils::Archive::is_apple_signature_like_path($input);
+
+    is ( $result, $expected, "File pattern should match apple signature 2" );
+}
+
+{
+    my $input    = 'folder/image.png';
+    my $expected = 0;
+    my $result   = LANraragi::Utils::Archive::is_apple_signature_like_path($input);
+
+    is ( $result, $expected, "Valid PNG should not match apple signature" );
+}
+
+{
+    my $input    = 'folder/sub/cover.jpg';
+    my $expected = 0;
+    my $result   = LANraragi::Utils::Archive::is_apple_signature_like_path($input);
+
+    is ( $result, $expected, "Valid JPG should not match apple signature" );
+}
+
+{
+    my $input    = 'folder._cover.jpg';
+    my $expected = 0;
+    my $result   = LANraragi::Utils::Archive::is_apple_signature_like_path($input);
+
+    is ( $result, $expected, "Valid JPG should not match apple signature 2" );
+}
 
 done_testing();


### PR DESCRIPTION
When a macos user compresses an archive they've interacted with, they may introduce mac artifact files which have the image extension but in reality are not images.

Currently macos garbage files can slip through get_filelist checks, resulting in silent failures in image retrieval and thumbnail generation.

I added some logic to rule out these garbage files, including
- a pattern match for macos garbage files (assuming they fit the image extension mold)
- AppleSingle/Double header matching to eliminate false positives

see https://ciderpress2.com/formatdoc/AppleSingle-notes.html

logs
```
...
[2025-10-26 22:28:36] [Archive] [info] Checking Apple fork magic for: __MACOSX/test/._1847334792305488292_1.png
[2025-10-26 22:28:36] [Archive] [info] AppleDouble magic matched for __MACOSX/test/._1847334792305488292_1.png
[2025-10-26 22:28:36] [Archive] [info] Checking Apple fork magic for: __MACOSX/test/._1847334792305488292_1.png
[2025-10-26 22:28:36] [Archive] [info] AppleDouble magic matched for __MACOSX/test/._1847334792305488292_1.png
...
```