### PR TITLE
Use fetchpriority to make browsers fetch current image before thumbnails

### DIFF
--- a/templates/reader.html.tt2
+++ b/templates/reader.html.tt2
@@ -58,7 +58,7 @@
             </div>
 
             <a id="display">
-                <img id="img" class="reader-image" src=""><img id="img_doublepage" class="reader-image" src="">
+                <img id="img" class="reader-image" src="" fetchpriority="high"><img id="img_doublepage" class="reader-image" src="" fetchpriority="high">
             </a>
 
         </div>


### PR DESCRIPTION
Another minor PR that can improve perceived performance a touch. By using fetchpriority on the active image, the browser SHOULD prioritize that/those over other images (such as thumbnails).

(The effect is partially nullified due to the other PR that prevents thumbnails from being loaded willy-nilly, but eh it's something)