### PR TITLE
Fixed broken apostrophe in FAKKU description

### DIFF
--- a/lib/LANraragi/Plugin/Metadata/Fakku.pm
+++ b/lib/LANraragi/Plugin/Metadata/Fakku.pm
@@ -9,6 +9,7 @@ use URI::Escape;
 use Mojo::JSON qw(decode_json);
 use Mojo::UserAgent;
 use Mojo::DOM;
+use Mojo::Util qw(html_unescape);
 
 #You can also use the LRR Internal API when fitting.
 use LANraragi::Model::Plugins;
@@ -25,7 +26,7 @@ sub plugin_info {
         namespace   => "fakkumetadata",
         login_from  => "fakkulogin",
         author      => "Difegue, Nodja, Nixis198",
-        version     => "1.0.1",
+        version     => "1.0.2",
         description =>
           "Searches FAKKU for tags matching your archive. If you have an account, don't forget to enter the matching cookie in the login plugin to be able to access controversial content. <br/><br/>
            <i class='fa fa-exclamation-circle'></i> <b>This plugin can and will return invalid results depending on what you're searching for!</b> <br/>The FAKKU search API isn't very precise and I recommend you either enable 'Only use current title for exact matches', or use the Chaika.moe plugin when possible.",
@@ -201,7 +202,12 @@ sub get_tags_from_fakku {
 
     # # If the Summary DIV doesn't exist, return a blank string.
     if ($summ_div) {
-        $summary = $summ_div->{content};
+        $summary = html_unescape( $summ_div->{content} );
+
+        # Sometime if the description has unwanted text.
+        if ( $summary =~ m/Free sample available now!/ ) {
+            $summary = "";
+        }
     } else {
         $summary = "";
     }

--- a/tests/LANraragi/Plugin/Metadata/Fakku.t
+++ b/tests/LANraragi/Plugin/Metadata/Fakku.t
@@ -55,8 +55,8 @@ note("testing parsing gallery front page no source tag...");
 
     my ( $tags, $title, $summary ) = LANraragi::Plugin::Metadata::Fakku::get_tags_from_fakku("https://url/to/my/page.html");
     cmp_bag( [ split( ', ', $tags ) ], \@tags_list_from_gallery_no_source, "tag check" );
-    is( $title,   'Kairakuten Cover Girl\'s Episode 009: Hamao',     "title check" );
-    is( $summary, 'Bold baby bold. This is a test summary. Hi mom.', "summary check" );
+    is( $title,   'Kairakuten Cover Girl\'s Episode 009: Hamao',             "title check" );
+    is( $summary, 'Bold baby bold. Test\'s This is a test summary. Hi mom.', "summary check" );
 }
 
 note("testing parsing gallery front page with source tag...");
@@ -70,8 +70,8 @@ note("testing parsing gallery front page with source tag...");
     my ( $tags, $title, $summary ) =
       LANraragi::Plugin::Metadata::Fakku::get_tags_from_fakku( "https://url/to/my/page.html", "", 1 );
     cmp_bag( [ split( ', ', $tags ) ], \@tags_list_from_gallery_with_source, "tag check" );
-    is( $title,   'Kairakuten Cover Girl\'s Episode 009: Hamao',     "title check" );
-    is( $summary, 'Bold baby bold. This is a test summary. Hi mom.', "summary check" );
+    is( $title,   'Kairakuten Cover Girl\'s Episode 009: Hamao',             "title check" );
+    is( $summary, 'Bold baby bold. Test\'s This is a test summary. Hi mom.', "summary check" );
 }
 
 note("get_tags dies if fakku's cookie doesn't exists");

--- a/tests/samples/fakku/002_gallery_front.html
+++ b/tests/samples/fakku/002_gallery_front.html
@@ -31,7 +31,7 @@
     <meta name="Robots" content="Index,Follow">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
 
-    <meta name="description" content="Bold baby bold. This is a test summary. Hi mom.">
+    <meta name="description" content="Bold baby bold. Test&amp;apos;s This is a test summary. Hi mom.">
     <meta property="og:title" content="Kairakuten Cover Girl&#39;s Episode 009: Hamao Hentai by Hamao - FAKKU">
     <meta property="og:type" content="article">
     <meta property="og:locale" content="en_US">
@@ -324,7 +324,7 @@
                         <div class="table text-sm w-full">
                             <div
                                 class="table-cell w-full align-top text-left space-y-2 leading-relaxed link:text-blue-700 dark:link:text-white">
-                                <b>Bold baby bold. </b>This is a test summary. Hi mom.
+                                <b>Bold baby bold. </b>Test's This is a test summary. Hi mom.
                             </div>
                         </div>
 


### PR DESCRIPTION
@kazuuuuu on Discord found an issue with the descriptions made from the FAKKU plugin. Before it wouldn't properly decode apostrophes and ampersands, now it wil. Updated the tests to add an apostrophe to check for. Also noticed that if a gallery doesn't have a description on FAKKU, in the HTML it still has one but it is more of an advertisement. Added a check to find that and not return a description if found.