### PR TITLE
UUID integration

### DIFF
--- a/lib/LANraragi/Model/Tankoubon.pm
+++ b/lib/LANraragi/Model/Tankoubon.pm
@@ -67,9 +67,8 @@ sub create_tankoubon ( $name, $tank_id ) {
 
     # Set all fields of the group object
     unless ( length($tank_id) ) {
-        my $timestamp = time();
-        my $md5_UUID     = create_uuid(UUID_V3, $timestamp);
-        my $str_appendix = uuid_to_string($md5_UUID);
+        my $v4_rand_UUID_2  = create_uuid(UUID_RANDOM);
+        my $str_appendix = uuid_to_string($v4_rand_UUID_2);
         $tank_id = "TANK_" . $str_appendix;
 
         my $isnewkey = 0;
@@ -185,7 +184,7 @@ sub delete_tankoubon ($tank_id) {
     my $redis        = LANraragi::Model::Config->get_redis;
     my $redis_search = LANraragi::Model::Config->get_redis_search;
 
-    if ( length($tank_id) != 15 ) {
+    if ( length($tank_id) != 41 ) {
 
         # Probably not a Tankoubon ID
         $logger->error("$tank_id is not a Tankoubon ID, doing nothing.");

--- a/lib/LANraragi/Model/Tankoubon.pm
+++ b/lib/LANraragi/Model/Tankoubon.pm
@@ -10,6 +10,7 @@ use utf8;
 use Redis;
 use Mojo::JSON qw(decode_json encode_json);
 use List::Util qw(min);
+use UUID::Tiny ':std';
 
 use LANraragi::Utils::Database qw(invalidate_cache get_archive_json_multi get_tankoubons_by_file);
 use LANraragi::Utils::Generic  qw(array_difference filter_hash_by_keys);
@@ -28,7 +29,7 @@ sub get_tankoubon_list ( $page = 0 ) {
     $page //= 0;
 
     # Tankoubons are represented by TANK_[timestamp] in DB. Can't wait for 2038!
-    my @tanks = $redis->keys('TANK_??????????');
+    my @tanks = $redis->keys('TANK_????????-????-????-????-????????????');
 
     # Jam tanks into an array of hashes
     my @result;
@@ -66,7 +67,10 @@ sub create_tankoubon ( $name, $tank_id ) {
 
     # Set all fields of the group object
     unless ( length($tank_id) ) {
-        $tank_id = "TANK_" . time();
+        my $timestamp = time();
+        my $md5_UUID     = create_uuid(UUID_V3, $timestamp);
+        my $str_appendix = uuid_to_string($md5_UUID);
+        $tank_id = "TANK_" . $str_appendix;
 
         my $isnewkey = 0;
         until ($isnewkey) {
@@ -124,7 +128,7 @@ sub get_tankoubon ( $tank_id, $fulldata = 0, $page = 0 ) {
         return ();
     }
 
-    unless ( length($tank_id) == 15 && $redis->exists($tank_id) ) {
+    unless ( length($tank_id) == 41 && $redis->exists($tank_id) ) {
         $logger->warn("$tank_id doesn't exist in the database!");
         return ();
     }

--- a/tests/mocks.pl
+++ b/tests/mocks.pl
@@ -122,12 +122,12 @@ sub setup_redis_mock {
             "summary": "",
             "lastreadtime": 0
         },
-        "TANK_1589141306": [
+        "TANK_0daa851e-55da-36b2-bfa3-2d1c8c3d6d08": [
             "name_Hello",
             "28697b96f0ac5858be2666ed10ca47742c955555",
             "28697b96f0ac5777be2614ed10ca47742c9522fa"
         ],
-        "TANK_1589138380":[
+        "TANK_0daa851e-55da-36b2-bfa3-2d1c8c3d6d09":[
             "name_World",
             "28697b96f0ac5777be2614ed10ca47742c9522fa"
         ]
@@ -146,7 +146,7 @@ sub setup_redis_mock {
 
             # Replace redis' '*' wildcards with regex '.*'s
             $expr = $expr =~ s/\*/\.\*/gr;
-            return grep { /$expr/ } keys %datamodel;
+            return grep { /^$expr$/ } keys %datamodel;
         }
     );
     $redis->mock( 'exists',  sub { shift; return $_[0] eq "LRR_SEARCHCACHE" ? 0 : 1 } );

--- a/tests/tankoubon.t
+++ b/tests/tankoubon.t
@@ -25,21 +25,18 @@ my $redis = LANraragi::Model::Config->get_redis;
 # Build search hashes
 LANraragi::Model::Stats::build_stat_hashes();
 
-# Search queries
-my ( $total, $filtered, @rgs );
-
 # Get Tankoubon
-my ( $total, $filtered, %tankoubon ) = LANraragi::Model::Tankoubon::get_tankoubon("TANK_1589141306", 0, 0);
-is($tankoubon{id}, "TANK_1589141306", 'ID test');
+my ( $total, $filtered, %tankoubon ) = LANraragi::Model::Tankoubon::get_tankoubon("TANK_0daa851e-55da-36b2-bfa3-2d1c8c3d6d08", 0, 0);
+is($tankoubon{id}, "TANK_0daa851e-55da-36b2-bfa3-2d1c8c3d6d08", 'ID test');
 is($tankoubon{name}, "Hello", 'Name test');
 is($total, 2, 'Total Test');
 is($filtered, 2, 'Count Test');
 ok($tankoubon{archives}[0] eq "28697b96f0ac5858be2666ed10ca47742c955555", 'Archives test');
 
 # List Tankoubon
-( $total, $filtered, @rgs ) = LANraragi::Model::Tankoubon::get_tankoubon_list(0);
-is($total, 2, 'Total Test');
-is($filtered, 2, 'Count Test');
-ok($rgs[0]{name} eq "World" && $rgs[1]{name} eq "Hello", 'Tank List test');
+my ( $total_list, $filtered_list, @rgs ) = LANraragi::Model::Tankoubon::get_tankoubon_list(0);
+is($total_list, 2, 'Total Test');
+is($filtered_list, 2, 'Count Test');
+ok($rgs[0]{name} eq "Hello" && $rgs[1]{name} eq "World", 'Tank List test');
 
 done_testing();


### PR DESCRIPTION
This is just a simple example of how to integrate UUID::Tiny to use for the hash table IDs. This example generates a Timestamp like we currently do, but generates an MD5 UUID from it, which is always 36 characters long, so we only need to update the KEYS string to TANK_????????-????-????-????-???????????? to make it compatible. This of course would require far more work, like an script to migrate all existent tanks to the new format, but is enough for the moment for demonstration purposes.

I didn't add any dependency to LRR install scripts, since I want to know first if this a good approach, and if UUID::Tiny is the right version to use, or we can choose a different one, so if you want to test this branch you would need to install manually the module in your environment, but the good news is that if everything works correctly, we can get rid of the ominous "Can't wait for 2038!" message :smile_cat: 