### PR TITLE
Avoid error toast when server-side progress API returns 423

### DIFF
--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -868,11 +868,11 @@ Reader.goToPage = function (page) {
 Reader.updateProgress = function () {
     // Send an API request to update progress on the server
     if (Reader.authenticateProgress && LRR.isUserLogged()) {
-        Server.callAPI(`/api/archives/${Reader.id}/progress/${Reader.currentPage + 1}`, "PUT", null, I18N.ReaderErrorProgress, null);
+        Server.updateServerSideProgress(Reader.id, Reader.currentPage + 1);
     } else if (Reader.trackProgressLocally) {
         localStorage.setItem(`${Reader.id}-reader`, Reader.currentPage + 1);
     } else if (!Reader.authenticateProgress) {
-        Server.callAPI(`/api/archives/${Reader.id}/progress/${Reader.currentPage + 1}`, "PUT", null, I18N.ReaderErrorProgress, null);
+        Server.updateServerSideProgress(Reader.id, Reader.currentPage + 1);
     }
 };
 

--- a/public/js/server.js
+++ b/public/js/server.js
@@ -344,3 +344,40 @@ Server.loadBookmarkCategoryId = function () {
         return data.category_id;
     });
 }
+
+/**
+ * Update server-side read progression.
+ *
+ * @param {*} id Archive ID
+ * @param {number} currentPage Page the user navigated to
+ */
+Server.updateServerSideProgress = function (id, currentPage) {
+    let endpointUrl = new LRR.apiURL(`/api/archives/${id}/progress/${currentPage + 1}`);
+    return fetch(endpointUrl, { method: "PUT" })
+        .then((response) => (response.ok ? {code: response.status, data: response.json()} : { code: response.status, data: {success: 0, error: I18N.GenericReponseError} }))
+        .then((response) => {
+            const { code, data } = response;
+            if (code === 423) {
+                // Rapid calls to the API endpoint can return a 423 due to a redis lock
+                return;
+            }
+            if (Object.prototype.hasOwnProperty.call(data, "success") && !data.success) {
+                throw new Error(data.error);
+            } else {
+                let message = null;
+                if ("successMessage" in data && data.successMessage) {
+                    message = data.successMessage;
+                }
+                if (message !== null) {
+                    LRR.toast({
+                        heading: message,
+                        icon: "success",
+                        hideAfter: 7000,
+                    });
+                }
+
+                return null;
+            }
+        })
+        .catch((error) => LRR.showErrorToast(I18N.ReaderErrorProgress, error));
+};


### PR DESCRIPTION
`update_progress` can thus return a 423 if there's concurrent calls (possible with infinite scroll). This PR avoids puking out a toast when that happens.