### PR TITLE
Log more on archive read failure

### DIFF
--- a/lib/LANraragi/Model/Opds.pm
+++ b/lib/LANraragi/Model/Opds.pm
@@ -141,7 +141,7 @@ sub render_archive_page {
     my $archive = $redis->hget( $id, "file" );
 
     # Parse archive to get its list of images
-    my @images = get_filelist($archive);
+    my @images = get_filelist($archive, $id);
 
     # If the page number is invalid, use the first page.
     if ( $page > scalar @images ) {

--- a/lib/LANraragi/Model/Reader.pm
+++ b/lib/LANraragi/Model/Reader.pm
@@ -49,7 +49,7 @@ sub build_reader_JSON ( $self, $id, $force ) {
     my $archive = $redis->hget( $id, "file" );
 
     # Parse archive to get its list of images
-    my @images = get_filelist($archive);
+    my @images = get_filelist($archive, $id);
 
     $self->LRR_LOGGER->debug( "Files found in archive (encoding might be incorrect): \n " . Dumper @images );
 

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -107,7 +107,7 @@ sub extract_thumbnail ( $thumbdir, $id, $page, $set_cover, $use_hq ) {
     my $file  = $redis->hget( $id, "file" );
 
     # Get first image from archive using filelist
-    my @filelist        = get_filelist($file);
+    my @filelist        = get_filelist($file, $id);
     my $requested_image = $filelist[ $page > 0 ? $page - 1 : 0 ];
 
     die "Requested image not found: $id page $page" unless $requested_image;
@@ -153,8 +153,8 @@ sub expand {
     return lc($file);
 }
 
-# Returns a list of all the files contained in the given archive.
-sub get_filelist ($archive) {
+# Returns a list of all the files contained in the given archive with corresponding archive ID.
+sub get_filelist ($archive, $arcid) {
 
     my $logger = get_logger( "Archive", "lanraragi" );
 
@@ -184,7 +184,7 @@ sub get_filelist ($archive) {
             my $archive_exists          = -e $archive ? 'yes' : 'no';
             my $archive_readable        = -r $archive ? 'yes' : 'no';
             my $archive_size            = -e $archive ? (-s _) : 'NA';
-            my $open_filename_err   = "Couldn't open archive '$archive' (exists:$archive_exists; readable:$archive_readable; size:$archive_size)"
+            my $open_filename_err   = "Couldn't open archive '$archive' (id:$arcid, exists:$archive_exists; readable:$archive_readable; size:$archive_size)"
                 . "libarchive: " . $r->error_string . " (errno $open_filename_errno: $open_filename_strerr)";
             $logger->error($open_filename_err);
             die $r->open_filename_err;

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -177,6 +177,8 @@ sub get_filelist ($archive, $arcid) {
         $r->support_filter_all;
         $r->support_format_all;
 
+        $archive = create_path( $archive );
+
         my $ret = $r->open_filename( $archive, 10240 );
         if ( $ret != ARCHIVE_OK ) {
             my $open_filename_errno     = $r->errno;
@@ -202,7 +204,7 @@ sub get_filelist ($archive, $arcid) {
             }
 
             if ( is_apple_signature_like_path($filename) ) {
-                my $peek = Archive::Libarchive::Peek->new( filename => create_path($archive) );
+                my $peek = Archive::Libarchive::Peek->new( filename => $archive );
                 if ( is_apple_signature( $peek, $filename ) ) {
                     $r->read_data_skip;
                     next;

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -179,13 +179,13 @@ sub get_filelist ($archive) {
 
         my $ret = $r->open_filename( $archive, 10240 );
         if ( $ret != ARCHIVE_OK ) {
-            my $errno               = $r->errno;
-            my $errno_txt           = strerror($errno);
-            my $exists              = -e $archive ? 'yes' : 'no';
-            my $readable            = -r $archive ? 'yes' : 'no';
-            my $size                = -e $archive ? (-s _) : 'NA';
-            my $open_filename_err   = "Couldn't open archive '$archive' (exists:$exists; readable:$readable; size:$size)"
-                . "libarchive: " . $r->error_string . " (errno $errno: $errno_txt)";
+            my $open_filename_errno     = $r->errno;
+            my $open_filename_strerr    = strerror($open_filename_errno);
+            my $archive_exists          = -e $archive ? 'yes' : 'no';
+            my $archive_readable        = -r $archive ? 'yes' : 'no';
+            my $archive_size            = -e $archive ? (-s _) : 'NA';
+            my $open_filename_err   = "Couldn't open archive '$archive' (exists:$archive_exists; readable:$archive_readable; size:$archive_size)"
+                . "libarchive: " . $r->error_string . " (errno $open_filename_errno: $open_filename_strerr)";
             $logger->error($open_filename_err);
             die $r->open_filename_err;
         }

--- a/lib/LANraragi/Utils/Database.pm
+++ b/lib/LANraragi/Utils/Database.pm
@@ -139,7 +139,7 @@ sub add_pagecount ( $redis, $id ) {
     my $logger = get_logger( "Archive", "lanraragi" );
 
     my $file   = $redis->hget( $id, "file" );
-    my @images = get_filelist($file);
+    my @images = get_filelist($file, $id);
     $redis->hset( $id, "pagecount", scalar @images );
 }
 


### PR DESCRIPTION
If a file fails to open (e.g. during thumbnail extraction), the current logs don't say much. Just another attempt to make problems more transparent (and log all possible info based what libarchive provides).

Previous:
```
[2025-10-31 07:01:12] [Archive] [error] Couldn't open archive, libarchive says:Failed to open '/home/koyomi/lanraragi/content/69829671/pixiv_102851995.zip'
```

After:
```
[2025-10-31 07:36:36] [Archive] [error] Couldn't open archive '/home/koyomi/lanraragi/content/69829671/pixiv_102851995.zip' (exists:no readable:no size:NA) libarchive: Failed to open '/home/koyomi/lanraragi/content/69829671/pixiv_102851995.zip' (errno 2: No such file or directory)
```