### PR TITLE
Rework actions workflow

### DIFF
--- a/.github/actions/docker-builder/action.yml
+++ b/.github/actions/docker-builder/action.yml
@@ -1,0 +1,54 @@
+name: 'Docker builder'
+inputs:
+  platform:
+    required: true
+  docker-username:
+    required: true
+  docker-password:
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Prepare
+      shell: bash
+      run: |
+        platform=${{ inputs.platform }}
+        echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.docker-username }}
+        password: ${{ inputs.docker-password }}
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY_IMAGE }}
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Build and push by digest
+      id: build
+      uses: docker/build-push-action@v6
+      env:
+        DOCKER_BUILD_SUMMARY: false
+      with:
+        platforms: ${{ inputs.platform }}
+        labels: ${{ steps.meta.outputs.labels }}
+        tags: ${{ env.REGISTRY_IMAGE }}
+        cache-from: type=gha,scope=buildkit-${{ env.PLATFORM_PAIR }}
+        cache-to: type=gha,mode=max,scope=buildkit-${{ env.PLATFORM_PAIR }}
+        outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+        file: ./tools/build/docker/Dockerfile
+    - name: Export digest
+      shell: bash
+      run: |
+        mkdir -p ${{ runner.temp }}/digests
+        digest="${{ steps.build.outputs.digest }}"
+        touch "${{ runner.temp }}/digests/${digest#sha256:}"
+    - name: Upload digest
+      uses: actions/upload-artifact@v4
+      with:
+        name: digests-${{ env.PLATFORM_PAIR }}
+        path: ${{ runner.temp }}/digests/*
+        if-no-files-found: error
+        retention-days: 1

--- a/.github/actions/docker-merge/action.yml
+++ b/.github/actions/docker-merge/action.yml
@@ -1,0 +1,44 @@
+name: 'Docker merge'
+inputs:
+  docker-username:
+    required: true
+  docker-password:
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Download digests
+      uses: actions/download-artifact@v4
+      with:
+        path: ${{ runner.temp }}/digests
+        pattern: digests-*
+        merge-multiple: true
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.docker-username }}
+        password: ${{ inputs.docker-password }}
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY_IMAGE }}
+        flavor: |
+          latest=false
+          prefix=
+          suffix=
+        tags: |
+          type=ref,event=tag
+          ${{ env.TAG }}
+    - name: Create manifest list and push
+      working-directory: ${{ runner.temp }}/digests
+      shell: bash
+      run: |
+        docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+    - name: Inspect image
+      shell: bash
+      run: |
+        docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/push-continous-delivery.yml
+++ b/.github/workflows/push-continous-delivery.yml
@@ -4,66 +4,61 @@ on:
     - dev
     - test-builds
     - actions-testing
+env:
+  REGISTRY_IMAGE: difegue/lanraragi
+  TAG: nightly
 name: Continuous Delivery 
 jobs:
 
-  buildDockerARM:
+  buildDockerArm:
     name: Build Docker Images (ARM)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/arm/v6
+          - linux/arm/v7
+          - linux/arm64
     steps:
-    - uses: actions/checkout@master
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-    - uses: actions/cache@v4
-      with: 
-        path: /tmp/buildxcache
-        key: ${{ runner.os }}-docker-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-docker-buildx-
-    - name: Build ARMv6/ARMv7 images
-      run: |
-        apt-get update && apt-get upgrade 
-        docker buildx build \
-          --platform linux/arm/v6,linux/arm/v7 \
-          --output "type=image,push=false" \
-          --tag difegue/lanraragi:nightly \
-          --cache-from "type=local,src=/tmp/buildxcache" \
-          --cache-to "type=local,dest=/tmp/buildxcache" \
-          --file ./tools/build/docker/Dockerfile .
+    - uses: actions/checkout@v5
+    - name: Docker builder
+      uses: ./.github/actions/docker-builder
+      with:
+        platform: ${{ matrix.platform }}
+        docker-username: ${{ secrets.DOCKER_USERNAME }}
+        docker-password: ${{ secrets.DOCKER_PASSWORD }}
 
-  buildNightlyDocker:
-    name: Bundle and Push Docker Image
-    needs: buildDockerARM
-    runs-on: ubuntu-latest
+  buildDockerx86:
+    name: Build Docker Images (x86)
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/386
+          - linux/amd64
     steps:
-    - uses: actions/checkout@master
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-    - uses: actions/cache@v4
-      with: 
-        path: /tmp/buildxcache
-        key: ${{ runner.os }}-docker-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-docker-buildx-
-    - name: Docker Login
-      env:
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      run: |
-        echo "${DOCKER_PASSWORD}" | docker login -u ${DOCKER_USERNAME} --password-stdin
-    - name: Build/Push Nightly Docker
-      run: |
-        docker buildx build \
-          --platform linux/386,linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7 \
-          --output "type=image,push=true" \
-          --tag difegue/lanraragi:nightly \
-          --cache-from "type=local,src=/tmp/buildxcache" \
-          --cache-to "type=local,dest=/tmp/buildxcache" \
-          --file ./tools/build/docker/Dockerfile .
+    - uses: actions/checkout@v5
+    - name: Docker builder
+      uses: ./.github/actions/docker-builder
+      with:
+        platform: ${{ matrix.platform }}
+        docker-username: ${{ secrets.DOCKER_USERNAME }}
+        docker-password: ${{ secrets.DOCKER_PASSWORD }}
+
+  mergeDocker:
+    name: Merge Docker Images
+    runs-on: ubuntu-24.04
+    needs:
+      - buildDockerArm
+      - buildDockerx86
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/docker-merge
+        with:
+          docker-username: ${{ secrets.DOCKER_USERNAME }}
+          docker-password: ${{ secrets.DOCKER_PASSWORD }}
 
   buildNightlyMSYS2:
     name: Build and export native Windows version

--- a/.github/workflows/release-delivery.yml
+++ b/.github/workflows/release-delivery.yml
@@ -1,6 +1,9 @@
 on: 
   release:
     types: [published]
+env:
+  REGISTRY_IMAGE: difegue/lanraragi
+  TAG: latest
 name: New Version Release
 jobs:
 
@@ -63,43 +66,60 @@ jobs:
       with:
         args: 'Windows Installer built and available on the Release page! <:logo:821516019179978772>🪟'
 
-  buildLatestDocker:
-    name: Build Latest Docker image
-    runs-on: ubuntu-latest
+  buildDockerArm:
+    name: Build Docker Images (ARM)
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/arm/v6
+          - linux/arm/v7
+          - linux/arm64
     steps:
-    - uses: actions/checkout@master
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-    - uses: actions/cache@v4
-      with: 
-        path: /tmp/buildxcache
-        key: ${{ runner.os }}-docker-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-docker-buildx-
-    - name: Docker Login
-      env:
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      run: |
-        echo "${DOCKER_PASSWORD}" | docker login -u ${DOCKER_USERNAME} --password-stdin
-    - name: Build/Push Latest Docker image and tag with Release number
-      run: |
-        TAG=${GITHUB_REF:10:10}
-        docker buildx build \
-          --platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64 \
-          --output "type=image,push=true" \
-          --tag difegue/lanraragi:latest \
-          --tag difegue/lanraragi:$TAG \
-          --cache-from "type=local,src=/tmp/buildxcache" \
-          --cache-to "type=local,dest=/tmp/buildxcache" \
-          --file ./tools/build/docker/Dockerfile .
-    - uses: Ilshidur/action-discord@master
-      env:
-        DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+    - uses: actions/checkout@v5
+    - name: Docker builder
+      uses: ./.github/actions/docker-builder
       with:
-        args: 'Docker image built and available on Docker Hub! 🐳'
+        platform: ${{ matrix.platform }}
+        docker-username: ${{ secrets.DOCKER_USERNAME }}
+        docker-password: ${{ secrets.DOCKER_PASSWORD }}
+
+  buildDockerx86:
+    name: Build Docker Images (x86)
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/386
+          - linux/amd64
+    steps:
+    - uses: actions/checkout@v5
+    - name: Docker builder
+      uses: ./.github/actions/docker-builder
+      with:
+        platform: ${{ matrix.platform }}
+        docker-username: ${{ secrets.DOCKER_USERNAME }}
+        docker-password: ${{ secrets.DOCKER_PASSWORD }}
+
+  mergeDocker:
+    name: Merge Docker Images
+    runs-on: ubuntu-24.04
+    needs:
+      - buildDockerArm
+      - buildDockerx86
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/docker-merge
+        with:
+          docker-username: ${{ secrets.DOCKER_USERNAME }}
+          docker-password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: Ilshidur/action-discord@master
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        with:
+          args: 'Docker image built and available on Docker Hub! 🐳'
 
   discordNotifications:
     name: Send out some notifications


### PR DESCRIPTION
- Distribute docker builds across runners.
- Use arm64 runner for arm builds.
- Unify steps using composite actions.

From around 2h to 5m~6m for clean builds and from 1h to 1m30s for cached builds.