### PR TITLE
Add go-to-page feature.

### DIFF
--- a/locales/template/en.po
+++ b/locales/template/en.po
@@ -1028,6 +1028,9 @@ msgstr "B: toggle bookmark"
 msgid "N: toggle auto next page"
 msgstr "N: toggle auto next page"
 
+msgid "G: go to page number"
+msgstr "G: go to page number"
+
 msgid "To return to the archive index, touch the arrow pointing down or use Backspace."
 msgstr "To return to the archive index, touch the arrow pointing down or use Backspace."
 
@@ -1714,6 +1717,9 @@ msgstr "Error while downloading file."
 
 msgid "Error sending job to Minion"
 msgstr "Error sending job to Minion"
+
+msgid "Go to page:"
+msgstr "Go to page:"
 
 # ------End of i18n.html.tt2------
 

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -544,6 +544,14 @@ Reader.handleShortcuts = function (e) {
         case 70: // f
             Reader.toggleFullScreen();
             break;
+
+        case 71: // g
+            let page = parseInt(prompt(I18N.GoToPage), 10);
+            // parseInt returns NaN for non-numbers; normal equality checks don't work to detect NaN
+            if (!Number.isNaN(page)) {
+                Reader.goToPage(page - 1);
+            }
+            break;
         case 72: // h
             Reader.toggleHelp();
             break;

--- a/templates/i18n.html.tt2
+++ b/templates/i18n.html.tt2
@@ -140,6 +140,7 @@ I18N.ReaderTocAdded = "[% c.lh("Chapter added!") %]";
 I18N.ReaderTocError = "[% c.lh("Error adding/removing chapter:") %]";
 I18N.ReaderClearRating = "[% c.lh("Clear Rating") %]";
 I18N.UntitledChapter = "[% c.lh("Untitled Chapter") %]";
+I18N.GoToPage = "[% c.lh("Go to page:") %]";
 
 I18N.ScriptRunning = "[% c.lh("A script is already running.") %]";
 I18N.ScriptRunningDesc = "[% c.lh("Please wait for it to finish before starting a new one.") %]";

--- a/templates/reader.html.tt2
+++ b/templates/reader.html.tt2
@@ -189,6 +189,7 @@
                 <li>[% c.lh("F: toggle fullscreen mode") %]</li>
                 <li>[% c.lh("B: toggle bookmark") %]</li>
                 <li>[% c.lh("N: toggle auto next page") %]</li>
+                <li>[% c.lh("G: go to page number") %]</li>
             </ul>
             <br>[% c.lh("To return to the archive index, touch the arrow pointing down or use Backspace.") %]
         </div>


### PR DESCRIPTION
When you know exactly what page you want, and especially for larger archives, this can be faster than pulling up the thumbnails with Q.

This has been working well for me for a while. A caveat: it does use prompt() rather than any fancy DOM-based UI, but I tested a bit on firefox and safari and on both of these prompt() seems pretty OK (doesn't seem to disable back/forward or closing the tab, but does prevent page interaction).