### PR TITLE
Add support for Redis connections through unix socket

### DIFF
--- a/lib/LANraragi.pm
+++ b/lib/LANraragi.pm
@@ -10,6 +10,7 @@ use Mojo::JSON qw(decode_json encode_json);
 use Storable;
 use Sys::Hostname;
 use Config;
+use URI::Escape;
 
 use LANraragi::Utils::Generic    qw(start_shinobu start_minion);
 use LANraragi::Utils::Logging    qw(get_logger get_logdir);
@@ -166,7 +167,12 @@ sub startup {
         shutdown_from_pid( get_temp . "/minion.pid" );
     }
 
-    my $miniondb      = $self->LRR_CONF->get_redisad . "/" . $self->LRR_CONF->get_miniondb;
+    my $redisad = $self->LRR_CONF->get_redisad;
+
+    # URL encode the unix socket path so it can be recognized as the host
+    if ( $redisad =~ m{^/} ) { $redisad = uri_escape( $redisad ); }
+
+    my $miniondb      = $redisad . "/" . $self->LRR_CONF->get_miniondb;
     my $redispassword = $self->LRR_CONF->get_redispassword;
 
     # If the password is non-empty, add the required delimiters

--- a/lib/LANraragi/Model/Config.pm
+++ b/lib/LANraragi/Model/Config.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use utf8;
 use Cwd 'abs_path';
+use URI::Escape;
 
 use Mojo::Util qw(xml_escape);
 use Minion;
@@ -49,7 +50,12 @@ sub get_baseurl { return "$config->{base_url_path}" }
 
 # Create a Minion object connected to the Minion database.
 sub get_minion {
-    my $miniondb = get_redisad . "/" . get_miniondb;
+    my $redisad = get_redisad;
+
+    # URL encode the unix socket path so it can be recognized as the host
+    if ( $redisad =~ m{^/} ) { $redisad = uri_escape( $redisad ); }
+
+    my $miniondb = $redisad . "/" . get_miniondb;
     my $password = get_redispassword;
 
     # If the password is non-empty, add the required delimiters
@@ -72,13 +78,14 @@ sub get_redis_search {
 
 sub get_redis_internal {
 
-    my $db = $_[0];
+    my $db      = $_[0];
+    my $redisad = &get_redisad;
 
     # Default redis server location is localhost:6379.
     # Auto-reconnect on, one attempt every 2ms up to 3 seconds. Die after that.
     # Auth if password is set
     my $redis = Redis->new(
-        server    => &get_redisad,
+        ( $redisad =~ m{^/} ? ( sock => $redisad ) : ( server => $redisad ) ),
         debug     => $ENV{LRR_DEVSERVER} ? "1" : "0",
         reconnect => 3,
         &get_redispassword ? ( password => &get_redispassword ) : ()


### PR DESCRIPTION
I tested this on the latest release using both Unix and TCP connections.

Another approach would be to create a Mojo::URL manually and pass it to Minion but I think this is simpler.