### PR TITLE
Prefer RFC5987 filename* for downloaded archive names

### DIFF
--- a/lib/LANraragi/Model/Upload.pm
+++ b/lib/LANraragi/Model/Upload.pm
@@ -220,12 +220,17 @@ sub download_url ( $url, $ua ) {
     }
 
     $logger->debug("Content-Disposition Header: $content_disp");
-    if ( $content_disp =~ /.*filename=\"(.*)\".*/gim ) {
-        $filename = Encode::decode('iso-8859-1', $1 );
-    } elsif ( $content_disp =~ /.*filename\*=UTF-8''(.*)/gim ) {
+    if ( $content_disp =~ /.*filename\*=UTF-8''(.*)/gim ) {
         # This is an UTF8 filename as per rfc5987.
         # URL-decode to get the full filename.
         $filename = Encode::decode('utf8', uri_unescape( $1 ) );
+    } elsif ( $content_disp =~ /.*filename=\"(.*)\".*/gim ) {
+        my $legacy_filename = $1;
+
+        # Some servers put raw UTF-8 bytes in the legacy filename field.
+        # Try UTF-8 first, then fall back to ISO-8859-1 for compatibility.
+        $filename = eval { Encode::decode( 'utf8', $legacy_filename, Encode::FB_CROAK ) };
+        $filename = Encode::decode( 'iso-8859-1', $legacy_filename ) unless defined $filename;
     } elsif ( $url =~ /([^\/]+)\/?$/gm ) {
         # Fallback to the last element of the URL as the filename.
         $logger->debug("No filename found in header, using URL as filename.");


### PR DESCRIPTION
After upgrading to version 0.9.7, I encountered an error following a download:

```
   Error while processing file.
  (Couldn't open archive '/home/koyomi/lanraragi/content/[Ã£ÂÂÃ£ÂÂÃ£ÂÂÃ£ÂÂ¨Ã£ÂÂ¤Ã£ÂÂ
(Ã£ÂÂÃ£ÂÂÃ£ÂÂÃ£ÂÂÃ©Â®Â«Ã¨ÂÂ)]
  Ã£ÂÂÃ£ÂÂÃ£ÂÂ¼Ã£ÂÂ¢Ã£ÂÂ©Ã£ÂÂ¾Ã£ÂÂÃ£ÂÂ2026 [Ã¤Â¸ÂÃ¥ÂÂ½Ã§Â¿Â»Ã¨Â¨Â³] [DLÃ§ÂÂ].zip'
(id:e0c5f18b2685347c0dd7182508671cfbc3a160e6,
  exists:no; readable:no; size:NA)libarchive: Failed to open '/home/koyomi/lanraragi/content/[Ã£ÂÂÃ£ÂÂÃ£ÂÂÃ£ÂÂ¨Ã£ÂÂ¤Ã£ÂÂ
  (Ã£ÂÂÃ£ÂÂÃ£ÂÂÃ£ÂÂÃ©Â®Â«Ã¨ÂÂ)] Ã£ÂÂÃ£ÂÂÃ£ÂÂ¼Ã£ÂÂ¢Ã£ÂÂ©Ã£ÂÂ¾Ã£ÂÂÃ£ÂÂ2026 [Ã¤Â¸ÂÃ¥ÂÂ½Ã§Â¿Â»Ã¨Â¨Â³]
[DLÃ§ÂÂ].zip' (errno 2: No such
  file or directory) at /home/koyomi/lanraragi/script/../lib/LANraragi/Utils/Archive.pm line 190. )
```

In reality, the file is downloaded successfully, but the subsequent processing fails to correctly specify the file path due to an encoding issue.

After using an LLM to investigate, I identified a potentially problematic commit (ce88ed36) and applied a fix. I have verified that this fix resolves the issue.

I don’t have any experience with Perl, but the patch is minimal and seems reasonable. If there are any concerns with this approach, feel free to close this PR; I am happy for it to serve merely as a reference.

Below is the explanation provided by the LLM:

> 
> A recent change in download_url started decoding the legacy Content-Disposition field filename="..." as ISO-8859-1 before checking filename*=.
>   Some download responses include both fields (or put raw UTF-8 bytes in filename), so this order caused mojibake paths (for example Ã...) and LANraragi failed to open the downloaded archive even though the file was actually saved.
> 
>   This patch keeps the fix minimal and focused:
> 
>   1. Prefer RFC5987 filename*= over legacy filename=.
>   2. For legacy filename=, try UTF-8 decoding first, then fall back to ISO-8859-1 for compatibility.
> 
> 
>   Reasoning: filename* is the standards-based UTF-8 source and should take precedence; the fallback preserves old behavior for servers that still use Latin-1. This fixes broken non-ASCII filenames without changing the rest of the download pipeline.