### PR TITLE
Use resource timing API over XHR head

### DIFF
--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -898,12 +898,12 @@ Reader.loadImage = function (index) {
         const img = new Image();
         img.src = src;
         Reader.preloadedImg[src] = img;
-        if (!Reader.preloadedSizes[index]) {
-            LRR.getImgSizeAsync(src).done((data, textStatus, request) => {
-                const size = parseInt(request.getResponseHeader("Content-Length") / 1024, 10);
-                Reader.preloadedSizes[index] = size;
-            });
-        }
+        img.addEventListener("load", () => {
+            const entry = performance.getEntriesByName(img.src, "resource").pop();
+            if (entry) {
+                Reader.preloadedSizes[index] = Math.round(entry.decodedBodySize / 1024);
+            }
+        });
     }
 
     return Reader.preloadedImg[src];


### PR DESCRIPTION
- closes https://github.com/Difegue/LANraragi/issues/1433
- resource timing API: https://developer.mozilla.org/en-US/docs/Web/API/Performance_API/Resource_timing

(I still cannot explain this well enough, but here goes...)

Motivating issue: preloading doesn't work in safari. If you look at network inspector, the URL for any given image is always fetched at least twice. In a slow network or when using weak devices, this problem becomes noticeable through slow image loading.

This is reproducible via a test case: https://github.com/psilabs-dev/aio-lanraragi/blob/0a8e4a9c15a4395fca02e63a338f12e2d0dd00a5/integration_tests/tests/simple/test_reader.py#L137. It tells you *something* is wrong, but not *what* is wrong or *why*.

This PR changes how file size is obtained. The issue (empirically by testing behavior locally) is that `LRR.getImgSizeAsync` for some reason messes up safari browser fetch deduplication behavior and triggers a re-fetch. So we just avoid using this and use a different approach instead.

Reading docs did not really help explain "why", but this PR is smaller. I've been looking for a more minimal change than PR https://github.com/Difegue/LANraragi/pull/1459, given the changes were not defensible.

Maybe someone more knowledgeable can explain. I probably won't spend anymore time researching this topic, as the change directly resolves my issue.