### PR TITLE
Move tank/category operations before del($id)

### DIFF
--- a/lib/LANraragi/Model/Archive.pm
+++ b/lib/LANraragi/Model/Archive.pm
@@ -331,6 +331,16 @@ sub delete_archive ($id) {
     $oldtitle = trim_CRLF($oldtitle);
     $oldtitle = redis_encode($oldtitle);
 
+    # Remove from tanks/collections
+    foreach my $tank_id ( LANraragi::Model::Tankoubon::get_tankoubons_containing_archive($id) ) {
+        LANraragi::Model::Tankoubon::remove_from_tankoubon( $tank_id, $id );
+    }
+
+    foreach my $cat ( LANraragi::Model::Category::get_categories_containing_archive($id) ) {
+        my $catid = %{$cat}{"id"};
+        LANraragi::Model::Category::remove_from_category( $catid, $id );
+    }
+
     $redis->del($id);
     $redis->quit();
 
@@ -341,16 +351,6 @@ sub delete_archive ($id) {
     $redis_search->srem( "LRR_UNTAGGED",    $id );
     $redis_search->srem( "LRR_TANKGROUPED", $id );
     $redis_search->quit();
-
-    # Remove from tanks/collections
-    foreach my $tank_id ( LANraragi::Model::Tankoubon::get_tankoubons_containing_archive($id) ) {
-        LANraragi::Model::Tankoubon::remove_from_tankoubon( $tank_id, $id );
-    }
-
-    foreach my $cat ( LANraragi::Model::Category::get_categories_containing_archive($id) ) {
-        my $catid = %{$cat}{"id"};
-        LANraragi::Model::Category::remove_from_category( $catid, $id );
-    }
 
     LANraragi::Utils::Database::update_indexes( $id, $oldtags, "" );
 


### PR DESCRIPTION
Generally, relations should be removed before the entry itself, to prevent orphans and enforce referential integrity.