### PR TITLE
Adjust handlePaste so that it can append the pasted text to an existing pending tag

### DIFF
--- a/public/js/edit.js
+++ b/public/js/edit.js
@@ -77,11 +77,28 @@ Edit.handlePaste = function (event) {
     event.stopPropagation();
     event.preventDefault();
 
+    // Get the pending text already typed in the input field
+    const inputElement = $(".tagger-new").children()[0];
+    const pendingText = inputElement ? inputElement.textContent : "";
+
     // Get pasted data via clipboard API
     const pastedData = event.originalEvent.clipboardData.getData("Text");
 
     if (pastedData !== "") {
-        pastedData.split(/,\s?/).forEach((tag) => {
+        // Split by comma to handle multiple pasted tags
+        const tags = pastedData.split(/,\s?/);
+
+        // Prepend pending text to the first tag
+        if (pendingText && tags.length > 0) {
+            tags[0] = pendingText + tags[0];
+
+            // Clear the pending text from the input since we're incorporating it
+            if (inputElement) {
+                inputElement.textContent = "";
+            }
+        }
+
+        tags.forEach((tag) => {
             Edit.addTag(tag);
         });
     }


### PR DESCRIPTION
## Description
- This PR enhances `Edit.handlePaste` so it appends the pasted text to a pending tag before combining them together into a new tag.
- Currently when you paste text into the `Tags` text box with no pending tag in it, it submits it as a new tag. If it does have a pending tag like "artist:" and you paste in text like "Hirohiko Araki", it creates "Hirohiko Araki" as a new tag and the "artist:" is still pending.


https://github.com/user-attachments/assets/e812d2d6-6ce1-4fd1-ae31-a26d60cb1213


https://github.com/user-attachments/assets/ed5062d6-af25-4591-8ae9-d1df59a3e221

