### PR TITLE
Only push a new history entry if it is different from the current URL

### DIFF
--- a/public/js/index_datatables.js
+++ b/public/js/index_datatables.js
@@ -281,8 +281,17 @@ IndexTable.drawCallback = function () {
             IndexTable.isComingFromPopstate = false;
         } else {
             let params = IndexTable.buildURLParameters();
-            if (params === "?") params = "/";
-            window.history.pushState(null, null, params);
+            // don't push duplicate state entries, because that would wipe out forward history and
+            // require multiple 'back' presses to go back)
+            if (params === "?") {
+                // special case for empty search params: window.location.search is "" if there are
+                // no search params, even if window.location ends with '?'
+                if (window.location.search !== "") {
+                    window.history.pushState(null, null, "/");
+                }
+            } else if (params !== window.location.search) {
+                window.history.pushState(null, null, params);
+            }
         }
 
         let currentSort = IndexTable.dataTable.order()[0][0];
@@ -292,7 +301,6 @@ IndexTable.drawCallback = function () {
         localStorage.indexSort = currentSort;
         localStorage.indexOrder = currentOrder;
 
-        // Using double equals here since the sort column can be either a string or an int
         // get current columns count, except title and tags
         const currentCustomColumnCount = IndexTable.dataTable.columns().count() - 2;
         // check currentSort, if out of range, back to use title
@@ -342,17 +350,19 @@ IndexTable.consumeURLParameters = function () {
     // Get order from URL, fallback to localstorage if available
     const order = [[0, "asc"]];
 
+    // Query params and localStorage values are always strings, parse them so order[0][0] is always
+    // a number. (This lets us correctly compare to 0 using !== above.)
     if (params.has("sort")) {
-        order[0][0] = params.get("sort");
+        order[0][0] = parseInt(params.get("sort"), 10);
     } else if (localStorage.indexSort) {
-        order[0][0] = localStorage.indexSort;
+        order[0][0] = parseInt(localStorage.indexSort, 10);
     }
     // get current columns count, except title and tags
     const currentCustomColumnCount = IndexTable.dataTable.columns().count() - 2;
     // check currentSort, if out of range, back to use title
     if (localStorage.indexSort > currentCustomColumnCount) {
         localStorage.indexSort = 0;
-        order[0][0] = localStorage.indexSort;
+        order[0][0] = parseInt(localStorage.indexSort, 10);
     }
 
     if (params.has("sortdir")) {


### PR DESCRIPTION
This means duplicate history stack entries will not be created when reloading, which makes going back easier and avoids blanking out forward history unless required.

To explain the issue more thoroughly: suppose you navigate from the search page to an archive, use 'back' to get back to the search page, and perform some action that triggers this code (like updating a rating from the search page, or just refreshing). Before this change, that would result in a pushState call that got rid of the 'forward' history entries, so you couldn't navigate forward to the archive again.

Even if there isn't forward history to lose, repeated reloads end up creating more and more (identical) entries on the history stack. Keep hitting f5 and watch the back stack grow (or use browser session restore, that's how I noticed this).

Please note that you need to have nonempty query params to trigger these cases.