### PR TITLE
reverse direction for spacebar hotkey and slideshow when in manga mode

### DIFF
--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -390,7 +390,8 @@ Reader.handleShortcuts = function (e) {
     e.preventDefault();
 
     // Capture direction now so we dont lose it if shift state changes while held
-    const direction = e.shiftKey ? -1 : 1;
+    let direction = e.shiftKey ? -1 : 1;
+    if (Reader.mangaMode) direction *= -1;
     const cfg = Reader.scrollConfig;
 
     if (e.type === "keydown") {


### PR DESCRIPTION
closes https://github.com/Difegue/LANraragi/issues/1399

When the reading direction is changed to right to left, both the spacebar and slideshow will progress the archive backwards. This is a small patch to reverse (and correct) the direction when `Reader.mangaMode` is `true`.