### PR TITLE
Hide fullscreen toggle on iphone safari

### DIFF
--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -152,12 +152,11 @@ Reader.initializeAll = function () {
 
     // Apply full-screen utility
     // F11 Fullscreen is totally another "Fullscreen", so its support is beyong consideration.
+    // Small override function, always returns boolean
+    window.fscreen.inFullscreen = () => !!window.fscreen.fullscreenElement;
     if (!window.fscreen.fullscreenEnabled) {
-        // Fullscreen mode is unsupported
-        $("#toggle-full-screen").hide();
-    } else {
-        // Small override function, always returns boolean
-        window.fscreen.inFullscreen = () => !!window.fscreen.fullscreenElement;
+        // Fullscreen mode is unsupported; use attribute selector to hide all instances
+        $("[id='toggle-full-screen']").hide();
     }
 
     // Infer initial information from the URL


### PR DESCRIPTION
There are two issues with current fullscreen logic:

1. `window.fscreen.inFullscreen` may not be defined. When undefined, an exception gets thrown (see logs).
2. `$("#toggle-full-screen").hide();` only hides one full screen toggle.

This became apparent when inspecting iphone behavior. As is known, safari on iphone doesn't support fullscreen API (even with ios 26); therefore, fullscreen support is disabled.

However on versions 26, the fullscreen toggle still appears, and clicking on them exhibits no apparent behavior. With console debugging via commit https://github.com/Difegue/LANraragi/commit/66e169d27742dd5fb1c8a11bc355db32517eb254 on ios dev tools:

```
  [Log] [fullscreen-debug] fullscreenEnabled: – false (reader.js, line 171)
  [Log] [fullscreen-debug] fscreen extensible: – true (reader.js, line 172)
  [Log] [fullscreen-debug] fscreen keys before: – ["requestFullscreen", "requestFullscreenFunction", "exitFullscreen", …] (10) (reader.js, line 173)
  ["requestFullscreen", "requestFullscreenFunction", "exitFullscreen", "fullscreenPseudoClass", "addEventListener", "removeEventListener", "fullscreenEnabled", "fullscreenElement",
   "onfullscreenchange", "onfullscreenerror"]Array (10)
  [Log] [fullscreen-debug] hiding fullscreen button (not supported) (reader.js, line 176)
  [Log] [fullscreen-debug] after hide() – {display: "none", inlineStyle: "display: none;", hidden: false, …} (reader.js, line 180)
  {display: "none", inlineStyle: "display: none;", hidden: false, offsetWidth: 0}Object
  [Log] [fullscreen-debug] click handler fired – {eventTarget: "toggle-full-screen", eventCurrentTarget: "toggle-full-screen", elementExists: true, …} (reader.js, line 62)
  {eventTarget: "toggle-full-screen", eventCurrentTarget: "toggle-full-screen", elementExists: true, display: "none", visibility: "visible", …}Object
  [Log] Trace: [fullscreen-debug] click stack trace
      (anonymous function) (reader.js:73)
      dispatch (jquery.min.js:2:43070)
  [Log] [fullscreen-debug] handleFullScreen called – {enableFullscreen: true, inFullscreenType: "undefined", fullscreenEnabled: false} (reader.js, line 1140)
  [Error] TypeError: window.fscreen.inFullscreen is not a function. (In 'window.fscreen.inFullscreen()', 'window.fscreen.inFullscreen' is undefined)
      (anonymous function) (reader.js:1145)
      (anonymous function) (reader.js:74)
      dispatch (jquery.min.js:2:43070)
```