### PR TITLE
update Edit.handlePaste

### DIFF
--- a/public/js/edit.js
+++ b/public/js/edit.js
@@ -80,7 +80,7 @@ Edit.handlePaste = function (event) {
 
     // Get the pending text already typed in the input field
     const inputElement = $(".tagger-new").children()[0];
-    const pendingText = inputElement ? inputElement.textContent : "";
+    const pendingText = inputElement ? inputElement.value : "";
 
     // Get pasted data via clipboard API
     const pastedData = event.originalEvent.clipboardData.getData("Text");
@@ -95,7 +95,7 @@ Edit.handlePaste = function (event) {
 
             // Clear the pending text from the input since we're incorporating it
             if (inputElement) {
-                inputElement.textContent = "";
+                inputElement.value = "";
             }
         }
 


### PR DESCRIPTION
Fixes the paste thingy during editor mode.

Currently: when you type "t" and paste "ag", LRR UI will create "ag" tag, with "t" after. I'm assuming that the expectation is for the paste to complete the tag creation, i.e. "tag" tag is created.

To see the problem, apply the following console logs; textContent is always empty regardless of what you paste:
```
    // Get the pending text already typed in the input field
    const inputElement = $(".tagger-new").children()[0];
    const pendingText = inputElement ? inputElement.textContent : "";
    console.log(inputElement.textContent);
    console.log(inputElement.value);
    console.log(inputElement);
```