### PR TITLE
Move toggleArchiveOverlay after updateArchiveOverlay

### DIFF
--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -298,14 +298,16 @@ Reader.addTocSection = function (page, currentTitle = null) {
         showCancelButton: true,
         reverseButtons: true,
     }).then((result) => {
-        Reader.toggleArchiveOverlay();
         if (result.isConfirmed && result.value.trim() !== "") {
-            Server.callAPI(`/api/archives/${Reader.id}/toc?page=${page}&title=${result.value}`, "PUT", "Chapter added!", I18N.ReaderTocError, 
+            Server.callAPI(`/api/archives/${Reader.id}/toc?page=${page}&title=${result.value}`, "PUT", "Chapter added!", I18N.ReaderTocError,
                 () => Reader.loadContentData().then(() => {
-                        Reader.updateArchiveOverlay(true); 
-                        Reader.goToPage(page);
-                      })
+                    Reader.updateArchiveOverlay(true);
+                    Reader.toggleArchiveOverlay();
+                    Reader.goToPage(page);
+                })
             );
+        } else {
+            Reader.toggleArchiveOverlay();
         }
     });
 }
@@ -322,12 +324,16 @@ Reader.removeTocSection = function () {
         reverseButtons: true,
         confirmButtonColor: "#d33",
     }).then((result) => {
-        Reader.toggleArchiveOverlay();
         if (result.isConfirmed) {
-            let page = Reader.currentChapter.startPage; 
-            Server.callAPI(`/api/archives/${Reader.id}/toc?page=${page}`, "DELETE", "Chapter removed!", I18N.ReaderTocError, 
-                () => Reader.loadContentData().then(() => Reader.updateArchiveOverlay(true))
+            let page = Reader.currentChapter.startPage;
+            Server.callAPI(`/api/archives/${Reader.id}/toc?page=${page}`, "DELETE", "Chapter removed!", I18N.ReaderTocError,
+                () => Reader.loadContentData().then(() => {
+                    Reader.updateArchiveOverlay(true);
+                    Reader.toggleArchiveOverlay();
+                })
             );
+        } else {
+            Reader.toggleArchiveOverlay();
         }
     });
 }


### PR DESCRIPTION
Toggle the overlay only once the chapter name has been updated.

A (minor) staleness issue, as the PUT call may not update quickly enough resulting in stale data in the frontend. However, it did fail tests, and probably would be noticable in a slow network.