### PR TITLE
Don't crash when all results are filtered out

### DIFF
--- a/lib/LANraragi/Model/Search.pm
+++ b/lib/LANraragi/Model/Search.pm
@@ -184,6 +184,7 @@ sub search_uncached ( $category_id, $filter, $sortkey, $sortorder, $newonly, $un
                     result[#result + 1] = id
                 end
             end
+            if #result == 0 then return "[]" end
             return cjson.encode(result)
 LUA
 


### PR DESCRIPTION
Return an empty array instead of default "{}" when all archives (under a filter) are completed.