### PR TITLE
Don't initialize archive overlay immediately to save CPU on huge arch…

### DIFF
--- a/public/js/common.js
+++ b/public/js/common.js
@@ -132,6 +132,7 @@ LRR.openInNewTab = function (url) {
  * @returns
  */
 LRR.toggleOverlay = function (selector) {
+    Reader.initializeArchiveOverlay();
     const overlay = $(selector);
     overlay.is(":visible")
         ? LRR.closeOverlay()

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -255,7 +255,6 @@ Reader.loadImages = function () {
             }
 
             if (Reader.showOverlayByDefault) { Reader.toggleArchiveOverlay(); }
-            Reader.initializeArchiveOverlay();
         },
     ).finally(() => {
         if (Reader.pages === undefined) {


### PR DESCRIPTION
Despite previous optimizations, initializing the archive overlay can still be really slow on huge archives. This PR delays the initialization until the user actually tries to open the overlay.

It'll still be slow, but only if you try to open the overlay at least!