### PR TITLE
Update search cache logic to prioritize keyed archives

### DIFF
--- a/lib/LANraragi/Model/Search.pm
+++ b/lib/LANraragi/Model/Search.pm
@@ -89,7 +89,7 @@ sub check_cache ( $cachekey, $cachekey_inv ) {
 
         my $frozendata = $redis->hget( "LRR_SEARCHCACHE", $cachekey );
         my @cached = @{ thaw $frozendata };
-        shift @cached;
+        shift @cached; # Discard the keyed count, since they're at the bottom of the list naturally
         @filtered = @cached;
 
     } elsif ( $redis->exists("LRR_SEARCHCACHE") && $redis->hexists( "LRR_SEARCHCACHE", $cachekey_inv ) ) {

--- a/lib/LANraragi/Model/Search.pm
+++ b/lib/LANraragi/Model/Search.pm
@@ -53,10 +53,11 @@ sub do_search ( $filter, $category_id, $start, $sortkey, $sortorder, $newonly, $
     # Don't use cache for history searches since setting lastreadtime doesn't (and shouldn't) cachebust
     unless ( $cachehit && $sortkey ne "lastread" ) {
         $logger->debug("No cache available (or history-sorted search), doing a full DB parse.");
-        @filtered = search_uncached( $category_id, $filter, $sortkey, $sortorder, $newonly, $untaggedonly, $grouptanks );
+        my $keyed_count;
+        ( $keyed_count, @filtered ) = search_uncached( $category_id, $filter, $sortkey, $sortorder, $newonly, $untaggedonly, $grouptanks );
 
-        # Cache this query in the search database
-        eval { $redis->hset( "LRR_SEARCHCACHE", $cachekey, nfreeze \@filtered ); };
+        # Cache this query in the search database, prepending the keyed count for partition-aware cache inversion
+        eval { $redis->hset( "LRR_SEARCHCACHE", $cachekey, nfreeze [ $keyed_count, @filtered ] ); };
     }
     $redis->quit();
 
@@ -86,17 +87,25 @@ sub check_cache ( $cachekey, $cachekey_inv ) {
         $logger->debug("Using cache for this query.");
         $cachehit = 1;
 
-        # Thaw cache and use that as the filtered list
         my $frozendata = $redis->hget( "LRR_SEARCHCACHE", $cachekey );
-        @filtered = @{ thaw $frozendata };
+        my @cached = @{ thaw $frozendata };
+        shift @cached;
+        @filtered = @cached;
 
     } elsif ( $redis->exists("LRR_SEARCHCACHE") && $redis->hexists( "LRR_SEARCHCACHE", $cachekey_inv ) ) {
         $logger->debug("A cache key exists with the opposite sortorder.");
         $cachehit = 1;
 
-        # Thaw cache, invert the list to match the sortorder and use that as the filtered list
         my $frozendata = $redis->hget( "LRR_SEARCHCACHE", $cachekey_inv );
-        @filtered = reverse @{ thaw $frozendata };
+        my @cached = @{ thaw $frozendata };
+        my $keyed_count = shift @cached;
+
+        # Reverse only the keyed prefix; unkeyed archives stay at the back
+        if ( $keyed_count > 0 && $keyed_count < scalar @cached ) {
+            @filtered = ( reverse( @cached[ 0 .. $keyed_count - 1 ] ), @cached[ $keyed_count .. $#cached ] );
+        } else {
+            @filtered = reverse @cached;
+        }
     }
 
     $redis->quit();
@@ -300,17 +309,20 @@ sub search_uncached ( $category_id, $filter, $sortkey, $sortorder, $newonly, $un
         } else {
 
             # For other sorting, we need to get the metadata for each archive and sort it manually.
-            # Just use the old sort algorithm at this point.
-            @filtered = sort_results( $sortkey, $sortorder, @filtered );
+            my $keyed_count;
+            ( $keyed_count, @filtered ) = sort_results( $sortkey, $sortorder, @filtered );
 
-            # We could theoretically use the tag indexes for this by scanning them all
-            # to find the filtered IDs and then ordering on those namespace/ID pairs, but that's a lot of work for little gain.
+            $redis->quit();
+            $redis_db->quit();
+            return ( $keyed_count, @filtered );
         }
     }
 
     $redis->quit();
     $redis_db->quit();
-    return @filtered;
+
+    # Title sort and unfiltered results: all archives are keyed
+    return ( scalar @filtered, @filtered );
 }
 
 # Transform the search engine syntax into a list of tokens.
@@ -413,7 +425,7 @@ sub sort_results ( $sortkey, $sortorder, @filtered ) {
 
     # Should there be no IDs requiring sorting, return an empty array directly
     if (scalar @filtered == 0) {
-        return @sorted;
+        return ( 0, @sorted );
     }
 
     # Employ Lua scripting to fetch data in bulk, thereby minimizing network request frequency
@@ -505,19 +517,36 @@ LUA
             }
         }
 
-        # Read comments from the bottom up for a better understanding of this sort algorithm.
-        @sorted = map { $_->[0] }                  # Map back to only having the ID
-          sort { ncmp( $a->[1], $b->[1] ) }        # Sort by the tag
-          map  { [ $_, lc( $tmpfilter{$_} ) ] }    # Map to an array containing the ID and the lowercased tag
-          @filtered;                               # List of IDs
+        # Partition: archives with the sort namespace vs those without it
+        my @keyed_ids   = grep { $tmpfilter{$_} ne "zzzz" } @filtered;
+        my @unkeyed_ids = grep { $tmpfilter{$_} eq "zzzz" } @filtered;
+
+        # Sort only the keyed archives
+        @sorted = map { $_->[0] }
+          sort { ncmp( $a->[1], $b->[1] ) }
+          map  { [ $_, lc( $tmpfilter{$_} ) ] }
+          @keyed_ids;
+
+        if ($sortorder) {
+            @sorted = reverse @sorted;
+        }
+
+        # Archives missing the sort namespace always go to the back
+        push @sorted, @unkeyed_ids;
+
+        my $total_time = time() - $start_time;
+        $logger->debug("[PERF] sort_results completed in ${total_time}s");
+        return ( scalar @keyed_ids, @sorted );
     }
 
-    if ($sortorder) {
+    if ( $sortkey eq "lastread" && $sortorder ) {
         @sorted = reverse @sorted;
     }
     my $total_time = time() - $start_time;
     $logger->debug("[PERF] sort_results completed in ${total_time}s");
-    return @sorted;
+
+    # lastread: all returned archives are keyed (nil timestamps filtered out)
+    return ( scalar @sorted, @sorted );
 }
 
 1;

--- a/lib/LANraragi/Model/Search.pm
+++ b/lib/LANraragi/Model/Search.pm
@@ -322,7 +322,7 @@ sub search_uncached ( $category_id, $filter, $sortkey, $sortorder, $newonly, $un
     $redis_db->quit();
 
     # Title sort and unfiltered results: all archives are keyed
-    return ( scalar @filtered, @filtered );
+    return ( -1, @filtered );
 }
 
 # Transform the search engine syntax into a list of tokens.
@@ -546,7 +546,7 @@ LUA
     $logger->debug("[PERF] sort_results completed in ${total_time}s");
 
     # lastread: all returned archives are keyed (nil timestamps filtered out)
-    return ( scalar @sorted, @sorted );
+    return ( -1, @sorted );
 }
 
 1;

--- a/lib/LANraragi/Model/Search.pm
+++ b/lib/LANraragi/Model/Search.pm
@@ -521,11 +521,11 @@ LUA
         my @keyed_ids   = grep { $tmpfilter{$_} ne "zzzz" } @filtered;
         my @unkeyed_ids = grep { $tmpfilter{$_} eq "zzzz" } @filtered;
 
-        # Sort only the keyed archives
-        @sorted = map { $_->[0] }
-          sort { ncmp( $a->[1], $b->[1] ) }
-          map  { [ $_, lc( $tmpfilter{$_} ) ] }
-          @keyed_ids;
+        # Read comments from the bottom up for a better understanding of this sort algorithm.
+        @sorted = map { $_->[0] }                   # Map back to only having the ID
+          sort { ncmp( $a->[1], $b->[1] ) }         # Sort by the tag
+          map  { [ $_, lc( $tmpfilter{$_} ) ] }     # Map to an array containing the ID and the lowercased tag
+          @keyed_ids;                               # List of keyed archive IDs
 
         if ($sortorder) {
             @sorted = reverse @sorted;

--- a/tests/backup.t
+++ b/tests/backup.t
@@ -23,6 +23,7 @@ use LANraragi::Model::Backup;
 # Would've liked to compare JSON strings directly here, but since the key order is non-deterministic it's easier to compare the result hashes.
 my %expected_backup =
   %{ decode_json qq({"archives":[
+          {"arcid":"be447b58ea66137c415ee306ee2ac44b308ee484","filename":null,"tags":"series:Neon Genesis Evangelion, artist:Yoshiyuki Sadamoto, chapter:1, character:Shinji Ikari, character:Misato Katsuragi, science fiction","thumbhash":null,"title":"\u4f7f\u5f92\u3001\u8972\u6765", "summary":""},
           {"arcid":"e4c422fd10943dc169e3489a38cdbf57101a5f7e","filename":null,"tags":"parody: jojo's bizarre adventure","thumbhash":null,"title":"Rohan Kishibe goes to Gucci", "summary":""},
           {"arcid":"4857fd2e7c00db8b0af0337b94055d8445118630","filename":null,"tags":"artist:shirow masamune","thumbhash":null,"title":"Ghost in the Shell 1.5 - Human-Error Processor vol01ch01", "summary":""},
           {"arcid":"e69e43e1355267f7d32a4f9b7f2fe108d2401ebf","filename":null,"tags":"character:segata sanshiro, male:very cool","thumbhash":null,"title":"Saturn Backup Cartridge - Japanese Manual", "summary":""},

--- a/tests/mocks.pl
+++ b/tests/mocks.pl
@@ -112,6 +112,16 @@ sub setup_redis_mock {
             "summary": "CURSE OF RA",
             "lastreadtime": 0
         },
+        "be447b58ea66137c415ee306ee2ac44b308ee484": {
+            "isnew": "false",
+            "pagecount": 34,
+            "progress": 0,
+            "tags": "series:Neon Genesis Evangelion, artist:Yoshiyuki Sadamoto, chapter:1, character:Shinji Ikari, character:Misato Katsuragi, science fiction",
+            "title": "\u4f7f\u5f92\u3001\u8972\u6765",
+            "file": "package.json",
+            "summary": "",
+            "lastreadtime": 0
+        },
         "TANK_1589141306": [
             "name_Hello",
             "28697b96f0ac5858be2666ed10ca47742c955555",

--- a/tests/samples/opds/opds_sample.xml
+++ b/tests/samples/opds/opds_sample.xml
@@ -10,7 +10,7 @@
     <link rel="self" href="/api/opds" type="application/atom+xml;profile=opds-catalog;kind=acquisition" />
     <link rel="start" href="/api/opds" type="application/atom+xml;profile=opds-catalog;kind=acquisition" />
 
-    <link rel="next" href="/api/opds?start=8" type="application/atom+xml;profile=opds-catalog;kind=navigation" />
+    <link rel="next" href="/api/opds?start=9" type="application/atom+xml;profile=opds-catalog;kind=navigation" />
 
     <title>LANraragi</title>
     <updated>2010-01-10T10:03:10Z</updated>
@@ -41,7 +41,39 @@
         thr:count="2" />
     
 
-    
+
+    <entry>
+        <title>4f7f5f92300189726765</title>
+        <id>urn:lrr:be447b58ea66137c415ee306ee2ac44b308ee484</id>
+        <updated>1970-01-01T00:00:00Z</updated>
+        <published>1970-01-01T00:00:00Z</published>
+        <author>
+            <name>Yoshiyuki Sadamoto</name>
+        </author>
+        <rights></rights>
+        <dcterms:language></dcterms:language>
+        <dcterms:publisher></dcterms:publisher>
+        <dcterms:issued></dcterms:issued>
+
+        <category term="Archive" />
+
+        <summary>series:Neon Genesis Evangelion, artist:Yoshiyuki Sadamoto, chapter:1, character:Shinji Ikari, character:Misato Katsuragi, science fiction</summary>
+
+        <link rel="alternate" href="/api/opds/be447b58ea66137c415ee306ee2ac44b308ee484"
+            type="application/atom+xml;type=entry;profile=opds-catalog" />
+
+        <link rel="http://opds-spec.org/image" href="/api/archives/be447b58ea66137c415ee306ee2ac44b308ee484/thumbnail" type="image/jpeg" />
+        <link rel="http://opds-spec.org/image/thumbnail" href="/api/archives/be447b58ea66137c415ee306ee2ac44b308ee484/thumbnail"
+            type="image/jpeg" />
+        <link rel="http://opds-spec.org/acquisition" href="/api/archives/be447b58ea66137c415ee306ee2ac44b308ee484/download" title="Download/Read"
+            type="application/x-cbz" />
+        <link rel="http://vaemendis.net/opds-pse/stream" type="image/jpeg"
+            href="/api/opds/be447b58ea66137c415ee306ee2ac44b308ee484/pse?page={pageNumber}" pse:count="34"
+
+            />
+        <link type="text/html" rel="alternate" title="Open in LANraragi" href="/reader?id=be447b58ea66137c415ee306ee2ac44b308ee484" />
+    </entry>
+
     <entry>
         <title>All about Egypt</title>
         <id>urn:lrr:28697b96f0ac5858be2666ed10ca47742c955555</id>

--- a/tests/search.t
+++ b/tests/search.t
@@ -36,9 +36,9 @@ sub do_test_search {
 }
 
 do_test_search();
-is( $filtered, 8, qq(Empty search(full index)) );
+is( $filtered, 9, qq(Empty search(full index)) );
 ( $total, $filtered, @ids ) = LANraragi::Model::Search::do_search( $search, "", 0, 0, 0, 0, 0, 0 );
-is( $filtered, 8, qq(Empty search(tank grouping off)) );
+is( $filtered, 9, qq(Empty search(tank grouping off)) );
 
 $search = qq(Ghost in the Shell);
 do_test_search();
@@ -144,5 +144,56 @@ is( $filtered, 2,                 qq(Tankoubon grouping count) );
 ( $total, $filtered, @ids ) = LANraragi::Model::Search::do_search( $search, "", 0, 0, 0, 0, 0, 0 );
 is( $filtered, 1,                                          qq(No tank grouping count) );
 is( $ids[0],   "28697b96f0ac5777be2614ed10ca47742c9522fa", qq(Tank grouping disabled) );
+
+note('testing namespace sort partition (keyed archives first, unkeyed at back)...');
+
+my %expected_keyed = map { $_ => 1 } (
+    "4857fd2e7c00db8b0af0337b94055d8445118630",     # artist:shirow masamune
+    "2810d5e0a8d027ecefebca6237031a0fa7b91eb3",     # artist:wada rco
+    "28697b96f0ac5858be2614ed10ca47742c9522fd",     # artist:wada rco
+    "be447b58ea66137c415ee306ee2ac44b308ee484",     # artist:yoshiyuki sadamoto
+);
+my %expected_unkeyed = map { $_ => 1 } (
+    "e69e43e1355267f7d32a4f9b7f2fe108d2401ebf",
+    "e69e43e1355267f7d32a4f9b7f2fe108d2401ebg",
+    "e4c422fd10943dc169e3489a38cdbf57101a5f7e",
+    "28697b96f0ac5777be2614ed10ca47742c9522fa",
+    "28697b96f0ac5858be2666ed10ca47742c955555",
+);
+
+{
+    # Sort by artist, ascending: shirow masamune < wada rco < yoshiyuki sadamoto
+    my ( $total, $filtered, @ids ) = LANraragi::Model::Search::do_search( "", "", -1, "artist", 0, 0, 0, 0 );
+    is( $filtered, 9, 'Artist sort should return all archives' );
+
+    # Keyed partition (positions 0-3): boundary positions are deterministic
+    is( $ids[0], "4857fd2e7c00db8b0af0337b94055d8445118630",
+        'Artist asc should place shirow masamune first' );
+    is( $ids[3], "be447b58ea66137c415ee306ee2ac44b308ee484",
+        'Artist asc should place yoshiyuki sadamoto last in keyed partition' );
+    is_deeply( { map { $_ => 1 } @ids[0..3] }, \%expected_keyed,
+        'Artist asc keyed partition should contain all artist-tagged archives' );
+
+    # Unkeyed partition (positions 4-8): archives without artist tag
+    is_deeply( { map { $_ => 1 } @ids[4..8] }, \%expected_unkeyed,
+        'Artist asc should place all unkeyed archives at positions 5-9' );
+}
+
+{
+    # Sort by artist, descending — only keyed partition reverses
+    my ( $total, $filtered, @ids ) = LANraragi::Model::Search::do_search( "", "", -1, "artist", 1, 0, 0, 0 );
+
+    # Keyed partition reversed: boundary positions swap
+    is( $ids[0], "be447b58ea66137c415ee306ee2ac44b308ee484",
+        'Artist desc should place yoshiyuki sadamoto first' );
+    is( $ids[3], "4857fd2e7c00db8b0af0337b94055d8445118630",
+        'Artist desc should place shirow masamune last in keyed partition' );
+    is_deeply( { map { $_ => 1 } @ids[0..3] }, \%expected_keyed,
+        'Artist desc keyed partition should contain all artist-tagged archives' );
+
+    # Unkeyed partition still at back
+    is_deeply( { map { $_ => 1 } @ids[4..8] }, \%expected_unkeyed,
+        'Artist desc should keep all unkeyed archives at positions 5-9' );
+}
 
 done_testing();


### PR DESCRIPTION
Closes https://github.com/Difegue/LANraragi/issues/1299

Terminology:
- An archive is *keyed* with respect to a namespace if it contains a tag prefixed with that namespace; otherwise it's *unkeyed*. For example, untagged archives are always unkeyed, and an archive with tag string "artist:test" is unkeyed WRT namespace "date_added", but keyed WRT namespace "artist".

This means that every search filter and namespace sort creates a partition of keyed and unkeyed archives. 

The existing problem is that when a user decides to sort by a namespace, they are expecting to view *keyed archives*. However, LRR may provide unkeyed archives upfront, forcing the user to navigate several pages before finding the first keyed archive in the sorted sequence.

The goal of this PR is to always place unkeyed (not just untagged) archives at the back, while keeping keyed archives sorted and in the front.

Since this must apply regardless of ascending/descending order, the existing "just reverse the list" logic won't apply. We'd need to sort the keyed part while pushing the unkeyed archives at the back for each cache key and order.

A cache key and order produces a (keyed list, unkeyed list) pair. If order is inverted, take the keyed list only and invert this list, then return (inverted keyed list, unkeyed list) in this order.