### PR TITLE
ToC related fixes

### DIFF
--- a/lib/LANraragi/Controller/Api/Archive.pm
+++ b/lib/LANraragi/Controller/Api/Archive.pm
@@ -379,6 +379,10 @@ sub add_toc {
     my $page  = $self->req->param('page');
     my $title = $self->req->param('title');
 
+    unless ( defined $page && defined $title ) {
+        return render_api_response( $self, "add_toc", "Missing page and/or title." );
+    }
+
     return unless exec_with_lock(
         $self,
         "archive-write:$id",
@@ -402,6 +406,10 @@ sub remove_toc {
     my $id   = check_id_parameter( $self, "remove_toc" ) || return;
 
     my $page = $self->req->param('page');
+
+    unless ( defined $page ) {
+        return render_api_response( $self, "remove_toc", "Please specify a page to remove" );
+    }
 
     return unless exec_with_lock(
         $self,

--- a/lib/LANraragi/Model/Archive.pm
+++ b/lib/LANraragi/Model/Archive.pm
@@ -360,11 +360,11 @@ sub remove_toc_entry {
         $toc = decode_json($toc);
         delete $toc->{$page};
         $toc = encode_json($toc);
-        $redis->hset( $id, "toc", $toc );
     } catch ($e) {
         $logger->warn("Error while updating ToC: $e -- Will overwrite with a blank ToC.");
-        $redis->hset( $id, "toc", "{}" );
+        $toc = "{}";
     }
+    $redis->hset( $id, "toc", $toc );
 
     $redis->quit();
     return "";

--- a/lib/LANraragi/Model/Archive.pm
+++ b/lib/LANraragi/Model/Archive.pm
@@ -325,10 +325,6 @@ sub update_metadata {
 sub add_toc_entry {
     my ( $id, $page, $title ) = @_;
 
-    unless ( defined $page and defined $title ) {
-        return "Missing page and/or title.";
-    }
-
     my $redis  = LANraragi::Model::Config->get_redis;
     my $logger = get_logger( "Archives", "lanraragi" );
     my $toc    = $redis->hget( $id, "toc" );
@@ -354,10 +350,6 @@ sub add_toc_entry {
 
 sub remove_toc_entry {
     my ( $id, $page ) = @_;
-
-    unless ( defined $page ) {
-        return "Please specify a page to remove";
-    }
 
     my $redis  = LANraragi::Model::Config->get_redis;
     my $logger = get_logger( "Archives", "lanraragi" );

--- a/lib/LANraragi/Model/Archive.pm
+++ b/lib/LANraragi/Model/Archive.pm
@@ -338,7 +338,6 @@ sub add_toc_entry {
         $toc          = decode_json($toc);
         $toc->{$page} = $title;
         $toc          = encode_json($toc);
-        $redis->hset( $id, "toc", $toc );
     } catch ($e) {
         $logger->warn(
             "Error while updating ToC: $e -- Will overwrite with a ToC containing the new data. (This is normal if this ID had no ToC yet.)"
@@ -346,8 +345,8 @@ sub add_toc_entry {
         $toc          = {};
         $toc->{$page} = $title;
         $toc          = encode_json($toc);
-        $redis->hset( $id, "toc", "{}" );
     }
+    $redis->hset( $id, "toc", $toc );
 
     $redis->quit();
     return "";

--- a/lib/LANraragi/Utils/Database.pm
+++ b/lib/LANraragi/Utils/Database.pm
@@ -247,8 +247,16 @@ sub build_json ( $id, %hash ) {
     if ( defined $toc ) {
         eval { $toc = decode_json($toc) };
 
-        foreach my $page ( keys %$toc ) {
-            push @chapters, { page => $page + 0, name => $toc->{$page} };
+        if ( my $decode_error = $@ ) {
+            get_logger( "Archive", "lanraragi" )->error("Failed to parse ToC JSON for archive $id: $decode_error");
+            $toc = undef;
+        }
+        if ( defined $toc && ref($toc) eq 'HASH' ) {
+            foreach my $page ( keys %$toc ) {
+                push @chapters, { page => $page + 0, name => $toc->{$page} };
+            }
+        } elsif ( defined $toc ) {
+            get_logger( "Archive", "lanraragi" )->error("ToC is not a hash: $toc");
         }
 
         # Sort chapters by page number


### PR DESCRIPTION
Addresses 2 issues raised during code review, which I'll explain below.

Issue 1: `add_toc_entry`

If an exception happens, (supposedly judging from the code) a basic toc is still passed into Redis. However, an empty hash gets passed into the database, instead of `{"page": $title}`. Also, otherwise the previous ops on toc wouldn't make much sense.

There's another small issue outside of review. Suppose redis drops while in the try block, then hset will fail and put the process into the catch block. If redis comes back up during the catch block, then LRR will have erased the toc entry due to the database being unstable.

Issue 2: `build_json`

Since eval code already exists, then we might as well just account for the cases when eval fails.

Eval failure already means that none of the subsequent code should be executed. However, even if decode passes, we should probably check that we have a hash instead of `[]`.