### PR TITLE
Fix some compact mode issues

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -961,6 +961,7 @@ Index.resizableColumns = function () {
     let currentIndex;
     let startX;
     let startWidth;
+    let didDrag = false;
 
     const headers = document.querySelectorAll("#header-row th");
     headers.forEach(header => {
@@ -975,17 +976,21 @@ Index.resizableColumns = function () {
                 if (!Number.isInteger(startWidth))
                     startWidth = parseInt(startWidth.replace("px", ""));
 
+                didDrag = false;
+
                 document.addEventListener("mousemove", resizeColumn);
                 document.addEventListener("mouseup", stopResize);
-
-                // Disable DataTables sorting while resizing
-                // (Unfortunately, sorting is perma-disabled after this..)
-                // TODO fix both deprecated and the broken sorting
-                $("th").unbind("click.DT");
 
                 document.body.style.cursor = "col-resize";
             }
         });
+        header.addEventListener("click", function (e) {
+            if (didDrag) {
+                // If releasing from a drag, block click.DT handler from triggering a draw.
+                e.stopImmediatePropagation();
+                didDrag = false;
+            }
+        }, true);
         header.addEventListener("mousemove", function (event) {
             if (event.offsetX > header.offsetWidth - 10) {
                 header.style.cursor = "col-resize";
@@ -996,6 +1001,7 @@ Index.resizableColumns = function () {
     });
 
     function resizeColumn(event) {
+        didDrag = true;
         if (currentHeader) {
             currentHeader.style.cursor = "col-resize";
             let newWidth = startWidth + (event.clientX - startX);

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -343,11 +343,12 @@ Index.promptCustomColumn = function (column) {
     }).then((result) => {
         if (result.isConfirmed) {
             if (!LRR.isNullOrWhitespace(result.value)) {
-                localStorage.setItem(`customColumn${column}`, result.value.trim());
+                const namespace = result.value.trim();
+                localStorage.setItem(`customColumn${column}`, namespace);
 
-                // Absolutely disgusting
-                IndexTable.dataTable.settings()[0].aoColumns[column].sName = result.value.trim();
-                Index.updateTableHeaders();
+                IndexTable.dataTable.settings()[0].aoColumns[column].sName = namespace;
+                // Update header text in-place to preserve DataTables sort handlers
+                $(`#header-${column}`).html(namespace.charAt(0).toUpperCase() + namespace.slice(1));
                 IndexTable.doSearch();
             }
         }
@@ -408,7 +409,8 @@ Index.handleCustomSort = function () {
         order[0][0] = 1;
         localStorage.customColumn1 = namespace;
         IndexTable.dataTable.settings()[0].aoColumns[1].sName = namespace;
-        Index.updateTableHeaders();
+        // Update header text in-place to preserve DataTables sort handlers
+        $(`#header-1`).html(namespace.charAt(0).toUpperCase() + namespace.slice(1));
     }
 
     IndexTable.dataTable.order(order);

--- a/public/js/index_datatables.js
+++ b/public/js/index_datatables.js
@@ -141,7 +141,7 @@ IndexTable.doSearch = function (page) {
 IndexTable.renderColumn = function (namespace, type, data) {
     if (type === "display") {
         if (data === "") return "";
-        const regex = new RegExp(`${namespace}:([^,]+)`, "gi"); // catch all values associated to the given namespace
+        const regex = new RegExp(`${namespace}:([^,]+)`, "g"); // catch all values associated to the given namespace
         const matches = [...data.matchAll(regex)];
 
         if (matches != null) {


### PR DESCRIPTION
Closes https://github.com/Difegue/LANraragi/issues/1229.

One existing issue and one or two bugs.

First, the issue: we have a TODO in compact mode that disables sort toggle via clicking header. Apparently, this was because before we added customizable column width and that makes any drag event become a click, which triggers a DT draw.

For this issue, I propose that we just distinguish between a "drag" and a "click". If an action is a drag, it's cosmetic/alters DT appearance, and we don't draw. If an action is a click, then it's functional, and we do a draw.

Second is bug 1229. Well, there are two issues.

1. updateTableHeaders calls generateTableHeaders, which calls `headerRow.empty();`... so we destroy the header rows, the things DT only binds to during initialization. This meant that when you edit an extra column the headers become outright ineffective, not just giving wrong sorts.

2. Say I change a column name to "Group" (doesn't have to be new column), then the api sent to perl backend carries "Group" namespace sort key. Perl's backend sort logic is case sensitive, so this request returns nonsense zzzz-sort response. But the frontend `const regex = new RegExp(`${namespace}:([^,]+)`, "gi");` is case *insensitive*, so this nonsense is propagated confusingly to the UI layer.

In reality, "Group" shouldn't correspond to anything because in most backend plugins, it's all lowercase. However, the UI *suggests* that "Group" should be passed instead of "group", because all *user-facing* namespaces have their first letters capitalized.

So this PR enforces the behavior that any input that isn't strictly equal to a namespace in the metadata db is invalid. If the DB has "group" and user passes "Group", invalid. If DB has "Group" and user passes "group", invalid. This makes the problem more obvious if the user did make this type of mistake, as they would see an empty column (instead of a column of unsorted elements that don't react to their endless sort toggling).