### PR TITLE
Add ratings section to reader overlay

### DIFF
--- a/locales/template/en.po
+++ b/locales/template/en.po
@@ -938,6 +938,18 @@ msgstr " -- No Category -- "
 msgid "Add Archive to Category"
 msgstr "Add Archive to Category"
 
+msgid "Rating"
+msgstr "Rating"
+
+msgid "Set Rating"
+msgstr "Set Rating"
+
+msgid "Clear Rating"
+msgstr "Clear Rating"
+
+msgid " -- Select Rating -- "
+msgstr " -- Select Rating -- "
+
 msgid "Pages"
 msgstr "Pages"
 

--- a/public/js/common.js
+++ b/public/js/common.js
@@ -226,6 +226,15 @@ LRR.splitTagsByNamespace = function (tags) {
 };
 
 /**
+ * Converts tag dictionary into list of tags.
+ * @param {{ [namespace: string]: string[] }} tagsDict Per-namespace dictionary of arrays containing tags under each namespace.
+ * @returns List of tags prefixed with namespace.
+ */
+LRR.buildTagList = function(tagsDict) {
+    return Object.entries(tagsDict).flatMap(([namespace, tagArray]) => tagArray.map(tag => LRR.buildNamespacedTag(namespace, tag)));
+};
+
+/**
  * Builds a caption div containing clickable tags. Namespaces are resolved on the fly.
  * @param {*} tags string containing all tags, split by commas.
  * @returns the div

--- a/public/js/common.js
+++ b/public/js/common.js
@@ -109,7 +109,7 @@ LRR.isNullOrWhitespace = function (input) {
 LRR.getTagSearchURL = function (namespace, tag) {
     const namespacedTag = this.buildNamespacedTag(namespace, tag);
     if (namespace !== "source") {
-        return new LRR.apiURL(`/?q=${encodeURIComponent(namespacedTag)}`);
+        return new LRR.apiURL(`/?q=${encodeURIComponent(namespacedTag)}$`);
     } else if (/https?:\/\//.test(tag)) {
         return `${tag}`;
     } else {

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -734,7 +734,7 @@ Index.loadContextMenuRatings = (id) => Server.callAPI(`/api/archives/${id}/metad
                     if(i === 0) delete tags["rating"];
                     else tags["rating"] = [ratings[i].name];
 
-                    Server.updateTagsFromArchive(id, Object.entries(tags).flatMap(([namespace, tagArray]) => tagArray.map(tag => LRR.buildNamespacedTag(namespace, tag))));
+                    Server.updateTagsFromArchive(id, LRR.buildTagList(tags));
 
                     // Update the rating info without reload but have to refresh everything.
                     IndexTable.dataTable.ajax.reload(null, false);

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -109,14 +109,14 @@ Reader.initializeAll = function () {
         let selectedRating = $("#rating").val();
         if (selectedRating === "") { return };
         tags.rating = [selectedRating];
-        let tagList = Object.entries(tags).flatMap(([namespace, tagArray]) => tagArray.map(tag => LRR.buildNamespacedTag(namespace, tag)))
+        let tagList = LRR.buildTagList(tags);
         Server.updateTagsFromArchive(Reader.id, tagList);
         $("#tagContainer > table").replaceWith(LRR.buildTagsDiv(tagList.join(",")));
     });
     $(document).on("click.clear-rating", "#clear-rating", () => {
         let tags = LRR.splitTagsByNamespace(Reader.tags);
         delete tags.rating;
-        let tagList = Object.entries(tags).flatMap(([namespace, tagArray]) => tagArray.map(tag => LRR.buildNamespacedTag(namespace, tag)))
+        let tagList = LRR.buildTagList(tags);
         Server.updateTagsFromArchive(Reader.id, tagList);
         document.querySelector('#rating').selectedIndex = 0;
         $("#tagContainer > table").replaceWith(LRR.buildTagsDiv(tagList.join(",")));

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -104,6 +104,23 @@ Reader.initializeAll = function () {
                 .addClass("far fa-bookmark");
         }
     });
+    $(document).on("click.set-rating", "#set-rating", () => {
+        let tags = LRR.splitTagsByNamespace(Reader.tags);
+        let selectedRating = $("#rating").val();
+        if (selectedRating === "") { return };
+        tags.rating = [selectedRating];
+        let tagList = Object.entries(tags).flatMap(([namespace, tagArray]) => tagArray.map(tag => LRR.buildNamespacedTag(namespace, tag)))
+        Server.updateTagsFromArchive(Reader.id, tagList);
+        $("#tagContainer > table").replaceWith(LRR.buildTagsDiv(tagList.join(",")));
+    });
+    $(document).on("click.clear-rating", "#clear-rating", () => {
+        let tags = LRR.splitTagsByNamespace(Reader.tags);
+        delete tags.rating;
+        let tagList = Object.entries(tags).flatMap(([namespace, tagArray]) => tagArray.map(tag => LRR.buildNamespacedTag(namespace, tag)))
+        Server.updateTagsFromArchive(Reader.id, tagList);
+        document.querySelector('#rating').selectedIndex = 0;
+        $("#tagContainer > table").replaceWith(LRR.buildTagsDiv(tagList.join(",")));
+    });
     $(document).on("click.set-thumbnail", "#set-thumbnail", () => Server.callAPI(`/api/archives/${Reader.id}/thumbnail?page=${Reader.currentPage + 1}`,
         "PUT", I18N.ReaderUpdateThumbnail(Reader.currentPage), I18N.ReaderUpdateThumbnailError, null));
 

--- a/templates/reader.html.tt2
+++ b/templates/reader.html.tt2
@@ -141,7 +141,6 @@
                     <a class="fas fa-plus" id="add-category" href="#" title="[% c.lh('Add Archive to Category') %]"></a>
 
                     <h2>[% c.lh("Rating") %]</h2>
-                    <br />
 
                     <select id="rating" class="favtag-btn" style="width:200px" autocomplete="off">
                         <option selected value="">[% c.lh(" -- Select Rating -- ") %]</option>

--- a/templates/reader.html.tt2
+++ b/templates/reader.html.tt2
@@ -139,6 +139,23 @@
                         [% END %]
                     </select>
                     <a class="fas fa-plus" id="add-category" href="#" title="[% c.lh('Add Archive to Category') %]"></a>
+
+                    <h2>[% c.lh("Rating") %]</h2>
+                    <br />
+
+                    <select id="rating" class="favtag-btn" style="width:200px" autocomplete="off">
+                        <option selected value="">[% c.lh(" -- Select Rating -- ") %]</option>
+                        <option value="⭐">⭐</option>
+                        <option value="⭐⭐">⭐⭐</option>
+                        <option value="⭐⭐⭐">⭐⭐⭐</option>
+                        <option value="⭐⭐⭐⭐">⭐⭐⭐⭐</option>
+                        <option value="⭐⭐⭐⭐⭐">⭐⭐⭐⭐⭐</option>
+                    </select>
+                    <input id="set-rating" class="stdbtn" type="button" value="[% c.lh('Set Rating') %]"
+                        style="min-width: fit-content; padding-inline: 15px">
+                    <input id="clear-rating" class="stdbtn" type="button" value="[% c.lh('Clear Rating') %]"
+                        style="min-width: fit-content; padding-inline: 15px">
+
                 </div>
                 [% END %]
             </div>


### PR DESCRIPTION
Adds a section to reader overlay to set ratings. Includes buttons to clear and set rating, both will rebuild tags div after setting. 

* add `$` to the end of url returned by LRR.getTagSearchURL to return exact tag. This was particularly noticeable for ratings as `rating:⭐⭐⭐` would also return for 4 and 5 stars but could also result in unwanted results for normal tags.
* move tag object to list functionality found in index.js into function as the same pattern is used for updating reader tags