### PR TITLE
Update integration tests

### DIFF
--- a/.github/workflows/push-continuous-integration.yml
+++ b/.github/workflows/push-continuous-integration.yml
@@ -10,11 +10,11 @@ on:
       integration_test_ref:
         description: 'Integration testing repository git commit hash or branch'
         required: true
-        default: '4c5ffe9d09042023be65807bc288eda41fd91e59'
+        default: '78fe5fff8926b295120e764d0bd335b9bf47c440'
 
 env:
   INTEGRATION_TEST_REPOSITORY: ${{ github.event.inputs.integration_test_repository || 'psilabs-dev/aio-lanraragi' }}
-  INTEGRATION_TEST_REF: ${{ github.event.inputs.integration_test_ref || '4c5ffe9d09042023be65807bc288eda41fd91e59' }}
+  INTEGRATION_TEST_REF: ${{ github.event.inputs.integration_test_ref || '78fe5fff8926b295120e764d0bd335b9bf47c440' }}
 
 name: "Continuous Integration \U0001F44C\U0001F440"
 jobs:
@@ -54,16 +54,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Install aio-lanraragi package
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+      - name: Install workspace packages
+        working-directory: aio-lanraragi
         run: |
-          cd aio-lanraragi
-          python -m pip install --upgrade pip
-          pip install ".[dev]"
-      - name: Install integration test dependencies
-        run: |
-          cd aio-lanraragi/integration_tests
-          pip install .
-          playwright install
+          uv sync --all-packages
+          uv run playwright install
       - name: Create staging directory
         run: |
           mkdir -p "$GITHUB_WORKSPACE/staging"
@@ -73,7 +70,7 @@ jobs:
           cd aio-lanraragi/integration_tests
           export CI=true
           export DOCKER_BUILDKIT=1
-          pytest tests --log-cli-level=INFO \
+          uv run pytest tests --log-cli-level=INFO \
             --build "$GITHUB_WORKSPACE/lanraragi" \
             --staging "$GITHUB_WORKSPACE/staging" \
             --playwright \
@@ -141,16 +138,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Install main package (aio-lanraragi)
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+      - name: Install workspace packages
         working-directory: aio-lanraragi
         run: |
-          python -m pip install --upgrade pip
-          pip install ".[dev]"
-      - name: Install integration test dependencies
-        working-directory: aio-lanraragi/integration_tests
-        run: |
-          pip install .
-          playwright install
+          uv sync --all-packages
+          uv run playwright install
       - name: Create staging directory
         run: |
           New-Item -ItemType Directory -Path "$env:GITHUB_WORKSPACE\staging" -Force | Out-Null
@@ -159,7 +153,7 @@ jobs:
         timeout-minutes: 50
         run: |
           $env:CI='true'
-          pytest tests `
+          uv run pytest tests `
           --log-cli-level=INFO `
           --windist "$env:GITHUB_WORKSPACE\LANraragi\win-dist" `
           --staging "$env:GITHUB_WORKSPACE\staging" `

--- a/.github/workflows/push-continuous-integration.yml
+++ b/.github/workflows/push-continuous-integration.yml
@@ -10,11 +10,11 @@ on:
       integration_test_ref:
         description: 'Integration testing repository git commit hash or branch'
         required: true
-        default: '57c32813e235abfb0b617edb272c8e58b4094801'
+        default: 'dfdcd948cbc6d6bbd2db6620d8499bc8698843e3'
 
 env:
   INTEGRATION_TEST_REPOSITORY: ${{ github.event.inputs.integration_test_repository || 'psilabs-dev/aio-lanraragi' }}
-  INTEGRATION_TEST_REF: ${{ github.event.inputs.integration_test_ref || '57c32813e235abfb0b617edb272c8e58b4094801' }}
+  INTEGRATION_TEST_REF: ${{ github.event.inputs.integration_test_ref || 'dfdcd948cbc6d6bbd2db6620d8499bc8698843e3' }}
 
 name: "Continuous Integration \U0001F44C\U0001F440"
 jobs:

--- a/.github/workflows/push-continuous-integration.yml
+++ b/.github/workflows/push-continuous-integration.yml
@@ -10,11 +10,11 @@ on:
       integration_test_ref:
         description: 'Integration testing repository git commit hash or branch'
         required: true
-        default: '78fe5fff8926b295120e764d0bd335b9bf47c440'
+        default: '57c32813e235abfb0b617edb272c8e58b4094801'
 
 env:
   INTEGRATION_TEST_REPOSITORY: ${{ github.event.inputs.integration_test_repository || 'psilabs-dev/aio-lanraragi' }}
-  INTEGRATION_TEST_REF: ${{ github.event.inputs.integration_test_ref || '78fe5fff8926b295120e764d0bd335b9bf47c440' }}
+  INTEGRATION_TEST_REF: ${{ github.event.inputs.integration_test_ref || '57c32813e235abfb0b617edb272c8e58b4094801' }}
 
 name: "Continuous Integration \U0001F44C\U0001F440"
 jobs:

--- a/.github/workflows/push-continuous-integration.yml
+++ b/.github/workflows/push-continuous-integration.yml
@@ -10,11 +10,11 @@ on:
       integration_test_ref:
         description: 'Integration testing repository git commit hash or branch'
         required: true
-        default: 'e50968c19f50b718044335836c98ddfe99841d3f'
+        default: '4c5ffe9d09042023be65807bc288eda41fd91e59'
 
 env:
   INTEGRATION_TEST_REPOSITORY: ${{ github.event.inputs.integration_test_repository || 'psilabs-dev/aio-lanraragi' }}
-  INTEGRATION_TEST_REF: ${{ github.event.inputs.integration_test_ref || 'e50968c19f50b718044335836c98ddfe99841d3f' }}
+  INTEGRATION_TEST_REF: ${{ github.event.inputs.integration_test_ref || '4c5ffe9d09042023be65807bc288eda41fd91e59' }}
 
 name: "Continuous Integration \U0001F44C\U0001F440"
 jobs:


### PR DESCRIPTION
- compare: https://github.com/psilabs-dev/aio-lanraragi/compare/e50968c19f50b718044335836c98ddfe99841d3f...4c5ffe9d09042023be65807bc288eda41fd91e59
- PR: https://github.com/psilabs-dev/aio-lanraragi/pull/163

No new tests planned atm, instead I've stabilized the existing test cases and make conditions stricter.

- Redis/docker connections will be explicitly closed on teardown when applicable.

The following updates apply to all Playwright UI tests:

- All tests now explicitly create a browser context, and explicitly close context/browser within the scope of a test case.
- All tests assert no errors when checking browser network inspector. This means that a UI test case will fail if the network inspector finds any LRR-side status code that isn't sub-400 or 401. Non-LRR origin URLs are excluded (e.g. Github rate limit errors will not trigger test case failure). This is a stricter client-side condition than expecting no server-side error logs, as 4xx validation errors and silent, server-side error responses will fail the test case. This will address a subset of upcoming OpenAPI integration testing failures, including the missing "/search" endpoint issue that escaped testing from earlier.

Log health assertions are occasionally capturing Shinobu error logs ("giving up adding it to the filesystem"); this is an existing race condition which can be ignored, or we can suppress it in the future test-side or LRR-side.