### PR TITLE
Multiple fixes for path-related issues and other stuff...

### DIFF
--- a/.github/workflows/push-continous-delivery.yml
+++ b/.github/workflows/push-continous-delivery.yml
@@ -72,10 +72,30 @@ jobs:
       with:
         msystem: UCRT64
         update: true
-    - name: Install deps
-      shell: msys2 {0}
-      run: |
-        ./tools/build/windows/install-deps.sh
+        # Keep in sync with tools/build/windows/install-deps.sh
+        install: >-
+          mingw-w64-ucrt-x86_64-perl
+          mingw-w64-ucrt-x86_64-perl-win32-api
+          mingw-w64-ucrt-x86_64-openssl
+          mingw-w64-ucrt-x86_64-imagemagick
+          mingw-w64-ucrt-x86_64-libjxl
+          mingw-w64-ucrt-x86_64-libheif
+          mingw-w64-ucrt-x86_64-ghostscript
+          mingw-w64-ucrt-x86_64-zlib
+          mingw-w64-ucrt-x86_64-lzo2
+          mingw-w64-ucrt-x86_64-libarchive
+          mingw-w64-ucrt-x86_64-ca-certificates
+          mingw-w64-ucrt-x86_64-libvips
+          libxcrypt
+          unzip
+          mingw-w64-ucrt-x86_64-gcc
+          mingw-w64-ucrt-x86_64-make
+          make
+          mingw-w64-ucrt-x86_64-diffutils
+          libbz2-devel
+          patch
+          mingw-w64-ucrt-x86_64-nodejs
+          mingw-w64-ucrt-x86_64-tools-git
     - name: Build
       shell: msys2 {0}
       run: |

--- a/.github/workflows/push-continuous-integration.yml
+++ b/.github/workflows/push-continuous-integration.yml
@@ -90,11 +90,30 @@ jobs:
         with:
           msystem: UCRT64
           update: true
-      - name: Install deps
-        shell: msys2 {0}
-        working-directory: LANraragi
-        run: |
-          ./tools/build/windows/install-deps.sh
+          # Keep in sync with tools/build/windows/install-deps.sh
+          install: >-
+            mingw-w64-ucrt-x86_64-perl
+            mingw-w64-ucrt-x86_64-perl-win32-api
+            mingw-w64-ucrt-x86_64-openssl
+            mingw-w64-ucrt-x86_64-imagemagick
+            mingw-w64-ucrt-x86_64-libjxl
+            mingw-w64-ucrt-x86_64-libheif
+            mingw-w64-ucrt-x86_64-ghostscript
+            mingw-w64-ucrt-x86_64-zlib
+            mingw-w64-ucrt-x86_64-lzo2
+            mingw-w64-ucrt-x86_64-libarchive
+            mingw-w64-ucrt-x86_64-ca-certificates
+            mingw-w64-ucrt-x86_64-libvips
+            libxcrypt
+            unzip
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-make
+            make
+            mingw-w64-ucrt-x86_64-diffutils
+            libbz2-devel
+            patch
+            mingw-w64-ucrt-x86_64-nodejs
+            mingw-w64-ucrt-x86_64-tools-git
       - name: Build
         shell: msys2 {0}
         working-directory: LANraragi

--- a/.github/workflows/release-delivery.yml
+++ b/.github/workflows/release-delivery.yml
@@ -19,10 +19,30 @@ jobs:
       with:
         msystem: UCRT64
         update: true
-    - name: Install deps
-      shell: msys2 {0}
-      run: |
-        ./tools/build/windows/install-deps.sh
+        # Keep in sync with tools/build/windows/install-deps.sh
+        install: >-
+          mingw-w64-ucrt-x86_64-perl
+          mingw-w64-ucrt-x86_64-perl-win32-api
+          mingw-w64-ucrt-x86_64-openssl
+          mingw-w64-ucrt-x86_64-imagemagick
+          mingw-w64-ucrt-x86_64-libjxl
+          mingw-w64-ucrt-x86_64-libheif
+          mingw-w64-ucrt-x86_64-ghostscript
+          mingw-w64-ucrt-x86_64-zlib
+          mingw-w64-ucrt-x86_64-lzo2
+          mingw-w64-ucrt-x86_64-libarchive
+          mingw-w64-ucrt-x86_64-ca-certificates
+          mingw-w64-ucrt-x86_64-libvips
+          libxcrypt
+          unzip
+          mingw-w64-ucrt-x86_64-gcc
+          mingw-w64-ucrt-x86_64-make
+          make
+          mingw-w64-ucrt-x86_64-diffutils
+          libbz2-devel
+          patch
+          mingw-w64-ucrt-x86_64-nodejs
+          mingw-w64-ucrt-x86_64-tools-git
     - name: Build
       shell: msys2 {0}
       run: |

--- a/lib/LANraragi/Controller/Api/Archive.pm
+++ b/lib/LANraragi/Controller/Api/Archive.pm
@@ -216,6 +216,8 @@ sub create_archive {
             );
         }
 
+        $tempfile = decode_utf8( $tempfile );
+
         my ( $status_code, $id, $response_title, $message ) =
           LANraragi::Model::Upload::handle_incoming_file( $tempfile, $catid, $tags, $title, $summary );
 

--- a/lib/LANraragi/Controller/Api/Archive.pm
+++ b/lib/LANraragi/Controller/Api/Archive.pm
@@ -8,7 +8,7 @@ use Storable;
 use Mojo::JSON   qw(decode_json);
 use Scalar::Util qw(looks_like_number);
 
-use File::Temp qw(tempdir);
+use File::Temp qw(tempdir tmpnam);
 use File::Basename;
 
 use LANraragi::Utils::Generic  qw(render_api_response is_archive get_bytelength exec_with_lock);

--- a/lib/LANraragi/Controller/Api/Archive.pm
+++ b/lib/LANraragi/Controller/Api/Archive.pm
@@ -193,7 +193,7 @@ sub create_archive {
 
         my $mojo_temp = tmpnam(); # Create another temp file as a target for Mojo's move_to so that the original handle can be closed
         if ( !$upload->move_to($mojo_temp) ) {
-            $logger->error("Could not move uploaded file $filename to $tempfile");
+            $logger->error("Could not move uploaded file $filename to $mojo_temp");
             return $self->render(
                 json => {
                     operation => "upload",
@@ -205,7 +205,7 @@ sub create_archive {
         }
 
         if ( !move_path( $mojo_temp, $tempfile ) ) { # Move the file for real this time
-            $logger->error("Could not move uploaded file $filename to $tempfile");
+            $logger->error("Could not move uploaded file $mojo_temp to $tempfile");
             return $self->render(
                 json => {
                     operation => "upload",

--- a/lib/LANraragi/Controller/Api/Archive.pm
+++ b/lib/LANraragi/Controller/Api/Archive.pm
@@ -3,9 +3,9 @@ use Mojo::Base 'Mojolicious::Controller';
 
 use Digest::SHA qw(sha1_hex);
 use Redis;
+use Config;
 use Encode;
 use Storable;
-use Mojo::JSON   qw(decode_json);
 use Scalar::Util qw(looks_like_number);
 
 use File::Temp qw(tempdir tmpnam);
@@ -21,6 +21,8 @@ use LANraragi::Model::Archive;
 use LANraragi::Model::Category;
 use LANraragi::Model::Config;
 use LANraragi::Model::Reader;
+
+use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );
 
 # Archive API.
 
@@ -216,7 +218,9 @@ sub create_archive {
             );
         }
 
-        $tempfile = decode_utf8( $tempfile );
+        if ( IS_UNIX ) {
+            $tempfile = decode_utf8( $tempfile );
+        }
 
         my ( $status_code, $id, $response_title, $message ) =
           LANraragi::Model::Upload::handle_incoming_file( $tempfile, $catid, $tags, $title, $summary );

--- a/lib/LANraragi/Controller/Api/Archive.pm
+++ b/lib/LANraragi/Controller/Api/Archive.pm
@@ -16,7 +16,7 @@ use LANraragi::Utils::Generic  qw(render_api_response is_archive get_bytelength 
 use LANraragi::Utils::Database qw(get_archive_json set_isnew);
 use LANraragi::Utils::Logging  qw(get_logger);
 use LANraragi::Utils::Redis    qw(redis_encode);
-use LANraragi::Utils::Path     qw(compat_path);
+use LANraragi::Utils::Path     qw(compat_path get_archive_path);
 
 use LANraragi::Model::Archive;
 use LANraragi::Model::Category;
@@ -110,7 +110,7 @@ sub serve_file {
     my $id    = check_id_parameter( $self, "serve_file" ) || return;
     my $redis = $self->LRR_CONF->get_redis;
 
-    my $file = $redis->hget( $id, "file" );
+    my $file = get_archive_path( $redis, $id );
     $redis->quit();
     $self->render_file( filepath => compat_path( $file ), filename => basename( $file ) );
 }

--- a/lib/LANraragi/Controller/Api/Archive.pm
+++ b/lib/LANraragi/Controller/Api/Archive.pm
@@ -193,7 +193,10 @@ sub create_archive {
 
         my $tempfile = $tempdir . '/' . $filename;
 
-        my $mojo_temp = tmpnam(); # Create another temp file as a target for Mojo's move_to so that the original handle can be closed
+        # On Windows Mojo will hold an open handle to the upload file preventing us from using the long-path compatible
+        # methods to move it.
+        # Workaround it by using another temp file as a target for Mojo's move_to so that the original handle can be closed.
+        my $mojo_temp = tmpnam();
         if ( !$upload->move_to($mojo_temp) ) {
             $logger->error("Could not move uploaded file $filename to $mojo_temp");
             return $self->render(

--- a/lib/LANraragi/Controller/Index.pm
+++ b/lib/LANraragi/Controller/Index.pm
@@ -9,7 +9,7 @@ use File::Basename;
 use Authen::Passphrase;
 
 use LANraragi::Utils::Generic qw(generate_themes_header);
-use LANraragi::Utils::Path    qw(create_path);
+use LANraragi::Utils::Path    qw(get_archive_path);
 
 # This endpoint is technically superseded by /api/search/random, but it's still useful in the Reader.
 sub random_archive {
@@ -31,7 +31,7 @@ sub random_archive {
         if (   length($archive) == 40
             && $redis->type($archive) eq "hash"
             && $redis->hexists( $archive, "file" ) ) {
-            my $arclocation = create_path( $redis->hget( $archive, "file" ) );
+            my $arclocation = get_archive_path( $redis, $archive );
             if ( -e $arclocation ) { $archiveexists = 1; }
         }
     }

--- a/lib/LANraragi/Controller/Upload.pm
+++ b/lib/LANraragi/Controller/Upload.pm
@@ -10,8 +10,6 @@ use File::Basename;
 use LANraragi::Utils::Generic qw(generate_themes_header is_archive get_bytelength);
 use LANraragi::Utils::Path    qw(move_path);
 
-use feature qw(say);
-
 sub process_upload {
     my $self = shift;
 

--- a/lib/LANraragi/Controller/Upload.pm
+++ b/lib/LANraragi/Controller/Upload.pm
@@ -4,12 +4,11 @@ use Mojo::Base 'Mojolicious::Controller';
 use Redis;
 use Encode;
 use File::Temp qw(tempdir tmpnam);
-use File::Copy;
 use File::Find;
 use File::Basename;
 
 use LANraragi::Utils::Generic qw(generate_themes_header is_archive get_bytelength);
-use LANraragi::Utils::Path    qw(rename_path);
+use LANraragi::Utils::Path    qw(move_path);
 
 use feature qw(say);
 
@@ -45,7 +44,7 @@ sub process_upload {
         my $mojo_temp = tmpnam(); # Create another temp file as a target for Mojo's move_to so that the original handle can be closed
         $file->move_to($mojo_temp) or die "Couldn't move uploaded file.";
 
-        rename_path( $mojo_temp, $tempfile ) or die "Couldn't move uploaded file."; # Move the file for real this time
+        move_path( $mojo_temp, $tempfile ) or die "Couldn't move uploaded file."; # Move the file for real this time
 
         # Send a job to Minion to handle the uploaded file.
         my $jobid = $self->minion->enqueue( handle_upload => [ $tempfile, $catid ] => { priority => 2 } );

--- a/lib/LANraragi/Controller/Upload.pm
+++ b/lib/LANraragi/Controller/Upload.pm
@@ -2,12 +2,16 @@ package LANraragi::Controller::Upload;
 use Mojo::Base 'Mojolicious::Controller';
 
 use Redis;
-use File::Temp qw(tempdir);
+use Encode;
+use File::Temp qw(tempdir tmpnam);
 use File::Copy;
 use File::Find;
 use File::Basename;
 
 use LANraragi::Utils::Generic qw(generate_themes_header is_archive get_bytelength);
+use LANraragi::Utils::Path    qw(rename_path);
+
+use feature qw(say);
 
 sub process_upload {
     my $self = shift;
@@ -15,7 +19,7 @@ sub process_upload {
     #Receive uploaded file.
     my $file     = $self->req->upload('file');
     my $catid    = $self->req->param('catid');
-    my $filename = $file->filename;
+    my $filename = encode_utf8( $file->filename );
 
     my $uploadMime = $file->headers->content_type;
 
@@ -37,18 +41,11 @@ sub process_upload {
         $filename = $filename . $ext;
 
         my $tempfile = $tempdir . '/' . $filename;
-        $file->move_to($tempfile) or die "Couldn't move uploaded file.";
 
-        # Update $tempfile to the exact reference created by the host filesystem
-        # This is done by finding the first (and only) file in $tempdir.
-        find(
-            sub {
-                return if -d $_;
-                $tempfile = $File::Find::name;
-                $filename = $_;
-            },
-            $tempdir
-        );
+        my $mojo_temp = tmpnam(); # Create another temp file as a target for Mojo's move_to so that the original handle can be closed
+        $file->move_to($mojo_temp) or die "Couldn't move uploaded file.";
+
+        rename_path( $mojo_temp, $tempfile ) or die "Couldn't move uploaded file."; # Move the file for real this time
 
         # Send a job to Minion to handle the uploaded file.
         my $jobid = $self->minion->enqueue( handle_upload => [ $tempfile, $catid ] => { priority => 2 } );

--- a/lib/LANraragi/Controller/Upload.pm
+++ b/lib/LANraragi/Controller/Upload.pm
@@ -39,7 +39,10 @@ sub process_upload {
 
         my $tempfile = $tempdir . '/' . $filename;
 
-        my $mojo_temp = tmpnam(); # Create another temp file as a target for Mojo's move_to so that the original handle can be closed
+        # On Windows Mojo will hold an open handle to the upload file preventing us from using the long-path compatible
+        # methods to move it.
+        # Workaround it by using another temp file as a target for Mojo's move_to so that the original handle can be closed.
+        my $mojo_temp = tmpnam();
         $file->move_to($mojo_temp) or die "Couldn't move uploaded file.";
 
         move_path( $mojo_temp, $tempfile ) or die "Couldn't move uploaded file."; # Move the file for real this time

--- a/lib/LANraragi/Model/Opds.pm
+++ b/lib/LANraragi/Model/Opds.pm
@@ -10,8 +10,8 @@ use Mojo::Util qw(xml_escape);
 
 use LANraragi::Utils::Generic  qw(get_tag_with_namespace);
 use LANraragi::Utils::Archive  qw(get_filelist);
-use LANraragi::Utils::Database qw(get_archive_json );
-use LANraragi::Utils::Path     qw(create_path);
+use LANraragi::Utils::Database qw(get_archive_json);
+use LANraragi::Utils::Path     qw(get_archive_path);
 
 use LANraragi::Model::Category;
 use LANraragi::Model::Search;
@@ -95,7 +95,7 @@ sub get_opds_data {
     my $id    = shift;
     my $redis = LANraragi::Model::Config->get_redis;
 
-    my $file = create_path( $redis->hget( $id, "file" ) );
+    my $file = get_archive_path( $redis, $id );
     unless ( -e $file ) { return; }
 
     my $arcdata = get_archive_json( $redis, $id );
@@ -138,7 +138,7 @@ sub render_archive_page {
     my ( $mojo, $id, $page ) = @_;
 
     my $redis   = $mojo->LRR_CONF->get_redis;
-    my $archive = $redis->hget( $id, "file" );
+    my $archive = get_archive_path( $redis, $id );
 
     # Parse archive to get its list of images
     my @images = get_filelist($archive, $id);

--- a/lib/LANraragi/Model/Plugins.pm
+++ b/lib/LANraragi/Model/Plugins.pm
@@ -21,6 +21,7 @@ use LANraragi::Utils::Logging  qw(get_logger);
 use LANraragi::Utils::Tags     qw(rewrite_tags split_tags_to_array);
 use LANraragi::Utils::Plugins  qw(get_plugin_parameters get_plugin);
 use LANraragi::Utils::Redis    qw(redis_decode);
+use LANraragi::Utils::Path     qw(create_path);
 
 # Sub used by Auto-Plugin.
 sub exec_enabled_plugins_on_file ($id) {
@@ -236,7 +237,7 @@ sub exec_metadata_plugin ( $plugin, $id, %args ) {
             archive_title  => $title,
             existing_tags  => $tags,
             thumbnail_hash => $thumbhash,
-            file_path      => $file,
+            file_path      => create_path( $file ),
             user_agent     => $ua,
             oneshot_param  => $args{'oneshot'}    # for old style plugins compatibility
         );

--- a/lib/LANraragi/Model/Reader.pm
+++ b/lib/LANraragi/Model/Reader.pm
@@ -21,6 +21,7 @@ use LANraragi::Utils::Logging qw(get_logger);
 use LANraragi::Utils::Archive qw(get_filelist);
 use LANraragi::Utils::Redis   qw(redis_decode);
 use LANraragi::Utils::Resizer qw(get_resizer);
+use LANraragi::Utils::Path    qw(get_archive_path);
 
 our $resampler = get_resizer();
 
@@ -46,7 +47,7 @@ sub build_reader_JSON ( $self, $id, $force ) {
     # Get the path from Redis.
     # Filenames are stored as they are on the OS, so no decoding!
     my $redis   = LANraragi::Model::Config->get_redis;
-    my $archive = $redis->hget( $id, "file" );
+    my $archive = get_archive_path( $redis, $id );
 
     # Parse archive to get its list of images
     my @images = get_filelist($archive, $id);

--- a/lib/LANraragi/Model/Upload.pm
+++ b/lib/LANraragi/Model/Upload.pm
@@ -6,6 +6,8 @@ use strict;
 use warnings;
 
 use Redis;
+use Config;
+use Encode;
 use URI::Escape;
 use File::Basename;
 use File::Temp qw(tempdir);
@@ -23,6 +25,8 @@ use LANraragi::Model::Config   qw(get_userdir);
 use LANraragi::Model::Plugins;
 use LANraragi::Model::Category;
 use LANraragi::Model::Archive;
+
+use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );
 
 # Handle files uploaded by the user, or downloaded from remote endpoints.
 
@@ -85,7 +89,7 @@ sub handle_incoming_file ( $tempfile, $catid, $tags, $title, $summary ) {
 
     # Add the file to the database ourselves so Shinobu doesn't do it
     # This allows autoplugin to be ran ASAP.
-    my $name = add_archive_to_redis( $id, redis_encode( redis_decode( $output_file ) ), $redis, $redis_search );
+    my $name = add_archive_to_redis( $id, (IS_UNIX ? encode_utf8( $output_file ) : $output_file), $redis, $redis_search );
 
     # If additional tags were given to the sub, add them now.
     if ($tags) {

--- a/lib/LANraragi/Model/Upload.pm
+++ b/lib/LANraragi/Model/Upload.pm
@@ -16,7 +16,7 @@ use File::Find qw(find);
 use LANraragi::Utils::Archive  qw(extract_thumbnail);
 use LANraragi::Utils::Database qw(invalidate_cache compute_id set_title set_summary add_archive_to_redis add_timestamp_tag add_pagecount add_arcsize);
 use LANraragi::Utils::Logging  qw(get_logger);
-use LANraragi::Utils::Redis    qw(redis_encode redis_decode);
+use LANraragi::Utils::Redis    qw(redis_encode);
 use LANraragi::Utils::Generic  qw(is_archive get_bytelength);
 use LANraragi::Utils::String   qw(trim trim_CRLF trim_url);
 use LANraragi::Utils::Path     qw(create_path get_archive_path rename_path move_path unlink_path);

--- a/lib/LANraragi/Utils/Minion.pm
+++ b/lib/LANraragi/Utils/Minion.pm
@@ -299,6 +299,10 @@ sub add_tasks {
 
             my $logger = get_logger( "Minion", "minion" );
 
+            if ( IS_UNIX ) {
+                $file = decode_utf8( $file );
+            }
+
             $logger->info("Processing uploaded file $file...");
 
             # Since we already have a file, this goes straight to handle_incoming_file.

--- a/lib/LANraragi/Utils/Minion.pm
+++ b/lib/LANraragi/Utils/Minion.pm
@@ -299,23 +299,6 @@ sub add_tasks {
 
             my $logger = get_logger( "Minion", "minion" );
 
-# Superjank warning for the code below.
-#
-# Filepaths are left unencoded across all of LRR to avoid any headaches with how the filesystem handles filenames with non-ASCII characters.
-# (Some FS do UTF-8 properly, others not at all. We use File::Find, which returns direct bytes, to always have a filepath that matches the FS.)
-#
-# By "unencoded" tho, I actually mean Latin-1/ISO-8859-1.
-# Perl strings are internally either in Latin-1 or non-strict utf-8 ("utf8"), depending on the history of the string.
-# (See https://perldoc.perl.org/perlunifaq#I-lost-track;-what-encoding-is-the-internal-format-really?)
-#
-# When passing the string through the Minion pipe, it gets switched to utf8 for...reasons? ¯\_(ツ)_/¯
-# This actually breaks the string and makes it no longer match the real name/byte sequence if it contained non-ASCII characters,
-# so we use this arcane dark magic function to switch it back.
-# (See https://perldoc.perl.org/perlunicode#Forcing-Unicode-in-Perl-(Or-Unforcing-Unicode-in-Perl))
-            utf8::downgrade( $file, 1 )
-              or die "Bullshit! File path could not be converted back to a byte sequence!"
-              ;    # This error happening would not make any sense at all so it deserves the EYE reference
-
             $logger->info("Processing uploaded file $file...");
 
             # Since we already have a file, this goes straight to handle_incoming_file.

--- a/lib/LANraragi/Utils/Path.pm
+++ b/lib/LANraragi/Utils/Path.pm
@@ -9,11 +9,12 @@ no warnings 'experimental::signatures';
 use Encode;
 use Config;
 use File::Find;
+use File::Copy qw(move);
 
 use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );
 
 use Exporter 'import';
-our @EXPORT_OK = qw(create_path open_path date_modified compat_path unlink_path find_path get_archive_path rename_path);
+our @EXPORT_OK = qw(create_path open_path date_modified compat_path unlink_path find_path get_archive_path rename_path move_path);
 
 BEGIN {
     if ( !IS_UNIX ) {
@@ -70,6 +71,15 @@ sub rename_path ( $old_file, $new_file ) {
         return CORE::rename $old_file, $new_file;
     } else {
         return Win32::LongPath::renameL( decode_utf8( $old_file ), decode_utf8( $new_file ) );
+    }
+}
+
+sub move_path ( $old_file, $new_file ) {
+    if ( IS_UNIX ) {
+        return move( $old_file, $new_file );
+    } else {
+        return unless Win32::LongPath::copyL( decode_utf8( $old_file ), decode_utf8( $new_file ) );
+        return Win32::LongPath::unlinkL( decode_utf8( $old_file ) );
     }
 }
 

--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -33,7 +33,7 @@ use LANraragi::Utils::Database   qw(invalidate_cache compute_id change_archive_i
 use LANraragi::Utils::Logging    qw(get_logger);
 use LANraragi::Utils::Generic    qw(is_archive);
 use LANraragi::Utils::Redis      qw(redis_encode);
-use LANraragi::Utils::Path       qw(create_path open_path find_path);
+use LANraragi::Utils::Path       qw(create_path open_path find_path get_archive_path);
 
 use LANraragi::Model::Config;
 use LANraragi::Model::Plugins;
@@ -233,7 +233,7 @@ sub add_to_filemap ( $redis_cfg, $file ) {
         # Filename sanity check
         if ( $redis_arc->exists($id) ) {
 
-            my $filecheck = $redis_arc->hget( $id, "file" );
+            my $filecheck = get_archive_path( $redis_arc, $id );
 
             #Update the real file path and title if they differ from the saved one
             #This is meant to always track the current filename for the OS.

--- a/tools/build/docker/install-everything.sh
+++ b/tools/build/docker/install-everything.sh
@@ -90,13 +90,13 @@ if [ $(uname -m) == 'x86_64' ]; then
   #Install deps only
   cpanm --notest --installdeps Alien::FFI
   cpanm Sort::Versions 
-  curl -L -s https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/Alien-FFI-0.25.tar.gz | tar -xz
-  cd Alien-FFI-0.25
+  curl -L -s https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/Alien-FFI-0.27.tar.gz | tar -xz
+  cd Alien-FFI-0.27
   # Patch build script to disable AVX - and SSE4 for real old CPUs
   # See https://developers.redhat.com/blog/2021/01/05/building-red-hat-enterprise-linux-9-for-the-x86-64-v2-microarchitecture-level
   sed -i 's/--disable-builddir/--disable-builddir --with-gcc-arch=x86-64/' alienfile
   perl Makefile.PL && make install
-  cd ../ && rm -rf Alien-FFI-0.25
+  cd ../ && rm -rf Alien-FFI-0.27
 fi
 
 #Install the LRR dependencies proper

--- a/tools/build/windows/create-dist.sh
+++ b/tools/build/windows/create-dist.sh
@@ -24,6 +24,10 @@ find ./win-dist/runtime/lib/ImageMagick-7.1.2/ -name "*.a" -type f -delete
 # Copy vips modules
 cp -R /ucrt64/lib/vips-modules-8.17 ./win-dist/runtime/lib
 
+# Remove unused vips modules
+rm ./win-dist/runtime/lib/vips-modules-8.17/vips-poppler.dll
+rm ./win-dist/runtime/lib/vips-modules-8.17/vips-openslide.dll
+
 # Copy more openssl stuff
 mkdir -p ./win-dist/runtime/share
 

--- a/tools/build/windows/install.sh
+++ b/tools/build/windows/install.sh
@@ -20,18 +20,18 @@ perl Makefile.PL && mingw32-make install
 cd ../ && rm -rf Crypt-DES-2.07
 
 cpanm --notest --installdeps Minion -M https://cpan.metacpan.org
-curl -L -s https://cpan.metacpan.org/authors/id/S/SR/SRI/Minion-10.31.tar.gz | tar -xz
-cd Minion-10.31
+curl -L -s https://cpan.metacpan.org/authors/id/S/SR/SRI/Minion-11.0.tar.gz | tar -xz
+cd Minion-11.0
 sed -i "s/croak 'Minion workers do not support fork emulation'/#croak 'Minion workers do not support fork emulation'/" lib/Minion.pm
 perl Makefile.PL && mingw32-make install
-cd ../ && rm -rf Minion-10.31
+cd ../ && rm -rf Minion-11.0
 
 cpanm --notest --installdeps Image::Magick -M https://cpan.metacpan.org
-curl -L -s https://cpan.metacpan.org/authors/id/J/JC/JCRISTY/Image-Magick-7.1.1-28.tar.gz | tar -xz
-cd Image-Magick-7.1.1
+curl -L -s https://cpan.metacpan.org/authors/id/J/JC/JCRISTY/Image-Magick-7.1.2-3.tar.gz | tar -xz
+cd Image-Magick-7.1.2
 patch -p1 < ../build/windows/perl-Image-Magic-fix-msys2.patch
 perl Makefile.PL && mingw32-make install
-cd ../ && rm -rf Image-Magick-7.1.1
+cd ../ && rm -rf Image-Magick-7.1.2
 
 # Install remaining modules
 cpanm --notest --installdeps . -M https://cpan.metacpan.org

--- a/tools/install.pl
+++ b/tools/install.pl
@@ -160,7 +160,7 @@ if ( $back || $full ) {
         say("Installing dependencies for windows systems... (This will do nothing if the package is there already)");
 
         install_package( "Win32::Process", $cpanopt );
-        install_package( "Win32::FileSystemHelper", "https://github.com/Guerra24/Win32-FileSystemHelper/archive/e0cc6443f6c88bf2281c99dc7ef32bca7628e707.zip " . $cpanopt );
+        install_package( "Win32::FileSystemHelper", "https://github.com/Guerra24/Win32-FileSystemHelper/archive/308b92c958bb4931dfd704cc5025f93e28ef0c8a.zip " . $cpanopt );
         install_package( "File::ChangeNotify::Watcher::Win32", "https://github.com/Guerra24/File-ChangeNotify-Watcher-Win32/archive/7cb4e60823569cca8e7652d19b1ba5b5cac00a16.zip " .$cpanopt );
     }
 

--- a/tools/install.pl
+++ b/tools/install.pl
@@ -160,7 +160,7 @@ if ( $back || $full ) {
         say("Installing dependencies for windows systems... (This will do nothing if the package is there already)");
 
         install_package( "Win32::Process", $cpanopt );
-        install_package( "Win32::FileSystemHelper", "https://github.com/Guerra24/Win32-FileSystemHelper/archive/d2f241714111ff4ab77498a15839315dd28b6287.zip " . $cpanopt );
+        install_package( "Win32::FileSystemHelper", "https://github.com/Guerra24/Win32-FileSystemHelper/archive/e0cc6443f6c88bf2281c99dc7ef32bca7628e707.zip " . $cpanopt );
         install_package( "File::ChangeNotify::Watcher::Win32", "https://github.com/Guerra24/File-ChangeNotify-Watcher-Win32/archive/7cb4e60823569cca8e7652d19b1ba5b5cac00a16.zip " .$cpanopt );
     }
 


### PR DESCRIPTION
- Fix #1410.
- Fix #1418.
- Fix filewatcher delete event using short paths instead of long paths.
- Added get_archive_path for getting the archive path without going through create_path every time.
- Better handling of special characters when uploading files.
- Install windows deps as part of the MSYS2 setup step.
- Update perl deps on Windows.
- Bump Alien::FFI version.

[Win32::FileSystemHelper diff](https://github.com/Guerra24/Win32-FileSystemHelper/commit/308b92c958bb4931dfd704cc5025f93e28ef0c8a)
