### PR TITLE
Feat: implment language option

### DIFF
--- a/lib/LANraragi/Controller/Config.pm
+++ b/lib/LANraragi/Controller/Config.pm
@@ -48,7 +48,8 @@ sub index {
         hqthumbpages    => $self->LRR_CONF->get_hqthumbpages,
         jxlthumbpages   => $self->LRR_CONF->get_jxlthumbpages,
         csshead         => generate_themes_header($self),
-        replacedupe     => $self->LRR_CONF->get_replacedupe
+        replacedupe     => $self->LRR_CONF->get_replacedupe,
+        language        => $self->LRR_CONF->get_language
     );
 }
 
@@ -73,6 +74,7 @@ sub save_config {
         readerquality => scalar $self->req->param('readerquality'),
         sizethreshold => scalar $self->req->param('sizethreshold'),
         theme         => scalar $self->req->param('theme'),
+        language      => scalar $self->req->param('language'),
 
         # For checkboxes,
         # we check if the parameter exists in the POST to return either 1 or 0.

--- a/lib/LANraragi/Model/Config.pm
+++ b/lib/LANraragi/Model/Config.pm
@@ -192,5 +192,6 @@ sub get_hqthumbpages     { return &get_redis_conf( "hqthumbpages",    "0" ) }
 sub get_jxlthumbpages    { return &get_redis_conf( "jxlthumbpages",   "0" ) }
 sub get_replacedupe      { return &get_redis_conf( "replacedupe",     "0" ) }
 sub can_replacetitles    { return &get_redis_conf( "replacetitles",   "1" ) }
+sub get_language         { return &get_redis_conf( "language",        "auto" ) }
 
 1;

--- a/lib/LANraragi/Utils/I18NInitializer.pm
+++ b/lib/LANraragi/Utils/I18NInitializer.pm
@@ -9,14 +9,20 @@ use LANraragi::Utils::I18N;
 sub initialize {
     my ($app) = @_;
 
+    # Load forced language setting at startup to avoid querying Redis on every request
+    my $forced_language = $app->LRR_CONF->get_language;
+    $app->defaults( forced_language => $forced_language );
+    
+    $app->LRR_LOGGER->debug("Forced language setting: $forced_language");
+
     $app->helper(
         lh => sub {
             my ( $c, $key, @args ) = @_;
             
             my @langs = ();
             
-            # Check if there's a forced language setting
-            my $forced_language = $c->LRR_CONF->get_language;
+            # Check if there's a forced language setting (loaded at startup)
+            my $forced_language = $c->stash('forced_language');
             
             if ( $forced_language && $forced_language ne 'auto' ) {
                 # Use the forced language setting

--- a/lib/LANraragi/Utils/I18NInitializer.pm
+++ b/lib/LANraragi/Utils/I18NInitializer.pm
@@ -12,23 +12,34 @@ sub initialize {
     $app->helper(
         lh => sub {
             my ( $c, $key, @args ) = @_;
-            my $accept_language = $c->req->headers->accept_language;
-
+            
             my @langs = ();
+            
+            # Check if there's a forced language setting
+            my $forced_language = $c->LRR_CONF->get_language;
+            
+            if ( $forced_language && $forced_language ne 'auto' ) {
+                # Use the forced language setting
+                push @langs, $forced_language;
+                $c->LRR_LOGGER->trace( "Using forced language: $forced_language" );
+            } else {
+                # Fall back to Accept-Language header
+                my $accept_language = $c->req->headers->accept_language;
 
-            if ($accept_language) {
+                if ($accept_language) {
 
-                # An Accept-Language header looks like: Accept-Language zh-TW,zh-CN;q=0.8,fr;q=0.7,fr-FR;q=0.5,en-US;q=0.3,en;q=0.2
-                # Split the header by commas to get the languages
-                @langs = split /,/, $accept_language;
+                    # An Accept-Language header looks like: Accept-Language zh-TW,zh-CN;q=0.8,fr;q=0.7,fr-FR;q=0.5,en-US;q=0.3,en;q=0.2
+                    # Split the header by commas to get the languages
+                    @langs = split /,/, $accept_language;
 
-                # For each language, remove the quality value (aka ;q=0.9)
-                # Browsers usually order the languages by quality already do we don't really need them
-                foreach my $lang (@langs) {
-                    $lang =~ s/;.*//;    # remove any quality value
+                    # For each language, remove the quality value (aka ;q=0.9)
+                    # Browsers usually order the languages by quality already do we don't really need them
+                    foreach my $lang (@langs) {
+                        $lang =~ s/;.*//;    # remove any quality value
+                    }
+
+                    $c->LRR_LOGGER->trace( "Detected languages in order of preference: " . join( ", ", @langs ) );
                 }
-
-                $c->LRR_LOGGER->trace( "Detected languages in order of preference: " . join( ", ", @langs ) );
             }
 
             # Add english to the end of the list if not already present

--- a/locales/template/en.po
+++ b/locales/template/en.po
@@ -313,6 +313,15 @@ msgstr "This will delete metadata for old files when they're replaced! Use with 
 
 # ------Start of Config_Global.html.tt2------
 
+msgid "Language"
+msgstr "Language"
+
+msgid "Automatic (browser default)"
+msgstr "Automatic (browser default)"
+
+msgid "Select the language for the user interface. Set to Automatic to use your browser's language preference."
+msgstr "Select the language for the user interface. Set to Automatic to use your browser's language preference."
+
 msgid "Site Title"
 msgstr "Site Title"
 

--- a/public/themes/ex.css
+++ b/public/themes/ex.css
@@ -261,10 +261,6 @@ tr.gtr1 {
     box-sizing: border-box;
 }
 
-select.stdinput {
-    height: 25px;
-}
-
 .stdinput:hover {
     color: #f1f1f1;
     background: #43464e

--- a/public/themes/ex.css
+++ b/public/themes/ex.css
@@ -258,6 +258,11 @@ tr.gtr1 {
     padding: 2px 3px 2px 3px;
     width: 80%;
     max-width: 450px;
+    box-sizing: border-box;
+}
+
+select.stdinput {
+    height: 25px;
 }
 
 .stdinput:hover {

--- a/public/themes/g.css
+++ b/public/themes/g.css
@@ -248,10 +248,6 @@ tr.gtr1 {
     box-sizing: border-box;
 }
 
-select.stdinput {
-    height: 25px;
-}
-
 .stdinput:hover {
     background: none repeat scroll 0 0 #F2EFDF;
     color: #9B4E03;

--- a/public/themes/g.css
+++ b/public/themes/g.css
@@ -245,6 +245,11 @@ tr.gtr1 {
     padding: 2px 3px;
     width: 80%;
     max-width: 450px;
+    box-sizing: border-box;
+}
+
+select.stdinput {
+    height: 25px;
 }
 
 .stdinput:hover {

--- a/public/themes/modern.css
+++ b/public/themes/modern.css
@@ -288,10 +288,6 @@ tr.gtr1 {
   box-sizing: border-box;
 }
 
-select.stdinput {
-  height: 25px;
-}
-
 .tagger {
   background: none repeat scroll 0 0 #ECF0F1;
   font-family: "Geist", arial, sans-serif;

--- a/public/themes/modern.css
+++ b/public/themes/modern.css
@@ -285,6 +285,11 @@ tr.gtr1 {
   margin: 4px 1px 0;
   padding: 2px 7px;
   border-radius: 3px;
+  box-sizing: border-box;
+}
+
+select.stdinput {
+  height: 25px;
 }
 
 .tagger {

--- a/public/themes/modern_clear.css
+++ b/public/themes/modern_clear.css
@@ -345,10 +345,6 @@ tr.gtr1 {
     box-sizing: border-box;
 }
 
-select.stdinput {
-    height: 25px;
-}
-
 .tagger {
     background: none repeat scroll 0 0 #fcfcfc;
     font-family: 'Inter UI', arial, sans-serif;

--- a/public/themes/modern_clear.css
+++ b/public/themes/modern_clear.css
@@ -342,6 +342,11 @@ tr.gtr1 {
     max-width: 450px;
     width: 80%;
     border-radius: 3px;
+    box-sizing: border-box;
+}
+
+select.stdinput {
+    height: 25px;
 }
 
 .tagger {

--- a/public/themes/modern_red.css
+++ b/public/themes/modern_red.css
@@ -276,6 +276,11 @@ tr.gtr1 {
   max-width: 450px;
   padding: 2px 3px;
   width: 80%;
+  box-sizing: border-box;
+}
+
+select.stdinput {
+  height: 25px;
 }
 
 .tagger {

--- a/public/themes/modern_red.css
+++ b/public/themes/modern_red.css
@@ -279,10 +279,6 @@ tr.gtr1 {
   box-sizing: border-box;
 }
 
-select.stdinput {
-  height: 25px;
-}
-
 .tagger {
   background: none repeat scroll 0 0 #FCFCFC;
   border: medium none;

--- a/templates/templates_config/config_global.html.tt2
+++ b/templates/templates_config/config_global.html.tt2
@@ -1,5 +1,29 @@
 <tr>
     <td class="option-td">
+        <h2 class="ih"> [% c.lh("Language") %] </h2>
+    </td>
+    <td class="config-td">
+        <select class="favtag-btn" name="language" style="width:100%">
+            <option value="auto" [% IF language == 'auto' %]selected[% END %]>[% c.lh("Automatic (browser default)") %]</option>
+            <option value="en" [% IF language == 'en' %]selected[% END %]>English</option>
+            <option value="es" [% IF language == 'es' %]selected[% END %]>Español (Spanish)</option>
+            <option value="zh" [% IF language == 'zh' %]selected[% END %]>简体中文 (Simplified Chinese)</option>
+            <option value="zh-tw" [% IF language == 'zh-tw' %]selected[% END %]>繁體中文 (Traditional Chinese)</option>
+            <option value="fr" [% IF language == 'fr' %]selected[% END %]>Français (French)</option>
+            <option value="id" [% IF language == 'id' %]selected[% END %]>Bahasa Indonesia (Indonesian)</option>
+            <option value="ko" [% IF language == 'ko' %]selected[% END %]>한국어 (Korean)</option>
+            <option value="no" [% IF language == 'no' %]selected[% END %]>Norsk (Norwegian)</option>
+            <option value="pt" [% IF language == 'pt' %]selected[% END %]>Português (Portuguese)</option>
+            <option value="de" [% IF language == 'de' %]selected[% END %]>Deutsch (German)</option>
+            <option value="it" [% IF language == 'it' %]selected[% END %]>Italiano (Italian)</option>
+            <option value="vi" [% IF language == 'vi' %]selected[% END %]>Tiếng Việt (Vietnamese)</option>
+        </select>
+        <br>[% c.lh("Select the language for the user interface. Set to Automatic to use your browser's language preference.") %]
+    </td>
+</tr>
+
+<tr>
+    <td class="option-td">
         <h2 class="ih"> [% c.lh("Site Title") %] </h2>
     </td>
     <td class="config-td">

--- a/templates/templates_config/config_global.html.tt2
+++ b/templates/templates_config/config_global.html.tt2
@@ -40,7 +40,8 @@
             <option value="it" [% IF language == 'it' %]selected[% END %]>Italiano (Italian)</option>
             <option value="vi" [% IF language == 'vi' %]selected[% END %]>Tiếng Việt (Vietnamese)</option>
         </select>
-        <br>[% c.lh("Select the language for the user interface. Set to Automatic to use your browser's language preference.") %]
+        <br>[% c.lh("Select the language for the user interface. Set to Automatic to use your browser's language preference.") %] <br />
+        [% c.lh("Fully effective after restarting LANraragi.") %]
     </td>
 </tr>
 

--- a/templates/templates_config/config_global.html.tt2
+++ b/templates/templates_config/config_global.html.tt2
@@ -1,29 +1,5 @@
 <tr>
     <td class="option-td">
-        <h2 class="ih"> [% c.lh("Language") %] </h2>
-    </td>
-    <td class="config-td">
-        <select class="favtag-btn" name="language" style="width:100%">
-            <option value="auto" [% IF language == 'auto' %]selected[% END %]>[% c.lh("Automatic (browser default)") %]</option>
-            <option value="en" [% IF language == 'en' %]selected[% END %]>English</option>
-            <option value="es" [% IF language == 'es' %]selected[% END %]>Español (Spanish)</option>
-            <option value="zh" [% IF language == 'zh' %]selected[% END %]>简体中文 (Simplified Chinese)</option>
-            <option value="zh-tw" [% IF language == 'zh-tw' %]selected[% END %]>繁體中文 (Traditional Chinese)</option>
-            <option value="fr" [% IF language == 'fr' %]selected[% END %]>Français (French)</option>
-            <option value="id" [% IF language == 'id' %]selected[% END %]>Bahasa Indonesia (Indonesian)</option>
-            <option value="ko" [% IF language == 'ko' %]selected[% END %]>한국어 (Korean)</option>
-            <option value="no" [% IF language == 'no' %]selected[% END %]>Norsk (Norwegian)</option>
-            <option value="pt" [% IF language == 'pt' %]selected[% END %]>Português (Portuguese)</option>
-            <option value="de" [% IF language == 'de' %]selected[% END %]>Deutsch (German)</option>
-            <option value="it" [% IF language == 'it' %]selected[% END %]>Italiano (Italian)</option>
-            <option value="vi" [% IF language == 'vi' %]selected[% END %]>Tiếng Việt (Vietnamese)</option>
-        </select>
-        <br>[% c.lh("Select the language for the user interface. Set to Automatic to use your browser's language preference.") %]
-    </td>
-</tr>
-
-<tr>
-    <td class="option-td">
         <h2 class="ih"> [% c.lh("Site Title") %] </h2>
     </td>
     <td class="config-td">
@@ -41,6 +17,30 @@
         <input id="motd" class="stdinput" style="width:100%" maxlength="255" size="20" value="[% motd %]" name="motd"
             type="text">
         <br>[% c.lh("Slang for Message of the Day. Appears on top of the main Library view.") %]
+    </td>
+</tr>
+
+<tr>
+    <td class="option-td">
+        <h2 class="ih"> [% c.lh("Language") %] </h2>
+    </td>
+    <td class="config-td">
+        <select class="stdinput" name="language" style="width:100%">
+            <option value="auto" [% IF language == 'auto' %]selected[% END %]>[% c.lh("Automatic (browser default)") %]</option>
+            <option value="en" [% IF language == 'en' %]selected[% END %]>English</option>
+            <option value="es" [% IF language == 'es' %]selected[% END %]>Español (Spanish)</option>
+            <option value="zh" [% IF language == 'zh' %]selected[% END %]>简体中文 (Simplified Chinese)</option>
+            <option value="zh-tw" [% IF language == 'zh-tw' %]selected[% END %]>繁體中文 (Traditional Chinese)</option>
+            <option value="fr" [% IF language == 'fr' %]selected[% END %]>Français (French)</option>
+            <option value="id" [% IF language == 'id' %]selected[% END %]>Bahasa Indonesia (Indonesian)</option>
+            <option value="ko" [% IF language == 'ko' %]selected[% END %]>한국어 (Korean)</option>
+            <option value="no" [% IF language == 'no' %]selected[% END %]>Norsk (Norwegian)</option>
+            <option value="pt" [% IF language == 'pt' %]selected[% END %]>Português (Portuguese)</option>
+            <option value="de" [% IF language == 'de' %]selected[% END %]>Deutsch (German)</option>
+            <option value="it" [% IF language == 'it' %]selected[% END %]>Italiano (Italian)</option>
+            <option value="vi" [% IF language == 'vi' %]selected[% END %]>Tiếng Việt (Vietnamese)</option>
+        </select>
+        <br>[% c.lh("Select the language for the user interface. Set to Automatic to use your browser's language preference.") %]
     </td>
 </tr>
 

--- a/tools/Documentation/extending-lanraragi/architecture.md
+++ b/tools/Documentation/extending-lanraragi/architecture.md
@@ -207,6 +207,7 @@ The base architecture is as follows:
 |- LRR_CONFIG <- Configuration keys, usually set through the LRR Configuration page.
 |  |- htmltitle
 |  |- motd
+|  |- language <- Forced UI language
 |  |- dirname  <- Content directory
 |  |- thumbdir <- Thumbnail directory  
 |  |- tempmaxsize <- Temp folder max size 

--- a/tools/Documentation/extending-lanraragi/translations.md
+++ b/tools/Documentation/extending-lanraragi/translations.md
@@ -4,7 +4,7 @@ description: Details on making additional translations for the server's Web UI.
 
 # 🈁 Translating LANraragi to other languages
 
-LRR will automatically render its web UI in the language requested by your web browser's `Accept-Language` header, if it supports it.\
+LRR will automatically render its web UI in the language requested by your web browser's `Accept-Language` header, if it supports it. You can also manually force a specific language in the Configuration page under Global Settings.\
 Unsupported languages will fallback to English.
 
 Here are some pointers on contributing additional translations to LANraragi.\


### PR DESCRIPTION
I implmented this FR issue #1278 .

I added a new item in the config page. To keep the styles of the existing inputs and this new select the same, some styles were updated.

One problem is that I can not judge whether the language names are correct since they are AI-generated, e.g. whether "Français" in French is the meaning of "French" in English. It seems OK when I searched these names on Google.

In addition, I updated related documents.

One future improvements may be using some library to map the language codes to their native language names and those in English. Also, the languages available can be fetched from weblate API so that we do not need to update the code when a new language is available.