### PR TITLE
Reuse the decoded image when changing pages

### DIFF
--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -827,7 +827,11 @@ Reader.goToPage = function (page) {
                 // Depending on whether we were going forward or backward, display img1 or img2
                 const wideImg = Reader.previousPage > Reader.currentPage ? img2 : img1;
                 $("#img").replaceWith(wideImg);
-                $(wideImg).attr("id", "img");
+                $(wideImg).attr({
+                    "id": "img",
+                    "class": "reader-image",
+                    "fetchpriority": "high"
+                });
                 $(wideImg).on("load", Reader.updateMetadata);
                 if (wideImg.complete && wideImg.naturalWidth > 0) {
                     setTimeout(() => Reader.updateMetadata(), 0);
@@ -836,14 +840,30 @@ Reader.goToPage = function (page) {
             } else {
                 if (Reader.mangaMode) {
                     $("#img").replaceWith(img2);
-                    $(img2).attr("id", "img");
+                    $(img2).attr({
+                        "id": "img",
+                        "class": "reader-image",
+                        "fetchpriority": "high"
+                    });
                     $("#img_doublepage").replaceWith(img1);
-                    $(img1).attr("id", "img_doublepage");
+                    $(img1).attr({
+                        "id": "img_doublepage",
+                        "class": "reader-image",
+                        "fetchpriority": "high"
+                    });
                 } else {
                     $("#img").replaceWith(img1);
-                    $(img1).attr("id", "img");
+                    $(img1).attr({
+                        "id": "img",
+                        "class": "reader-image",
+                        "fetchpriority": "high"
+                    });
                     $("#img_doublepage").replaceWith(img2);
-                    $(img2).attr("id", "img_doublepage");
+                    $(img2).attr({
+                        "id": "img_doublepage",
+                        "class": "reader-image",
+                        "fetchpriority": "high"
+                    });
                 }
                 $("#img").on("load", Reader.updateMetadata);
                 $("#img_doublepage").on("load", Reader.updateMetadata);
@@ -855,7 +875,11 @@ Reader.goToPage = function (page) {
         } else {
             const img = Reader.loadImage(Reader.currentPage);
             $("#img").replaceWith(img);
-            $(img).attr("id", "img");
+            $(img).attr({
+                "id": "img",
+                "class": "reader-image",
+                "fetchpriority": "high"
+            });
             $(img).on("load", Reader.updateMetadata);
             if (img.complete && img.naturalWidth > 0) {
                 setTimeout(() => Reader.updateMetadata(), 0);

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -347,8 +347,6 @@ Reader.loadImages = function () {
                     `);
                 }
             } else {
-                $("#img").on("load", Reader.updateMetadata);
-
                 // when click left or right img area change page
                 $(document).on("click", (event) => {
                     // check click Y position is in img Y area
@@ -815,7 +813,7 @@ Reader.goToPage = function (page) {
     if (Reader.infiniteScroll) {
         $("#display img").get(Reader.currentPage).scrollIntoView({ block: "nearest" });
     } else {
-        $("#img_doublepage").attr("src", "");
+        Reader.resetImageElement("#img_doublepage");
         $("#display").removeClass("double-mode");
         if (Reader.doublePageMode && Reader.currentPage > 0
             && Reader.currentPage < Reader.maxPage) {
@@ -826,47 +824,19 @@ Reader.goToPage = function (page) {
             if (img1.naturalWidth > img1.naturalHeight || img2.naturalWidth > img2.naturalHeight) {
                 // Depending on whether we were going forward or backward, display img1 or img2
                 const wideImg = Reader.previousPage > Reader.currentPage ? img2 : img1;
-                $("#img").replaceWith(wideImg);
-                $(wideImg).attr({
-                    "id": "img",
-                    "class": "reader-image",
-                    "fetchpriority": "high"
-                });
-                $(wideImg).on("load", Reader.updateMetadata);
+                Reader.replaceImageElement("#img", wideImg);
                 if (wideImg.complete && wideImg.naturalWidth > 0) {
                     setTimeout(() => Reader.updateMetadata(), 0);
                 }
                 Reader.showingSinglePage = true;
             } else {
                 if (Reader.mangaMode) {
-                    $("#img").replaceWith(img2);
-                    $(img2).attr({
-                        "id": "img",
-                        "class": "reader-image",
-                        "fetchpriority": "high"
-                    });
-                    $("#img_doublepage").replaceWith(img1);
-                    $(img1).attr({
-                        "id": "img_doublepage",
-                        "class": "reader-image",
-                        "fetchpriority": "high"
-                    });
+                    Reader.replaceImageElement("#img", img2);
+                    Reader.replaceImageElement("#img_doublepage", img1);
                 } else {
-                    $("#img").replaceWith(img1);
-                    $(img1).attr({
-                        "id": "img",
-                        "class": "reader-image",
-                        "fetchpriority": "high"
-                    });
-                    $("#img_doublepage").replaceWith(img2);
-                    $(img2).attr({
-                        "id": "img_doublepage",
-                        "class": "reader-image",
-                        "fetchpriority": "high"
-                    });
+                    Reader.replaceImageElement("#img", img1);
+                    Reader.replaceImageElement("#img_doublepage", img2);
                 }
-                $("#img").on("load", Reader.updateMetadata);
-                $("#img_doublepage").on("load", Reader.updateMetadata);
                 if (img1.complete && img1.naturalWidth > 0 && img2.complete && img2.naturalWidth > 0) {
                     setTimeout(() => Reader.updateMetadata(), 0);
                 }
@@ -874,13 +844,7 @@ Reader.goToPage = function (page) {
             }
         } else {
             const img = Reader.loadImage(Reader.currentPage);
-            $("#img").replaceWith(img);
-            $(img).attr({
-                "id": "img",
-                "class": "reader-image",
-                "fetchpriority": "high"
-            });
-            $(img).on("load", Reader.updateMetadata);
+            Reader.replaceImageElement("#img", img);
             if (img.complete && img.naturalWidth > 0) {
                 setTimeout(() => Reader.updateMetadata(), 0);
             }
@@ -950,6 +914,40 @@ Reader.loadImage = function (index) {
     }
 
     return Reader.preloadedImg[src];
+};
+
+/**
+ * Replace a reader image DOM element with a preloaded cached Image,
+ * preserving the old element's identity and managing load handlers
+ * to prevent accumulation on reused cache objects.
+ */
+Reader.replaceImageElement = function (selector, cachedImg) {
+    const $old = $(selector);
+    const attrs = {
+        "id": $old.attr("id"),
+        "class": $old.attr("class"),
+        "fetchpriority": $old.attr("fetchpriority"),
+    };
+
+    $old.replaceWith(cachedImg);
+    $(cachedImg).off("load").on("load", Reader.updateMetadata);
+    $(cachedImg).attr(attrs);
+};
+
+/**
+ * Reset a reader image element to an empty state, breaking any
+ * reference to a cached Image object to prevent cache corruption.
+ */
+Reader.resetImageElement = function (selector) {
+    const $old = $(selector);
+    const fresh = $("<img>").attr({
+        "id": $old.attr("id"),
+        "class": $old.attr("class"),
+        "fetchpriority": $old.attr("fetchpriority"),
+        "src": "",
+    });
+    $old.off("load");
+    $old.replaceWith(fresh);
 };
 
 Reader.toggleFitMode = function (e) {

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -825,22 +825,41 @@ Reader.goToPage = function (page) {
             // If w > h on one of the images(widespread), set canvasdata to the first image only
             if (img1.naturalWidth > img1.naturalHeight || img2.naturalWidth > img2.naturalHeight) {
                 // Depending on whether we were going forward or backward, display img1 or img2
-                const wideSrc = Reader.previousPage > Reader.currentPage ? img2.src : img1.src;
-                $("#img").attr("src", wideSrc);
+                const wideImg = Reader.previousPage > Reader.currentPage ? img2 : img1;
+                $("#img").replaceWith(wideImg);
+                $(wideImg).attr("id", "img");
+                $(wideImg).on("load", Reader.updateMetadata);
+                if (wideImg.complete && wideImg.naturalWidth > 0) {
+                    setTimeout(() => Reader.updateMetadata(), 0);
+                }
                 Reader.showingSinglePage = true;
             } else {
                 if (Reader.mangaMode) {
-                    $("#img").attr("src", img2.src);
-                    $("#img_doublepage").attr("src", img1.src);
+                    $("#img").replaceWith(img2);
+                    $(img2).attr("id", "img");
+                    $("#img_doublepage").replaceWith(img1);
+                    $(img1).attr("id", "img_doublepage");
                 } else {
-                    $("#img").attr("src", img1.src);
-                    $("#img_doublepage").attr("src", img2.src);
+                    $("#img").replaceWith(img1);
+                    $(img1).attr("id", "img");
+                    $("#img_doublepage").replaceWith(img2);
+                    $(img2).attr("id", "img_doublepage");
+                }
+                $("#img").on("load", Reader.updateMetadata);
+                $("#img_doublepage").on("load", Reader.updateMetadata);
+                if (img1.complete && img1.naturalWidth > 0 && img2.complete && img2.naturalWidth > 0) {
+                    setTimeout(() => Reader.updateMetadata(), 0);
                 }
                 $("#display").addClass("double-mode");
             }
         } else {
             const img = Reader.loadImage(Reader.currentPage);
-            $("#img").attr("src", img.src);
+            $("#img").replaceWith(img);
+            $(img).attr("id", "img");
+            $(img).on("load", Reader.updateMetadata);
+            if (img.complete && img.naturalWidth > 0) {
+                setTimeout(() => Reader.updateMetadata(), 0);
+            }
             Reader.showingSinglePage = true;
         }
 

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -752,23 +752,16 @@ Reader.updateMetadata = function () {
     const imageUrl = new URL(img.src);
     const filename = imageUrl.searchParams.get("path");
 
-    const imgDoublePage = $("#img_doublepage")[0];
-    const imageUrlDoublePage = new URL(imgDoublePage.src);
-    const filenameDoublePage = imageUrlDoublePage.searchParams.get("path");
-
     if (!filename && Reader.showingSinglePage) {
         Reader.currentPageLoaded = true;
         $("#i3").removeClass("loading");
         return;
     }
 
-    const width = img.naturalWidth;
-    const height = img.naturalHeight;
-    const widthDoublePage = imgDoublePage.naturalWidth;
-    const heightDoublePage = imgDoublePage.naturalHeight;
-    const widthView = width + widthDoublePage;
-
     if (Reader.showingSinglePage) {
+        const width = img.naturalWidth;
+        const height = img.naturalHeight;
+
         let size = Reader.preloadedSizes[Reader.currentPage];
         if (!size) {
             size = LRR.getImgSize(Reader.pages[Reader.currentPage]);
@@ -780,6 +773,26 @@ Reader.updateMetadata = function () {
             $(".file-info").attr("title", `${filename} :: ${width} x ${height} :: ${size} KB`);
         }
     } else {
+        const imgDoublePage = $("#img_doublepage")[0];
+
+        // this is an edge case we may or may not want to cover
+        if (!imgDoublePage || !imgDoublePage.getAttribute("src")) {
+            console.warn("Reader.updateMetadata: missing #img_doublepage src in double-page branch", {
+                currentPage: Reader.currentPage,
+                showingSinglePage: Reader.showingSinglePage,
+                hasImgDoublePage: !!imgDoublePage,
+            });
+            return;
+        }
+
+        const imageUrlDoublePage = new URL(imgDoublePage.src);
+        const filenameDoublePage = imageUrlDoublePage.searchParams.get("path");
+        const width = img.naturalWidth;
+        const height = img.naturalHeight;
+        const widthDoublePage = imgDoublePage.naturalWidth;
+        const heightDoublePage = imgDoublePage.naturalHeight;
+        const widthView = width + widthDoublePage;
+
         let size = Reader.preloadedSizes[Reader.currentPage];
         let sizePre = Reader.preloadedSizes[Reader.currentPage + 1];
 

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -930,7 +930,7 @@ Reader.replaceImageElement = function (selector, cachedImg) {
     };
 
     $old.replaceWith(cachedImg);
-    $(cachedImg).off("load").on("load", Reader.updateMetadata);
+    $(cachedImg).on("load", Reader.updateMetadata);
     $(cachedImg).attr(attrs);
 };
 
@@ -944,9 +944,7 @@ Reader.resetImageElement = function (selector) {
         "id": $old.attr("id"),
         "class": $old.attr("class"),
         "fetchpriority": $old.attr("fetchpriority"),
-        "src": "",
     });
-    $old.off("load");
     $old.replaceWith(fresh);
 };
 


### PR DESCRIPTION
closes https://github.com/Difegue/LANraragi/issues/1433

explanation outline

- issue is that attr("src") triggers network fetch on webkit regardless of whether the image was fetched previously
- attr("src") triggers browser loading pipeline which invokes image decoding
- we don't want browser to decode, provide already decoded obj with `replaceWith`
- however, this removes updateMetadata handler, so we need to re-inject that.

explanation tbd

links tbd

- https://html.spec.whatwg.org/multipage/images.html
- https://github.com/whatwg/html/issues/2465
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decoding
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decode
- https://wiki.whatwg.org/wiki/ImageBitmap_Constructor_taking_URL