### PR TITLE
Check if download body-size matches Content-Length header

### DIFF
--- a/lib/LANraragi/Model/Upload.pm
+++ b/lib/LANraragi/Model/Upload.pm
@@ -215,6 +215,12 @@ sub download_url ( $url, $ua ) {
         die( "No valid Content-Disposition header received after 5 attempts, aborting. (Last result: " . $tx->result->body . ")" );
     }
 
+    my $content_length = $tx->result->headers->content_length;
+    my $body_size = $tx->result->body_size;
+    if ( $content_length && $content_length != $body_size ) {
+        die( "Failed to download full body. (Expected $content_length bytes, received $body_size)" );
+    }
+
     $logger->debug("Content-Disposition Header: $content_disp");
     if ( $content_disp =~ /.*filename=\"(.*)\".*/gim ) {
         $filename = $1;


### PR DESCRIPTION
If a connection drops during a download (e.g. because of a proxy or fucky server) then we can have a truncated body without a good way to check if there was an error.
[Mojo::Response::is_error](https://docs.mojolicious.org/Mojo/Message/Response#is_error) wasn't useful nor did [Mojo::Message::error](https://docs.mojolicious.org/Mojo/Message#error) seem to be anything, so here's a check for the `Content-Length` (if it exists) which can help sometimes.