### PR TITLE
Integration test updates

### DIFF
--- a/.github/workflows/push-continuous-integration.yml
+++ b/.github/workflows/push-continuous-integration.yml
@@ -10,11 +10,11 @@ on:
       integration_test_ref:
         description: 'Integration testing repository git commit hash or branch'
         required: true
-        default: '328c792313f24d667c73377fd67aadfa7df72d26'
+        default: '41e436b59f605d53307f7e2b420b31fed3d17013'
 
 env:
   INTEGRATION_TEST_REPOSITORY: ${{ github.event.inputs.integration_test_repository || 'psilabs-dev/aio-lanraragi' }}
-  INTEGRATION_TEST_REF: ${{ github.event.inputs.integration_test_ref || '328c792313f24d667c73377fd67aadfa7df72d26' }}
+  INTEGRATION_TEST_REF: ${{ github.event.inputs.integration_test_ref || '41e436b59f605d53307f7e2b420b31fed3d17013' }}
 
 name: "Continuous Integration \U0001F44C\U0001F440"
 jobs:
@@ -64,12 +64,17 @@ jobs:
           cd aio-lanraragi/integration_tests
           pip install .
           playwright install
+      - name: Create staging directory
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/staging"
       - name: Run integration tests against local LANraragi build
         run: |
           cd aio-lanraragi/integration_tests
           export CI=true
+          export DOCKER_BUILDKIT=1
           pytest tests --log-cli-level=INFO \
             --build "$GITHUB_WORKSPACE/lanraragi" \
+            --staging "$GITHUB_WORKSPACE/staging" \
             --playwright \
             --docker-api \
             --npseed 42

--- a/.github/workflows/push-continuous-integration.yml
+++ b/.github/workflows/push-continuous-integration.yml
@@ -10,11 +10,11 @@ on:
       integration_test_ref:
         description: 'Integration testing repository git commit hash or branch'
         required: true
-        default: '41e436b59f605d53307f7e2b420b31fed3d17013'
+        default: 'd6db424d1a2fa68ebaea15af915938746f146cad'
 
 env:
   INTEGRATION_TEST_REPOSITORY: ${{ github.event.inputs.integration_test_repository || 'psilabs-dev/aio-lanraragi' }}
-  INTEGRATION_TEST_REF: ${{ github.event.inputs.integration_test_ref || '41e436b59f605d53307f7e2b420b31fed3d17013' }}
+  INTEGRATION_TEST_REF: ${{ github.event.inputs.integration_test_ref || 'd6db424d1a2fa68ebaea15af915938746f146cad' }}
 
 name: "Continuous Integration \U0001F44C\U0001F440"
 jobs:
@@ -68,6 +68,7 @@ jobs:
         run: |
           mkdir -p "$GITHUB_WORKSPACE/staging"
       - name: Run integration tests against local LANraragi build
+        timeout-minutes: 30
         run: |
           cd aio-lanraragi/integration_tests
           export CI=true
@@ -136,7 +137,7 @@ jobs:
           New-Item -ItemType Directory -Path "$env:GITHUB_WORKSPACE\staging" -Force | Out-Null
       - name: Run integration tests against local LANraragi build
         working-directory: aio-lanraragi/integration_tests
-        timeout-minutes: 30
+        timeout-minutes: 50
         run: |
           $env:CI='true'
           pytest tests `


### PR DESCRIPTION
compare: https://github.com/psilabs-dev/aio-lanraragi/compare/328c792313f24d667c73377fd67aadfa7df72d26...41e436b59f605d53307f7e2b420b31fed3d17013

Another update from the integration testing repository with a side of client:

- added 2 integration tests for enabled/disabled CORS preflight
- added test to upload archives to symlinked archive directory
- extended coverage of existing tests to count archives directory files before/after uploads
- enforce no error-severity logs from LRR and Shinobu before end of test cases

Docker-based integration testing has moved from volumes to bind mounts, to simulate a more realistic testing environment. This extends to archives, thumb, redis, and logs. As such, all testing environments require a staging directory on the host.

- The docker workflow now uses buildkit, and logic changes in deployment setup are made to remove intermediate images, volumes, and container artifacts.
- Because bind mount is supported, tests involving 1) user operations on the archive directory (and shinobu archive discovery) and 2) symlinked archives/thumbs/logs are supported. However, archive discovery is too slow (2-3s/archive), so no tests planned for the time being.

When a VM is involved (e.g. macos lima + apple virtualization virtiosf/sshfs), then quick teardown/setup of docker containers + removal/creation of directories create stale FS cache problems which result in LRR seeing ghost files from a previous test run, so an explicit in-VM teardown is called to try to handle this, though success is not guaranteed.

This concern doesn't apply to Github runners, where the whole test environment is in basically the same FS.

Other stuff:
- Logs of internal server errors parse the HTML and return only the error message (no more "\<DOC HTML\>Oops I flubbed..." on workflow logs)
- Handle yet another Windows OS error that comes up during upload
- Display both LRR and Shinobu logs on failure, and display logs for all environments involved on failure