### PR TITLE
Demo: customize integration test origin with workflow dispatch

### DIFF
--- a/.github/workflows/push-continuous-integration.yml
+++ b/.github/workflows/push-continuous-integration.yml
@@ -1,4 +1,17 @@
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      integration_test_repository:
+        description: 'Integration testing repository path'
+        required: true
+        default: 'psilabs-dev/aio-lanraragi'
+      integration_test_ref:
+        description: 'Integration testing repository git commit hash or branch'
+        required: true
+        default: '328c792313f24d667c73377fd67aadfa7df72d26'
+
 name: "Continuous Integration \U0001F44C\U0001F440"
 jobs:
   testSuite:
@@ -30,8 +43,8 @@ jobs:
       - name: Checkout aio-lanraragi integration tests
         uses: actions/checkout@v4
         with:
-          repository: psilabs-dev/aio-lanraragi
-          ref: 328c792313f24d667c73377fd67aadfa7df72d26
+          repository: ${{ github.event.inputs.integration_test_repository }}
+          ref: ${{ github.event.inputs.integration_test_ref }}
           path: aio-lanraragi
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -92,8 +105,8 @@ jobs:
       - name: Checkout aio-lanraragi integration tests
         uses: actions/checkout@v4
         with:
-          repository: psilabs-dev/aio-lanraragi
-          ref: 328c792313f24d667c73377fd67aadfa7df72d26
+          repository: ${{ github.event.inputs.integration_test_repository }}
+          ref: ${{ github.event.inputs.integration_test_ref }}
           path: aio-lanraragi
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/push-continuous-integration.yml
+++ b/.github/workflows/push-continuous-integration.yml
@@ -12,6 +12,10 @@ on:
         required: true
         default: '328c792313f24d667c73377fd67aadfa7df72d26'
 
+env:
+  INTEGRATION_TEST_REPOSITORY: ${{ github.event.inputs.integration_test_repository || 'psilabs-dev/aio-lanraragi' }}
+  INTEGRATION_TEST_REF: ${{ github.event.inputs.integration_test_ref || '328c792313f24d667c73377fd67aadfa7df72d26' }}
+
 name: "Continuous Integration \U0001F44C\U0001F440"
 jobs:
   testSuite:
@@ -43,8 +47,8 @@ jobs:
       - name: Checkout aio-lanraragi integration tests
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.inputs.integration_test_repository }}
-          ref: ${{ github.event.inputs.integration_test_ref }}
+          repository: ${{ env.INTEGRATION_TEST_REPOSITORY }}
+          ref: ${{ env.INTEGRATION_TEST_REF }}
           path: aio-lanraragi
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -105,8 +109,8 @@ jobs:
       - name: Checkout aio-lanraragi integration tests
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.inputs.integration_test_repository }}
-          ref: ${{ github.event.inputs.integration_test_ref }}
+          repository: ${{ env.INTEGRATION_TEST_REPOSITORY }}
+          ref: ${{ env.INTEGRATION_TEST_REF }}
           path: aio-lanraragi
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
- Docs: https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_dispatch
- Tutorial: https://www.youtube.com/watch?v=Sb_zLeHEVqQ

Adds an option of triggering a manual workload for users to be able to run integration tests from their own forks and refs if desired.

In order for workflow dispatch/manual workload triggering to occur, the branch containing "workflow_dispatch" configuration must be default.

Only users with write permissions to the repository will be able to trigger these workflows (see [docs](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow)). This means an external PR authors of "difegue/LANraragi" cannot trigger workflows against a custom integration test origin, so nothing changes for this project from a PR author's view.

But repo/fork *owners* will have the ability to change where integration tests are run from. For example in my fork, I'll be able to change my integration test ref to "feature-test-branch" to run workflows against some LRR feature, allowing me to run nightly cross-platform integration tests without git committing a ref change in push-continuous-integration.yml.

## Screenshot
<img width="1503" height="665" alt="Screenshot 2025-10-29 at 11 52 49 PM" src="https://github.com/user-attachments/assets/963450ae-7ffc-40f3-9a60-c0867d0f323f" />
