### PR TITLE
Disable chaika testing

### DIFF
--- a/tests/plugins.t
+++ b/tests/plugins.t
@@ -63,23 +63,23 @@ note("nHentai Tests : Disabled due to cloudflare being used on nH");
 #     ok( length $nH_hashdata{title} > 0, 'nHentai title test' );
 # }
 
-note("Chaika Tests");
+note("Chaika Tests : Disabled due to rate limiting");
 
-{
-    my ( $tags_jsearch, $title_jsearch ) =
-      trap { LANraragi::Plugin::Metadata::Chaika::search_for_archive( "Zettai Seikou Keikaku", "artist:kemuri haku" ); };
-    ok( length $tags_jsearch > 0,  'chaika.moe search test' );
-    ok( length $title_jsearch > 0, 'chaika.moe title test' );
+# {
+#     my ( $tags_jsearch, $title_jsearch ) =
+#       trap { LANraragi::Plugin::Metadata::Chaika::search_for_archive( "Zettai Seikou Keikaku", "artist:kemuri haku" ); };
+#     ok( length $tags_jsearch > 0,  'chaika.moe search test' );
+#     ok( length $title_jsearch > 0, 'chaika.moe title test' );
 
-    my ( $tags_by_id, $title_by_id ) = trap { LANraragi::Plugin::Metadata::Chaika::tags_from_chaika_id( "archive", "27240" ); };
-    ok( length $tags_by_id > 0,  'chaika.moe API Tag retrieval test' );
-    ok( length $title_by_id > 0, 'chaika.moe ID title test ' );
+#     my ( $tags_by_id, $title_by_id ) = trap { LANraragi::Plugin::Metadata::Chaika::tags_from_chaika_id( "archive", "27240" ); };
+#     ok( length $tags_by_id > 0,  'chaika.moe API Tag retrieval test' );
+#     ok( length $title_by_id > 0, 'chaika.moe ID title test ' );
 
-    my ( $tags_by_sha1, $title_by_sha1 ) =
-      trap { LANraragi::Plugin::Metadata::Chaika::tags_from_sha1("276601a0e5dae9427940ed17ac470c9945b47073"); };
-    ok( length $tags_jsearch > 0, 'chaika.moe SHA-1 reverse search test' );
-    ok( length $title_by_id > 0,  'chaika.moe SHA-1 title test' );
-}
+#     my ( $tags_by_sha1, $title_by_sha1 ) =
+#       trap { LANraragi::Plugin::Metadata::Chaika::tags_from_sha1("276601a0e5dae9427940ed17ac470c9945b47073"); };
+#     ok( length $tags_by_sha1 > 0, 'chaika.moe SHA-1 reverse search test' );
+#     ok( length $title_by_sha1 > 0,  'chaika.moe SHA-1 title test' );
+# }
 
 note("FAKKU Tests : Disabled due to cloudflare being used");
 


### PR DESCRIPTION
Chaika has rate limits which can fail unit tests, resulting in unreliable CI: https://github.com/psilabs-dev/LANraragi/actions/runs/20865711478/job/59956235343

Incidentally, fixed third test's typos.