### PR TITLE
Implement excluded namespace logic

### DIFF
--- a/lib/LANraragi/Controller/Api/Database.pm
+++ b/lib/LANraragi/Controller/Api/Database.pm
@@ -27,8 +27,14 @@ sub drop_database {
 sub serve_tag_stats {
     my $self = shift->openapi->valid_input or return;
     my $minscore = $self->req->param('minweight') || "1";
+    my $hide_excluded = $self->req->param('hide_excluded_namespaces') || "0";
 
-    $self->render( openapi => LANraragi::Model::Stats::build_tag_stats($minscore) );
+    my @excluded;
+    if ( $hide_excluded eq "true" ) {
+        @excluded = split( /\s*,\s*/, $self->LRR_CONF->get_excludednamespaces );
+    }
+
+    $self->render( openapi => LANraragi::Model::Stats::build_tag_stats( $minscore, \@excluded ) );
 }
 
 sub clean_database {

--- a/lib/LANraragi/Controller/Api/Other.pm
+++ b/lib/LANraragi/Controller/Api/Other.pm
@@ -38,7 +38,10 @@ sub serve_serverinfo {
             authenticated_progress => $self->LRR_CONF->enable_authprogress ? \1 : \0,
             total_pages_read       => $page_stat,
             total_archives         => $arc_stat,
-            cache_last_cleared     => $last_clear
+            cache_last_cleared     => $last_clear,
+            excluded_namespaces    => [
+                split( /\s*,\s*/, $self->LRR_CONF->get_excludednamespaces )
+            ]
         }
     );
 }

--- a/lib/LANraragi/Controller/Config.pm
+++ b/lib/LANraragi/Controller/Config.pm
@@ -50,7 +50,8 @@ sub index {
         jxlthumbpages   => $self->LRR_CONF->get_jxlthumbpages,
         csshead         => generate_themes_header($self),
         replacedupe     => $self->LRR_CONF->get_replacedupe,
-        language        => $self->LRR_CONF->get_language
+        language        => $self->LRR_CONF->get_language,
+        excludednamespaces => $self->LRR_CONF->get_excludednamespaces
     );
 }
 
@@ -76,6 +77,7 @@ sub save_config {
         sizethreshold => scalar $self->req->param('sizethreshold'),
         theme         => scalar $self->req->param('theme'),
         language      => scalar $self->req->param('language'),
+        excludednamespaces => scalar $self->req->param('excludednamespaces'),
 
         # For checkboxes,
         # we check if the parameter exists in the POST to return either 1 or 0.

--- a/lib/LANraragi/Model/Config.pm
+++ b/lib/LANraragi/Model/Config.pm
@@ -210,6 +210,6 @@ sub get_jxlthumbpages    { return &get_redis_conf( "jxlthumbpages",   "0" ) }
 sub get_replacedupe      { return &get_redis_conf( "replacedupe",     "0" ) }
 sub can_replacetitles    { return &get_redis_conf( "replacetitles",   "1" ) }
 sub get_language         { return &get_redis_conf( "language",        "auto" ) }
-sub get_excludednamespaces { return &get_redis_conf( "excludednamespaces", "" ) }
+sub get_excludednamespaces { return &get_redis_conf( "excludednamespaces", "source, date_added" ) }
 
 1;

--- a/lib/LANraragi/Model/Config.pm
+++ b/lib/LANraragi/Model/Config.pm
@@ -210,5 +210,6 @@ sub get_jxlthumbpages    { return &get_redis_conf( "jxlthumbpages",   "0" ) }
 sub get_replacedupe      { return &get_redis_conf( "replacedupe",     "0" ) }
 sub can_replacetitles    { return &get_redis_conf( "replacetitles",   "1" ) }
 sub get_language         { return &get_redis_conf( "language",        "auto" ) }
+sub get_excludednamespaces { return &get_redis_conf( "excludednamespaces", "" ) }
 
 1;

--- a/lib/LANraragi/Model/Stats.pm
+++ b/lib/LANraragi/Model/Stats.pm
@@ -207,9 +207,12 @@ sub is_url_recorded ($url) {
 
 sub build_tag_stats {
 
-    my $minscore = shift;
-    my $logger   = get_logger( "Tag Stats", "lanraragi" );
+    my ( $minscore, $excluded_ns ) = @_;
+    my $logger = get_logger( "Tag Stats", "lanraragi" );
     $logger->debug("Serving tag statistics with a minimum weight of $minscore");
+
+    # Convert excluded namespaces into a hash for quick lookup
+    my %excluded = map { $_ => 1 } @{ $excluded_ns || [] };
 
     # Login to Redis and grab the stats sorted set
     my $redis    = LANraragi::Model::Config->get_redis_search;
@@ -228,10 +231,10 @@ sub build_tag_stats {
         my $t  = redis_decode($_);
         if ( $t =~ /([^:]*):(.*)/ ) { $ns = $1; $t = $2; }
 
-        if ( $_ ne "" ) {
-            my $j = { text => $t, namespace => $ns, weight => $w };
-            push( @tags, $j );
-        }
+        next if $_ eq "";                       # Skip empty Redis keys
+        next if %excluded && $excluded{$ns};    # Skip tags in excluded namespaces
+
+        push( @tags, { text => $t, namespace => $ns, weight => $w } );
     }
 
     return \@tags;

--- a/locales/template/en.po
+++ b/locales/template/en.po
@@ -577,6 +577,15 @@ msgstr "<b>tag => new-tag</b> : replaces one tag, but use a hash table internall
 msgid "<b>namespace:* -> new-namespace:*</b> : replaces the namespace with the new one"
 msgstr "<b>namespace:* -> new-namespace:*</b> : replaces the namespace with the new one"
 
+msgid "Excluded Namespaces"
+msgstr "Excluded Namespaces"
+
+msgid "Comma-separated list of tag namespaces to exclude from search suggestions and tag statistics."
+msgstr "Comma-separated list of tag namespaces to exclude from search suggestions and tag statistics."
+
+msgid "Clients will use this list to filter out noisy tags from autocomplete and tag clouds."
+msgstr "Clients will use this list to filter out noisy tags from autocomplete and tag clouds."
+
 # ------End of Config_Tags.html.tt2------
 
 # ------Start of Config_Theme.html.tt2------

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -797,13 +797,13 @@ Index.handleContextMenu = function (option, id) {
  * Load tag suggestions for the tag search bar.
  */
 Index.loadTagSuggestions = function () {
-    // Query the tag cloud API to get the most used tags.
-    Server.callAPI("/api/database/stats?minweight=2", "GET", null, I18N.TagStatsLoadFailure,
+    // Query the tag cloud API to get the most used tags, excluding configured namespaces.
+    Server.callAPI("/api/database/stats?minweight=2&hide_excluded_namespaces=true", "GET", null, I18N.TagStatsLoadFailure,
         (data) => {
             // Get namespaces objects in the data array to fill the namespace-sortby combobox
             const namespacesSet = new Set(data.map((element) => (element.namespace === "parody" ? "series" : element.namespace)));
             namespacesSet.forEach((element) => {
-                if (element !== "" && element !== "date_added") {
+                if (element !== "") {
                     $("#namespace-sortby").append(`<option value="${element}">${element.charAt(0).toUpperCase() + element.slice(1)}</option>`);
                 }
             });

--- a/public/js/stats.js
+++ b/public/js/stats.js
@@ -8,7 +8,7 @@ Stats.initializeAll = function () {
     // bind events to DOM
     $(document).on("click.goback", "#goback", () => { window.location.replace("./"); });
 
-    Server.callAPI("/api/database/stats?minweight=2", "GET", null, I18N.TagStatsLoadFailure,
+    Server.callAPI("/api/database/stats?minweight=2&hide_excluded_namespaces=true", "GET", null, I18N.TagStatsLoadFailure,
         (data) => {
             $("#statsLoading").hide();
             $("#tagcount").html(data.length);
@@ -22,9 +22,6 @@ Stats.initializeAll = function () {
             // Buildup detailed stats
             const tagList = $("#tagList");
             data.forEach((tag) => {
-                // Ignore tags that start with "source:" or "date_added:"
-                if (tag.namespace === "source" || tag.namespace === "date_added")
-                    return;
                 const namespacedTag = LRR.buildNamespacedTag(tag.namespace, tag.text);
                 const url = LRR.getTagSearchURL(tag.namespace, tag.text);
 

--- a/templates/templates_config/config_tags.html.tt2
+++ b/templates/templates_config/config_tags.html.tt2
@@ -93,6 +93,18 @@
 
 <tr>
     <td class="option-td">
+        <h2 class="ih"> [% c.lh("Excluded Namespaces") %] </h2>
+    </td>
+    <td class="config-td">
+        <input class="stdinput" style="width:100%" maxlength="255" size="20" value="[% excludednamespaces %]"
+            name="excludednamespaces" type="text">
+        <br>[% c.lh("Comma-separated list of tag namespaces to exclude from search suggestions and tag statistics.") %]
+        <br>[% c.lh("Clients will use this list to filter out noisy tags from autocomplete and tag clouds.") %]
+    </td>
+</tr>
+
+<tr>
+    <td class="option-td">
         <h2 class="ih"> [% c.lh("Tag Rules") %] </h2>
     </td>
     <td class="config-td">

--- a/tools/openapi.yaml
+++ b/tools/openapi.yaml
@@ -2122,6 +2122,14 @@ paths:
             Default is 1 if not specified, to get all tags.
           schema:
             type: integer
+        - name: hide_excluded_namespaces
+          in: query
+          required: false
+          description: >-
+            Set to true to exclude namespaces configured in server settings from
+            the results. Default behavior returns all tags.
+          schema:
+            type: string
       responses:
         '200':
           description: Success response
@@ -3385,6 +3393,11 @@ components:
         cache_last_cleared:
           type: integer
           description: Timestamp for last time the search cache was wiped
+        excluded_namespaces:
+          type: array
+          items:
+            type: string
+          description: List of tag namespaces excluded from search suggestions and tag statistics
       example:
         archives_per_page: 100
         cache_last_cleared: 1728852701
@@ -3399,6 +3412,9 @@ components:
         total_archives: 104
         total_pages_read: 252
         version: 0.9.30
+        excluded_namespaces:
+          - source
+          - date_added
         version_desc: I'm under Japanese influence and my honor's at stake!
         version_name: Law (Earthlings On Fire)
     PluginInfo:


### PR DESCRIPTION
Closes https://github.com/Difegue/LANraragi/issues/1404

Adds client-side namespace exclusion logic to search and stats. Updates "/api/info" with an "excluded_namespaces" list[str] field.

## Example

Without "date_added" exclusion, these tags naturally show up in search filter.

<img width="1118" height="242" alt="Screenshot 2026-03-12 at 12 32 59 AM" src="https://github.com/user-attachments/assets/245d478f-5725-45b6-b4fc-32ba125827f5" />

random numbers also appear in stats.

<img width="608" height="446" alt="Screenshot 2026-03-12 at 12 34 17 AM" src="https://github.com/user-attachments/assets/8d957ebc-21de-4121-a116-ed40e8e2c86d" />

Obviously, "date_added" is just an example. Source, any type of ID namespace will also have this problem.

### Configuration

To remove "date_added" field, configure excluded tag namespaces:

<img width="960" height="661" alt="Screenshot 2026-03-12 at 12 28 38 AM" src="https://github.com/user-attachments/assets/4de3de8e-2af8-4df0-9f4a-2d1f0565db78" />

No more random numbers in tag cloud:

<img width="904" height="751" alt="Screenshot 2026-03-12 at 12 28 22 AM" src="https://github.com/user-attachments/assets/5b0289b6-fe59-4ffe-af91-18b5cb0c4f92" />

"date_added" no longer shows up in search filter:

<img width="989" height="306" alt="Screenshot 2026-03-12 at 12 29 47 AM" src="https://github.com/user-attachments/assets/e4469bb3-1919-44d0-8831-1c748819a83d" />

Opt-in: starts with an empty string, users pass namespaces they want to exclude (e.g. "source,date_added").
