### PR TITLE
Extend Redis lock coverage

### DIFF
--- a/lib/LANraragi/Controller/Batch.pm
+++ b/lib/LANraragi/Controller/Batch.pm
@@ -5,7 +5,7 @@ use Redis;
 use Encode;
 use Mojo::JSON qw(decode_json);
 
-use LANraragi::Utils::Generic  qw(generate_themes_header);
+use LANraragi::Utils::Generic  qw(generate_themes_header exec_with_lock_pure);
 use LANraragi::Utils::Tags     qw(rewrite_tags build_tag_replace_hash split_tags_to_array restore_CRLF);
 use LANraragi::Utils::Database qw(get_computed_tagrules set_tags set_title set_summary set_isnew invalidate_cache);
 use LANraragi::Utils::Plugins  qw(get_plugins get_plugin get_plugin_parameters);
@@ -179,7 +179,24 @@ sub socket {
             if ( $operation eq "delete" ) {
                 $logger->debug("Deleting $id...");
 
-                my $delStatus = LANraragi::Model::Archive::delete_archive($id);
+                my ( $acquired, $delStatus ) = exec_with_lock_pure(
+                    [ "archive-write:$id" ],
+                    sub { LANraragi::Model::Archive::delete_archive($id) },
+                    $redis
+                );
+
+                unless ($acquired) {
+                    $client->send(
+                        {   json => {
+                                id       => $id,
+                                filename => "",
+                                message  => "Locked resource: $id.",
+                                success  => 0
+                            }
+                        }
+                    );
+                    return;
+                }
 
                 $client->send(
                     {   json => {

--- a/lib/LANraragi/Model/Plugins.pm
+++ b/lib/LANraragi/Model/Plugins.pm
@@ -68,7 +68,7 @@ sub exec_enabled_plugins_on_file ($id) {
         }
 
         # update metadata on lock
-        my $acquired, $_ = exec_with_lock_pure([ "archive-write:$id" ], sub {
+        my ($acquired, $_) = exec_with_lock_pure([ "archive-write:$id" ], sub {
             $successes++;
 
             #If the plugin exec returned metadata, add it

--- a/lib/LANraragi/Model/Plugins.pm
+++ b/lib/LANraragi/Model/Plugins.pm
@@ -16,6 +16,7 @@ use Data::Dumper;
 
 use LANraragi::Utils::String   qw(trim);
 use LANraragi::Utils::Database qw(set_tags set_title set_summary);
+use LANraragi::Utils::Generic  qw(exec_with_lock_pure);
 use LANraragi::Utils::Archive  qw(extract_thumbnail);
 use LANraragi::Utils::Logging  qw(get_logger);
 use LANraragi::Utils::Tags     qw(rewrite_tags split_tags_to_array);
@@ -66,28 +67,35 @@ sub exec_enabled_plugins_on_file ($id) {
             next;
         }
 
-        $successes++;
+        # update metadata on lock
+        my $acquired, $_ = exec_with_lock_pure([ "archive-write:$id" ], sub {
+            $successes++;
 
-        #If the plugin exec returned metadata, add it
-        set_tags( $id, $plugin_result{new_tags}, 1 );
+            #If the plugin exec returned metadata, add it
+            set_tags( $id, $plugin_result{new_tags}, 1 );
 
-        # Sum up all the added tags for later reporting.
-        # This doesn't take into account tags that are added twice
-        # (e.g by different plugins), but since this is more meant to show
-        # if the plugins added any data at all it's fine.
-        my @added_tags = split( ',', $plugin_result{new_tags} );
-        $addedtags += @added_tags;
+            # Sum up all the added tags for later reporting.
+            # This doesn't take into account tags that are added twice
+            # (e.g by different plugins), but since this is more meant to show
+            # if the plugins added any data at all it's fine.
+            my @added_tags = split( ',', $plugin_result{new_tags} );
+            $addedtags += @added_tags;
 
-        if ( exists $plugin_result{title} ) {
-            set_title( $id, $plugin_result{title} );
+            if ( exists $plugin_result{title} ) {
+                set_title( $id, $plugin_result{title} );
 
-            $newtitle = $plugin_result{title};
-            $logger->debug("Changing title to $newtitle. (Will do nothing if title is blank)");
-        }
+                $newtitle = $plugin_result{title};
+                $logger->debug("Changing title to $newtitle. (Will do nothing if title is blank)");
+            }
 
-        if ( exists $plugin_result{summary} ) {
-            set_summary( $id, $plugin_result{summary} );
-            $logger->debug("Summary has been changed.");    # don't put the new summary in logs, it can be huge
+            if ( exists $plugin_result{summary} ) {
+                set_summary( $id, $plugin_result{summary} );
+                $logger->debug("Summary has been changed.");    # don't put the new summary in logs, it can be huge
+            }
+        });
+        unless ( $acquired ) {
+            $logger->error("Write lock already acquired for archive $id.");
+            $failures++;
         }
     }
 

--- a/lib/LANraragi/Utils/Generic.pm
+++ b/lib/LANraragi/Utils/Generic.pm
@@ -361,11 +361,11 @@ sub exec_with_lock {
 # Redis connection is optional; if not supplied, a managed connection will be created.
 sub exec_with_lock_pure {
 
-    my $lock_names = shift;
-    my $func       = shift;
-    my $redis      = shift;
-    my $ttl        = shift // 10;
-    my $own_redis = 0;
+    my $lock_names  = shift;
+    my $func        = shift;
+    my $redis       = shift;
+    my $ttl         = shift // 10;
+    my $own_redis   = 0;
 
     die "Lock name list cannot be empty" unless scalar(@$lock_names);
 
@@ -390,7 +390,12 @@ LUA
     my @lock_name_stack = ();
     foreach my $lock_name ( @$lock_names ) {
         my $token = sha256_hex( $lock_name . ":" . $$ . ":" . time() . ":" . rand() );
-        my $lock  = $redis->set( $lock_name, $token, 'NX', 'EX', $ttl );
+        my $lock = eval { $redis->set( $lock_name, $token, 'NX', 'EX', $ttl ) };
+        if ( my $acquire_error = $@ ) {
+            # If a lock acquisition failure happens, then a problem has occurred with Redis.
+            get_logger( "Concurrency", "lanraragi" )->error("Failed to acquire lock $lock_name: $acquire_error");
+            last;
+        }
         last unless $lock;
         push( @lock_name_stack, [ $lock_name, $token ] );
     }
@@ -399,9 +404,16 @@ LUA
     unless ( scalar(@lock_name_stack) == scalar(@$lock_names) ) {
         while ( @lock_name_stack ) {
             my ( $lock_name, $token ) = @{ pop(@lock_name_stack) };
-            $redis->eval( $release_lua, 1, $lock_name, $token );
+
+            # This should be best effort release, but if failure happens, 
+            # then continue releasing remaining locks and let TTL take over.
+            my $release_error = eval { $redis->eval( $release_lua, 1, $lock_name, $token ); 1 } ? undef : $@;
+            get_logger( "Concurrency", "lanraragi" )->error("Failed to release lock ($lock_name): $release_error") if $release_error;
         }
-        $redis->quit() if $own_redis;
+        if ($own_redis) {
+            my $close_error = eval { $redis->quit(); 1 } ? undef : $@;
+            get_logger( "Concurrency", "lanraragi" )->error("Failed to close Redis connection: $close_error") if $close_error;
+        }
         return 0, undef;
     }
 
@@ -412,11 +424,13 @@ LUA
     # release all previously acquired locks in reverse order.
     while ( @lock_name_stack ) {
         my ( $lock_name, $token ) = @{ pop(@lock_name_stack) };
-        $redis->eval( $release_lua, 1, $lock_name, $token );
+        my $release_error = eval { $redis->eval( $release_lua, 1, $lock_name, $token ); 1 } ? undef : $@;
+        get_logger( "Concurrency", "lanraragi" )->error("Failed to release lock after evaluation ($lock_name): $release_error") if $release_error;
     }
 
     # close managed connection
-    $redis->quit() if $own_redis;
+    my $close_error = eval { $redis->quit() if $own_redis; 1 } ? undef : $@;
+    get_logger( "Concurrency", "lanraragi" )->error("Failed to close Redis connection after evaluation: $close_error") if $close_error;
 
     # throw error if exists
     die $fn_err if $fn_err;

--- a/lib/LANraragi/Utils/Generic.pm
+++ b/lib/LANraragi/Utils/Generic.pm
@@ -332,7 +332,7 @@ sub exec_with_lock {
     my ( $mojo, $lock_name, $operation, $resource_id, $func ) = @_;
 
     my ($acquired, $response) = exec_with_lock_pure(
-        $lock_name, $func
+        [ $lock_name ], $func
     );
 
     if ( !$acquired ) {
@@ -351,34 +351,65 @@ sub exec_with_lock {
 
 }
 
-# exec_with_lock_pure( $lock_name, $func, $redis (optional) )
-# Execute a function under a redis lock context.
+# exec_with_lock_pure( \@lock_names, $func, $redis (optional) )
+# Execute a function under a multi-lock context.
+# Does not implement lock_name sorting,
+# so locks should be passed in a deterministic order to avoid deadlocking.
 # For high-level, fast operations, as the expiry is set to 10s.
 # Returns a tuple ($acquired, $response), where $response is 
 # function response (if any) if acquired, or undef if not acquired.
 # Redis connection is optional; if not supplied, a managed connection will be created.
 sub exec_with_lock_pure {
 
-    my ( $lock_name, $func, $redis ) = @_;
+    my ( $lock_names, $func, $redis ) = @_;
     my $own_redis = 0;
 
-    if ( !defined $redis ) {
+    unless ( scalar(@$lock_names) ) {
+        die "Lock name list cannot be empty";
+    }
+
+    # create managed redis connection if not passed
+    unless ( defined $redis ) {
         $redis = LANraragi::Model::Config->get_redis;
         $own_redis = 1;
     }
 
-    my $lock = $redis->set( $lock_name, 1, 'NX', 'EX', 10 );
-    if ( !$lock ) {
-        $redis->quit();
+    # try to acquire all locks, or release all if any lock cannot be acquired.
+    my @lock_name_stack = ();
+    foreach my $lock_name ( @$lock_names ) {
+        my $lock = $redis->set( $lock_name, 1, 'NX', 'EX', 10 );
+        if ( $lock ) {
+            push(@lock_name_stack, $lock_name);
+        } else {
+            last;
+        }
+    }
+    # if a single lock fails to acquire, stop trying for the rest, and
+    # go release all previously acquired locks in the reverse order.
+    unless ( scalar(@lock_name_stack) == scalar(@$lock_names) ) {
+        while ( @lock_name_stack ) {
+            my $lock_name = pop(@lock_name_stack);
+            $redis->del($lock_name);
+        }
+        $redis->quit() if $own_redis;
         return 0, undef;
     }
 
+    # run the actual business logic (and collect response)
     my $response = eval { $func->(); };
-    my $err = $@;
-    $redis->del($lock_name);
+    my $fn_err = $@;
+
+    # release all previously acquired locks in reverse order.
+    while ( @lock_name_stack ) {
+        my $lock_name = pop(@lock_name_stack);
+        $redis->del($lock_name);
+    }
+
+    # close managed connection
     $redis->quit() if $own_redis;
 
-    die $err if $err;
+    # throw error if exists
+    die $fn_err if $fn_err;
     return 1, $response;
 
 }

--- a/lib/LANraragi/Utils/Generic.pm
+++ b/lib/LANraragi/Utils/Generic.pm
@@ -323,6 +323,7 @@ sub filter_hash_by_keys {
     return %hash;
 }
 
+# TODO: Probably rename to exec_with_lock_render
 # Execute a function under a redis lock context.
 # If the lock cannot be acquired, renders a 423 error and returns false,
 # otherwise executes the function and returns true (or rethrows error if any).
@@ -351,6 +352,7 @@ sub exec_with_lock {
 
 }
 
+# TODO: Probably rename to exec_with_lock
 # exec_with_lock_pure( \@lock_names, $func, $redis (optional), $ttl (optional) )
 # Execute a function under a multi-lock context.
 # Does not implement lock_name sorting,

--- a/lib/LANraragi/Utils/Generic.pm
+++ b/lib/LANraragi/Utils/Generic.pm
@@ -382,7 +382,7 @@ LUA
 
     # create managed redis connection if not passed
     unless ( defined $redis ) {
-        $redis = LANraragi::Model::Config->get_redis;
+        $redis = LANraragi::Model::Config->get_redis_config; 
         $own_redis = 1;
     }
 

--- a/lib/LANraragi/Utils/Generic.pm
+++ b/lib/LANraragi/Utils/Generic.pm
@@ -368,6 +368,17 @@ sub exec_with_lock_pure {
         die "Lock name list cannot be empty";
     }
 
+    # prepare the script for token release
+    # tokens demonstrate ownership over a redis lock, and is used to prevent workers 
+    # from deleting locks that don't belong to them.
+    # https://redis.io/docs/latest/develop/clients/patterns/distributed-locks/#correct-implementation-with-a-single-instance
+    my $release_lua = <<'LUA';
+    if redis.call('GET', KEYS[1]) == ARGV[1] then
+        return redis.call('DEL', KEYS[1])
+    end
+    return 0
+LUA
+
     # create managed redis connection if not passed
     unless ( defined $redis ) {
         $redis = LANraragi::Model::Config->get_redis;
@@ -377,9 +388,10 @@ sub exec_with_lock_pure {
     # try to acquire all locks, or release all if any lock cannot be acquired.
     my @lock_name_stack = ();
     foreach my $lock_name ( @$lock_names ) {
-        my $lock = $redis->set( $lock_name, 1, 'NX', 'EX', 10 );
+        my $token = sha256_hex( $lock_name . ":" . $$ . ":" . time() . ":" . rand() );
+        my $lock  = $redis->set( $lock_name, $token, 'NX', 'EX', 10 );
         if ( $lock ) {
-            push(@lock_name_stack, $lock_name);
+            push( @lock_name_stack, [ $lock_name, $token ] );
         } else {
             last;
         }
@@ -388,8 +400,8 @@ sub exec_with_lock_pure {
     # go release all previously acquired locks in the reverse order.
     unless ( scalar(@lock_name_stack) == scalar(@$lock_names) ) {
         while ( @lock_name_stack ) {
-            my $lock_name = pop(@lock_name_stack);
-            $redis->del($lock_name);
+            my ( $lock_name, $token ) = @{ pop(@lock_name_stack) };
+            $redis->eval( $release_lua, 1, $lock_name, $token );
         }
         $redis->quit() if $own_redis;
         return 0, undef;
@@ -401,8 +413,8 @@ sub exec_with_lock_pure {
 
     # release all previously acquired locks in reverse order.
     while ( @lock_name_stack ) {
-        my $lock_name = pop(@lock_name_stack);
-        $redis->del($lock_name);
+        my ( $lock_name, $token ) = @{ pop(@lock_name_stack) };
+        $redis->eval( $release_lua, 1, $lock_name, $token );
     }
 
     # close managed connection

--- a/lib/LANraragi/Utils/Generic.pm
+++ b/lib/LANraragi/Utils/Generic.pm
@@ -351,22 +351,23 @@ sub exec_with_lock {
 
 }
 
-# exec_with_lock_pure( \@lock_names, $func, $redis (optional) )
+# exec_with_lock_pure( \@lock_names, $func, $redis (optional), $ttl (optional) )
 # Execute a function under a multi-lock context.
 # Does not implement lock_name sorting,
 # so locks should be passed in a deterministic order to avoid deadlocking.
-# For high-level, fast operations, as the expiry is set to 10s.
+# For high-level, fast operations, as the expiry defaults to 10s.
 # Returns a tuple ($acquired, $response), where $response is 
 # function response (if any) if acquired, or undef if not acquired.
 # Redis connection is optional; if not supplied, a managed connection will be created.
 sub exec_with_lock_pure {
 
-    my ( $lock_names, $func, $redis ) = @_;
+    my $lock_names = shift;
+    my $func       = shift;
+    my $redis      = shift;
+    my $ttl        = shift // 10;
     my $own_redis = 0;
 
-    unless ( scalar(@$lock_names) ) {
-        die "Lock name list cannot be empty";
-    }
+    die "Lock name list cannot be empty" unless scalar(@$lock_names);
 
     # prepare the script for token release
     # tokens demonstrate ownership over a redis lock, and is used to prevent workers 
@@ -389,12 +390,9 @@ LUA
     my @lock_name_stack = ();
     foreach my $lock_name ( @$lock_names ) {
         my $token = sha256_hex( $lock_name . ":" . $$ . ":" . time() . ":" . rand() );
-        my $lock  = $redis->set( $lock_name, $token, 'NX', 'EX', 10 );
-        if ( $lock ) {
-            push( @lock_name_stack, [ $lock_name, $token ] );
-        } else {
-            last;
-        }
+        my $lock  = $redis->set( $lock_name, $token, 'NX', 'EX', $ttl );
+        last unless $lock;
+        push( @lock_name_stack, [ $lock_name, $token ] );
     }
     # if a single lock fails to acquire, stop trying for the rest, and
     # go release all previously acquired locks in the reverse order.

--- a/lib/LANraragi/Utils/Generic.pm
+++ b/lib/LANraragi/Utils/Generic.pm
@@ -32,7 +32,7 @@ BEGIN {
 use Exporter 'import';
 our @EXPORT_OK = qw(is_image is_archive render_api_response get_tag_with_namespace shasum_str start_shinobu
   split_workload_by_cpu start_minion get_css_list generate_themes_header flat get_bytelength array_difference
-  intersect_arrays filter_hash_by_keys exec_with_lock);
+  intersect_arrays filter_hash_by_keys exec_with_lock exec_with_lock_pure);
 
 # Checks if the provided file is an image.
 # Uses non-capturing groups (?:) to avoid modifying the incoming argument.
@@ -330,11 +330,12 @@ sub filter_hash_by_keys {
 sub exec_with_lock {
 
     my ( $mojo, $lock_name, $operation, $resource_id, $func ) = @_;
-    my $redis = LANraragi::Model::Config->get_redis;
 
-    my $lock = $redis->set( $lock_name, 1, 'NX', 'EX', 10 );
-    if ( !$lock ) {
-        $redis->quit();
+    my ($acquired, $response) = exec_with_lock_pure(
+        $lock_name, $func
+    );
+
+    if ( !$acquired ) {
         $mojo->render(
             json => {
                 operation => $operation,
@@ -346,13 +347,40 @@ sub exec_with_lock {
         return 0;
     }
 
-    eval { $func->(); };
+    return 1;
+
+}
+
+# exec_with_lock_pure( $lock_name, $func, $redis (optional) )
+# Execute a function under a redis lock context.
+# For high-level, fast operations, as the expiry is set to 10s.
+# Returns a tuple ($acquired, $response), where $response is 
+# function response (if any) if acquired, or undef if not acquired.
+# Redis connection is optional; if not supplied, a managed connection will be created.
+sub exec_with_lock_pure {
+
+    my ( $lock_name, $func, $redis ) = @_;
+    my $own_redis = 0;
+
+    if ( !defined $redis ) {
+        $redis = LANraragi::Model::Config->get_redis;
+        $own_redis = 1;
+    }
+
+    my $lock = $redis->set( $lock_name, 1, 'NX', 'EX', 10 );
+    if ( !$lock ) {
+        $redis->quit();
+        return 0, undef;
+    }
+
+    my $response = eval { $func->(); };
     my $err = $@;
     $redis->del($lock_name);
-    $redis->quit();
+    $redis->quit() if $own_redis;
 
     die $err if $err;
-    return 1;
+    return 1, $response;
+
 }
 
 1;

--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -31,7 +31,7 @@ use Encode;
 use LANraragi::Utils::Archive    qw(extract_thumbnail);
 use LANraragi::Utils::Database   qw(invalidate_cache compute_id change_archive_id get_arcsize add_timestamp_tag add_archive_to_redis add_arcsize add_pagecount);
 use LANraragi::Utils::Logging    qw(get_logger);
-use LANraragi::Utils::Generic    qw(is_archive);
+use LANraragi::Utils::Generic    qw(is_archive exec_with_lock_pure);
 use LANraragi::Utils::Redis      qw(redis_encode);
 use LANraragi::Utils::Path       qw(create_path open_path find_path get_archive_path);
 
@@ -201,70 +201,84 @@ sub add_to_filemap ( $redis_cfg, $file ) {
             return;
         }
 
-        $logger->debug("Computed ID is $id.");
+        # Acquire exclusive metadata and file write access for archive by ID
+        my $acquired, $_ = exec_with_lock_pure("archive-write:$id", sub {
 
-        # If the id already exists on the server, throw a warning about duplicates
-        if ( $redis_cfg->hexists( "LRR_FILEMAP", $file ) ) {
+            $logger->debug("Computed ID is $id.");
+            unless ( -e $file ) {
+                # A TOCTOU check, if the file was deleted after ID computation but before a lock was acquired.
+                $logger->warn("File does not exist; giving up on adding it to the filemap: $file");
+                return;
+            }
 
-            my $filemap_id = $redis_cfg->hget( "LRR_FILEMAP", $file );
+            # If the id already exists on the server, throw a warning about duplicates
+            if ( $redis_cfg->hexists( "LRR_FILEMAP", $file ) ) {
 
-            $logger->debug("$file was logged but is already in the filemap!");
+                my $filemap_id = $redis_cfg->hget( "LRR_FILEMAP", $file );
 
-            if ( $filemap_id ne $id ) {
-                $logger->debug("$file has a different ID than the one in the filemap! ($filemap_id)");
-                $logger->info("$file has been modified, updating its ID from $filemap_id to $id.");
+                $logger->debug("$file was logged but is already in the filemap!");
 
-                change_archive_id( $filemap_id, $id );
+                if ( $filemap_id ne $id ) {
+                    $logger->debug("$file has a different ID than the one in the filemap! ($filemap_id)");
+                    $logger->info("$file has been modified, updating its ID from $filemap_id to $id.");
 
-                # Don't forget to update the filemap, later operations will behave incorrectly otherwise
-                $redis_cfg->hset( "LRR_FILEMAP", $file, $id );
+                    change_archive_id( $filemap_id, $id );
+
+                    # Don't forget to update the filemap, later operations will behave incorrectly otherwise
+                    $redis_cfg->hset( "LRR_FILEMAP", $file, $id );
+                } else {
+                    $logger->debug(
+                        "$file has the same ID as the one in the filemap. Duplicate inotify events? Cleaning cache just to make sure");
+                    invalidate_cache();
+                }
+
+                return;
+
             } else {
-                $logger->debug(
-                    "$file has the same ID as the one in the filemap. Duplicate inotify events? Cleaning cache just to make sure");
+                $redis_cfg->hset( "LRR_FILEMAP", $file, $id );    # raw FS path so no encoding/decoding whatsoever
+            }
+
+            # Filename sanity check
+            if ( $redis_arc->exists($id) ) {
+
+                my $filecheck = get_archive_path( $redis_arc, $id );
+
+                #Update the real file path and title if they differ from the saved one
+                #This is meant to always track the current filename for the OS.
+                unless ( $file eq $filecheck ) {
+                    $logger->debug("File name discrepancy detected between DB and filesystem!");
+                    $logger->debug("Filesystem: $file");
+                    $logger->debug("Database: $filecheck");
+                    my ( $name, $path, $suffix ) = fileparse( $file, qr/\.[^.]*/ );
+                    $redis_arc->hset( $id, "file", $file );
+                    $redis_arc->hset( $id, "name", redis_encode($name) );
+                    $redis_arc->wait_all_responses;
+                    invalidate_cache();
+                }
+
+                unless ( get_arcsize( $redis_arc, $id ) ) {
+                    $logger->debug("arcsize is not set for $id, storing now!");
+                    add_arcsize( $redis_arc, $id );
+                }
+
+                # Set pagecount in case it's not already there
+                unless ( $redis_arc->hget( $id, "pagecount" ) ) {
+                    $logger->debug("Pagecount not calculated for $id, doing it now!");
+                    add_pagecount( $redis_arc, $id );
+                }
+
+            } else {
+
+                # Add to Redis if not present beforehand
+                add_new_file( $id, $file );
                 invalidate_cache();
             }
+        }, $redis_arc);
 
-            return;
-
-        } else {
-            $redis_cfg->hset( "LRR_FILEMAP", $file, $id );    # raw FS path so no encoding/decoding whatsoever
+        if ( !$acquired ) {
+            $logger->warn("Write lock already acquired for archive $file with ID $id, skipping.");
         }
 
-        # Filename sanity check
-        if ( $redis_arc->exists($id) ) {
-
-            my $filecheck = get_archive_path( $redis_arc, $id );
-
-            #Update the real file path and title if they differ from the saved one
-            #This is meant to always track the current filename for the OS.
-            unless ( $file eq $filecheck ) {
-                $logger->debug("File name discrepancy detected between DB and filesystem!");
-                $logger->debug("Filesystem: $file");
-                $logger->debug("Database: $filecheck");
-                my ( $name, $path, $suffix ) = fileparse( $file, qr/\.[^.]*/ );
-                $redis_arc->hset( $id, "file", $file );
-                $redis_arc->hset( $id, "name", redis_encode($name) );
-                $redis_arc->wait_all_responses;
-                invalidate_cache();
-            }
-
-            unless ( get_arcsize( $redis_arc, $id ) ) {
-                $logger->debug("arcsize is not set for $id, storing now!");
-                add_arcsize( $redis_arc, $id );
-            }
-
-            # Set pagecount in case it's not already there
-            unless ( $redis_arc->hget( $id, "pagecount" ) ) {
-                $logger->debug("Pagecount not calculated for $id, doing it now!");
-                add_pagecount( $redis_arc, $id );
-            }
-
-        } else {
-
-            # Add to Redis if not present beforehand
-            add_new_file( $id, $file );
-            invalidate_cache();
-        }
     } else {
         $logger->debug("$file not recognized as archive, skipping.");
     }

--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -194,10 +194,14 @@ sub add_to_filemap ( $redis_cfg, $file ) {
         #Compute the ID of the archive and add it to the hash
         my $id = "";
         eval { $id = compute_id($file); };
+        my $compute_error = $@;
 
-        if ($@ && -e $file) {
-            $logger->error("Couldn't open $file for ID computation: $@");
+        if ($compute_error && -e $file) {
+            $logger->error("Couldn't open $file for ID computation: $compute_error");
             $logger->error("Giving up on adding it to the filemap.");
+            return;
+        } elsif ($compute_error) {
+            $logger->warn("File $file no longer exists; giving up on adding it to the filemap.");
             return;
         }
 

--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -206,78 +206,11 @@ sub add_to_filemap ( $redis_cfg, $file ) {
         }
 
         # Acquire exclusive metadata and file write access for archive by ID with 1m timeout
-        my $acquired, $_ = exec_with_lock_pure([ "archive-write:$id" ], sub {
-
-            $logger->debug("Computed ID is $id.");
-            unless ( -e $file ) {
-                # A TOCTOU check, if the file was deleted after ID computation but before a lock was acquired.
-                $logger->warn("File does not exist; giving up on adding it to the filemap: $file");
-                return;
-            }
-
-            # If the id already exists on the server, throw a warning about duplicates
-            if ( $redis_cfg->hexists( "LRR_FILEMAP", $file ) ) {
-
-                my $filemap_id = $redis_cfg->hget( "LRR_FILEMAP", $file );
-
-                $logger->debug("$file was logged but is already in the filemap!");
-
-                if ( $filemap_id ne $id ) {
-                    $logger->debug("$file has a different ID than the one in the filemap! ($filemap_id)");
-                    $logger->info("$file has been modified, updating its ID from $filemap_id to $id.");
-
-                    change_archive_id( $filemap_id, $id );
-
-                    # Don't forget to update the filemap, later operations will behave incorrectly otherwise
-                    $redis_cfg->hset( "LRR_FILEMAP", $file, $id );
-                } else {
-                    $logger->debug(
-                        "$file has the same ID as the one in the filemap. Duplicate inotify events? Cleaning cache just to make sure");
-                    invalidate_cache();
-                }
-
-                return;
-
-            } else {
-                $redis_cfg->hset( "LRR_FILEMAP", $file, $id );    # raw FS path so no encoding/decoding whatsoever
-            }
-
-            # Filename sanity check
-            if ( $redis_arc->exists($id) ) {
-
-                my $filecheck = get_archive_path( $redis_arc, $id );
-
-                #Update the real file path and title if they differ from the saved one
-                #This is meant to always track the current filename for the OS.
-                unless ( $file eq $filecheck ) {
-                    $logger->debug("File name discrepancy detected between DB and filesystem!");
-                    $logger->debug("Filesystem: $file");
-                    $logger->debug("Database: $filecheck");
-                    my ( $name, $path, $suffix ) = fileparse( $file, qr/\.[^.]*/ );
-                    $redis_arc->hset( $id, "file", $file );
-                    $redis_arc->hset( $id, "name", redis_encode($name) );
-                    $redis_arc->wait_all_responses;
-                    invalidate_cache();
-                }
-
-                unless ( get_arcsize( $redis_arc, $id ) ) {
-                    $logger->debug("arcsize is not set for $id, storing now!");
-                    add_arcsize( $redis_arc, $id );
-                }
-
-                # Set pagecount in case it's not already there
-                unless ( $redis_arc->hget( $id, "pagecount" ) ) {
-                    $logger->debug("Pagecount not calculated for $id, doing it now!");
-                    add_pagecount( $redis_arc, $id );
-                }
-
-            } else {
-
-                # Add to Redis if not present beforehand
-                add_new_file( $id, $file );
-                invalidate_cache();
-            }
-        }, $redis_arc, 60);
+        my $acquired, $_ = exec_with_lock_pure(
+            [ "archive-write:$id" ],
+            sub { update_filemap_entry( $logger, $id, $file, $redis_cfg, $redis_arc ) },
+            $redis_arc, 60
+        );
 
         if ( !$acquired ) {
             $logger->warn("Write lock already acquired for archive $file with ID $id, skipping.");
@@ -287,6 +220,79 @@ sub add_to_filemap ( $redis_cfg, $file ) {
         $logger->debug("$file not recognized as archive, skipping.");
     }
     $redis_arc->quit;
+}
+
+sub update_filemap_entry ( $logger, $id, $file, $redis_cfg, $redis_arc ) {
+
+    $logger->debug("Computed ID is $id.");
+    unless ( -e $file ) {
+        # A TOCTOU check, if the file was deleted after ID computation but before a lock was acquired.
+        $logger->warn("File does not exist; giving up on adding it to the filemap: $file");
+        return;
+    }
+
+    # If the id already exists on the server, throw a warning about duplicates
+    if ( $redis_cfg->hexists( "LRR_FILEMAP", $file ) ) {
+
+        my $filemap_id = $redis_cfg->hget( "LRR_FILEMAP", $file );
+
+        $logger->debug("$file was logged but is already in the filemap!");
+
+        if ( $filemap_id ne $id ) {
+            $logger->debug("$file has a different ID than the one in the filemap! ($filemap_id)");
+            $logger->info("$file has been modified, updating its ID from $filemap_id to $id.");
+
+            change_archive_id( $filemap_id, $id );
+
+            # Don't forget to update the filemap, later operations will behave incorrectly otherwise
+            $redis_cfg->hset( "LRR_FILEMAP", $file, $id );
+        } else {
+            $logger->debug(
+                "$file has the same ID as the one in the filemap. Duplicate inotify events? Cleaning cache just to make sure");
+            invalidate_cache();
+        }
+
+        return;
+
+    } else {
+        $redis_cfg->hset( "LRR_FILEMAP", $file, $id );    # raw FS path so no encoding/decoding whatsoever
+    }
+
+    # Filename sanity check
+    if ( $redis_arc->exists($id) ) {
+
+        my $filecheck = get_archive_path( $redis_arc, $id );
+
+        #Update the real file path and title if they differ from the saved one
+        #This is meant to always track the current filename for the OS.
+        unless ( $file eq $filecheck ) {
+            $logger->debug("File name discrepancy detected between DB and filesystem!");
+            $logger->debug("Filesystem: $file");
+            $logger->debug("Database: $filecheck");
+            my ( $name, $path, $suffix ) = fileparse( $file, qr/\.[^.]*/ );
+            $redis_arc->hset( $id, "file", $file );
+            $redis_arc->hset( $id, "name", redis_encode($name) );
+            $redis_arc->wait_all_responses;
+            invalidate_cache();
+        }
+
+        unless ( get_arcsize( $redis_arc, $id ) ) {
+            $logger->debug("arcsize is not set for $id, storing now!");
+            add_arcsize( $redis_arc, $id );
+        }
+
+        # Set pagecount in case it's not already there
+        unless ( $redis_arc->hget( $id, "pagecount" ) ) {
+            $logger->debug("Pagecount not calculated for $id, doing it now!");
+            add_pagecount( $redis_arc, $id );
+        }
+
+    } else {
+
+        # Add to Redis if not present beforehand
+        add_new_file( $id, $file );
+        invalidate_cache();
+    }
 }
 
 # Only handle new files. As per the ChangeNotify doc, it

--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -206,7 +206,7 @@ sub add_to_filemap ( $redis_cfg, $file ) {
         }
 
         # Acquire exclusive metadata and file write access for archive by ID with 1m timeout
-        my $acquired, $_ = exec_with_lock_pure(
+        my ($acquired, $_) = exec_with_lock_pure(
             [ "archive-write:$id" ],
             sub { update_filemap_entry( $logger, $id, $file, $redis_cfg, $redis_arc ) },
             $redis_arc, 60

--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -201,7 +201,7 @@ sub add_to_filemap ( $redis_cfg, $file ) {
             return;
         }
 
-        # Acquire exclusive metadata and file write access for archive by ID
+        # Acquire exclusive metadata and file write access for archive by ID with 1m timeout
         my $acquired, $_ = exec_with_lock_pure([ "archive-write:$id" ], sub {
 
             $logger->debug("Computed ID is $id.");
@@ -273,7 +273,7 @@ sub add_to_filemap ( $redis_cfg, $file ) {
                 add_new_file( $id, $file );
                 invalidate_cache();
             }
-        }, $redis_arc);
+        }, $redis_arc, 60);
 
         if ( !$acquired ) {
             $logger->warn("Write lock already acquired for archive $file with ID $id, skipping.");

--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -202,7 +202,7 @@ sub add_to_filemap ( $redis_cfg, $file ) {
         }
 
         # Acquire exclusive metadata and file write access for archive by ID
-        my $acquired, $_ = exec_with_lock_pure("archive-write:$id", sub {
+        my $acquired, $_ = exec_with_lock_pure([ "archive-write:$id" ], sub {
 
             $logger->debug("Computed ID is $id.");
             unless ( -e $file ) {

--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -195,7 +195,7 @@ sub add_to_filemap ( $redis_cfg, $file ) {
         my $id = "";
         eval { $id = compute_id($file); };
 
-        if ($@) {
+        if ($@ && -e $file) {
             $logger->error("Couldn't open $file for ID computation: $@");
             $logger->error("Giving up on adding it to the filemap.");
             return;


### PR DESCRIPTION
close https://github.com/Difegue/LANraragi/issues/1425

`add_to_filemap` is triggered on file events, which can frequently race against active file changes resulting in missing files during ID computation. If this happens, we don't really have an "error"-severity log.

This is one of the main invalid integration test case failure reasons, so tightening this condition will get rid of some noise. Or we can keep the logs if a file doesn't exist and demote that case to warning.