### PR TITLE
Use `__FILE__` instead of `FindBin::Bin`

### DIFF
--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -7,7 +7,8 @@ use utf8;
 use feature 'say';
 use feature 'isa';
 use POSIX;
-use FindBin;
+use File::Basename;
+use Cwd 'abs_path';
 use Time::HiRes;
 use Config;
 
@@ -31,14 +32,14 @@ our %LOGGER_CACHE;
 # Get the Log folder.
 sub get_logdir {
 
-    my $log_folder = "$FindBin::Bin/../log";
+    my $log_folder = dirname(__FILE__) . "/../../../log";
 
     # Folder location can be overriden by LRR_LOG_DIRECTORY
     if ( $ENV{LRR_LOG_DIRECTORY} ) {
         $log_folder = $ENV{LRR_LOG_DIRECTORY};
     }
     mkdir $log_folder;
-    return $log_folder;
+    return abs_path($log_folder);
 }
 
 # Returns a Mojo::Log object with a custom name and a filename for the log file.

--- a/lib/LANraragi/Utils/TempFolder.pm
+++ b/lib/LANraragi/Utils/TempFolder.pm
@@ -5,15 +5,15 @@ use warnings;
 use utf8;
 
 use Cwd 'abs_path';
+use File::Basename;
 
 #Contains all functions related to the temporary folder.
 use Exporter 'import';
 our @EXPORT_OK = qw(get_temp);
 
 #Get the current tempfolder.
-#This can be called from any process safely as it uses FindBin.
 sub get_temp {
-    my $temp_folder = "$FindBin::Bin/../temp";
+    my $temp_folder = dirname(__FILE__) . "/../../../temp";
 
     # Folder location can be overriden by LRR_TEMP_DIRECTORY
     if ( $ENV{LRR_TEMP_DIRECTORY} ) {


### PR DESCRIPTION
For some reason, depending on whether you run prove with unit tests or perl, find::bin gives a different directory per entry script, which resulted in spamming the repo with log files during unit tests.

Sometimes it leaks to `tests/LANraragi/log/lanraragi.log`, because we run from `tests/LANraragi/Utils/Logging.t`.

According to https://perldoc.perl.org/FindBin:

"$Bin or $Dir
Path to the bin directory from where *script* was invoked"

Not sure why we use this; wouldn't `__FILE__` be more stable anyways?