### PR TITLE
Add support for uncompressed folders as content

### DIFF
--- a/lib/LANraragi/Controller/Api/Archive.pm
+++ b/lib/LANraragi/Controller/Api/Archive.pm
@@ -104,6 +104,11 @@ sub serve_file {
 
     my $file = get_archive_path( $redis, $id );
     $redis->quit();
+
+    if ( -d $file ) {
+        return render_api_response( $self, "serve_file", "Cannot download a folder-based archive as a single file." );
+    }
+
     $self->render_file( filepath => compat_path($file), filename => basename($file) );
 }
 

--- a/lib/LANraragi/Model/Archive.pm
+++ b/lib/LANraragi/Model/Archive.pm
@@ -235,14 +235,19 @@ sub serve_thumbnail {
 }
 
 sub get_page_data ( $id, $path ) {
+
+    my $redis   = LANraragi::Model::Config->get_redis;
+    my $archive = get_archive_path( $redis, $id );
+    $redis->quit();
+
+    # For directories, read directly from disk without caching
+    if ( -d $archive ) {
+        return extract_single_file( $archive, $path );
+    }
+
     my $cachekey = "page/$id/$path";
     my $content  = fetch($cachekey);
     if ( !defined($content) ) {
-
-        # Extract the file from the parent archive if it doesn't exist
-        my $redis   = LANraragi::Model::Config->get_redis;
-        my $archive = get_archive_path( $redis, $id );
-        $redis->quit();
         $content = extract_single_file( $archive, $path );
         put( $cachekey, $content );
     }
@@ -255,6 +260,18 @@ sub serve_page {
     my $logger = get_logger( "File Serving", "lanraragi" );
 
     $logger->debug("Page /$id/$path was requested");
+
+    my $redis   = LANraragi::Model::Config->get_redis;
+    my $archive = get_archive_path( $redis, $id );
+    $redis->quit();
+
+    # For directories without resize, serve the file directly from disk
+    if ( -d $archive && !LANraragi::Model::Config->enable_resize ) {
+        my $fullpath = "$archive/$path";
+        $logger->debug("Serving directory file directly: $fullpath");
+        $self->render_file( filepath => $fullpath, content_disposition => "inline" );
+        return;
+    }
 
     # Apply resizing transformation if set in Settings
     if ( LANraragi::Model::Config->enable_resize ) {
@@ -407,7 +424,12 @@ sub delete_archive ($id) {
     LANraragi::Utils::Database::update_indexes( $id, $oldtags, "" );
 
     if ( -e $filename ) {
-        my $status = unlink_path($filename);
+        my $status;
+        if ( -d $filename ) {
+            $status = remove_tree($filename);
+        } else {
+            $status = unlink_path($filename);
+        }
 
         my $thumbdir  = LANraragi::Model::Config->get_thumbdir;
         my $subfolder = substr( $id, 0, 2 );

--- a/lib/LANraragi/Model/Archive.pm
+++ b/lib/LANraragi/Model/Archive.pm
@@ -9,6 +9,7 @@ use utf8;
 
 use Cwd 'abs_path';
 use Redis;
+use Encode;
 use Mojo::JSON  qw(decode_json encode_json);
 use Time::HiRes qw(usleep);
 use File::Path  qw(remove_tree);
@@ -267,7 +268,10 @@ sub serve_page {
 
     # For directories without resize, serve the file directly from disk
     if ( -d $archive && !LANraragi::Model::Config->enable_resize ) {
-        my $fullpath = "$archive/$path";
+        # $path is a Perl internal UTF-8 string from URL decoding;
+        # encode back to raw bytes to match filesystem encoding of $archive.
+        my $path_bytes = Encode::is_utf8($path) ? encode_utf8($path) : $path;
+        my $fullpath = "$archive/$path_bytes";
         $logger->debug("Serving directory file directly: $fullpath");
         $self->render_file( filepath => $fullpath, content_disposition => "inline" );
         return;

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -372,7 +372,10 @@ sub extract_single_file ( $archive, $filepath ) {
     my $logger = get_logger( "Archive", "lanraragi" );
 
     if ( -d $archive ) {
-        my $fullpath = "$archive/$filepath";
+        # $filepath may be a Perl internal UTF-8 string (from URL decoding);
+        # encode back to raw bytes to match the filesystem encoding of $archive.
+        my $fp_bytes = Encode::is_utf8($filepath) ? encode_utf8($filepath) : $filepath;
+        my $fullpath = "$archive/$fp_bytes";
         $logger->debug("Reading file directly from directory: $fullpath");
         return Mojo::File->new($fullpath)->slurp;
     }
@@ -420,11 +423,12 @@ sub extract_file_from_archive ( $archive, $filename ) {
     my $tmp = tempdir( DIR => $path, CLEANUP => 1 );
 
     if ( -d $archive ) {
-        my $src = "$archive/$filename";
-        my ( $name, $dir, $suffix ) = fileparse( $filename, qr/\.[^.]*/ );
+        my $fn_bytes = Encode::is_utf8($filename) ? encode_utf8($filename) : $filename;
+        my $src = "$archive/$fn_bytes";
+        my ( $name, $dir, $suffix ) = fileparse( $fn_bytes, qr/\.[^.]*/ );
         my $destdir = "$tmp/$dir";
         make_path($destdir);
-        my $dest = "$tmp/$filename";
+        my $dest = "$tmp/$fn_bytes";
         File::Copy::cp( $src, $dest ) or die "Could not copy '$src' to '$dest': $!";
         return $dest;
     }

--- a/lib/LANraragi/Utils/Archive.pm
+++ b/lib/LANraragi/Utils/Archive.pm
@@ -29,7 +29,7 @@ use LANraragi::Utils::TempFolder qw(get_temp);
 use LANraragi::Utils::Logging    qw(get_logger);
 use LANraragi::Utils::Generic    qw(is_image shasum_str);
 use LANraragi::Utils::Redis      qw(redis_decode redis_encode);
-use LANraragi::Utils::Path       qw(get_archive_path);
+use LANraragi::Utils::Path       qw(get_archive_path find_path create_path);
 use LANraragi::Utils::Resizer    qw(get_resizer);
 
 # Utilitary functions for handling Archives.
@@ -153,14 +153,30 @@ sub expand {
     return lc($file);
 }
 
-# Returns a list of all the files contained in the given archive with corresponding archive ID.
+# Returns a list of all the files contained in the given archive/directory with corresponding archive ID.
 sub get_filelist ($archive, $arcid) {
 
     my $logger = get_logger( "Archive", "lanraragi" );
 
     my @files = ();
 
-    if ( is_pdf($archive) ) {
+    if ( -d $archive ) {
+
+        my $basedir = $archive;
+        find_path(
+            sub {
+                $_ = create_path($_);
+                return if -d $_;
+                return unless is_image($_);
+
+                my $rel = $_;
+                $rel =~ s/^\Q$basedir\E[\/\\]?//;
+                push @files, $rel;
+            },
+            $basedir
+        );
+
+    } elsif ( is_pdf($archive) ) {
 
         # For pdfs, extraction returns images from 1.jpg to x.jpg, where x is the pdf pagecount.
         # Using -dNOSAFER or --permit-file-read is required since GS 9.50, see https://github.com/doxygen/doxygen/issues/7290
@@ -282,11 +298,24 @@ sub is_apple_signature_like_path ($path) {
     return 0;
 }
 
-# Uses libarchive::peek to figure out if $archive contains $file.
+# Checks if $archive contains $file. For directories, checks the filesystem directly.
 # Returns the exact in-archive path of the file if it exists, undef otherwise.
 sub is_file_in_archive ( $archive, $wantedname ) {
 
     my $logger = get_logger( "Archive", "lanraragi" );
+
+    if ( -d $archive ) {
+        $logger->debug("Checking directory $archive for '$wantedname'");
+        my @filelist = get_filelist( $archive, "" );
+        for my $file (@filelist) {
+            my ( $name, $path, $suffix ) = fileparse( $file, qr/\.[^.]*/ );
+            if ( "$name$suffix" =~ /\Q$wantedname\E$/ ) {
+                $logger->debug("OK!");
+                return $file;
+            }
+        }
+        return;
+    }
 
     if ( is_pdf($archive) ) {
         $logger->debug("$archive is a pdf, no sense looking for specific files");
@@ -342,7 +371,12 @@ sub extract_single_file ( $archive, $filepath ) {
 
     my $logger = get_logger( "Archive", "lanraragi" );
 
-    # Remove file from $outfile and hand the full directory to make_path
+    if ( -d $archive ) {
+        my $fullpath = "$archive/$filepath";
+        $logger->debug("Reading file directly from directory: $fullpath");
+        return Mojo::File->new($fullpath)->slurp;
+    }
+
     if ( is_pdf($archive) ) {
 
         # For pdfs the filenames are always x.jpg, so we pull the page number from that
@@ -377,13 +411,24 @@ sub extract_single_file ( $archive, $filepath ) {
 }
 
 # Variant for plugins.
-# Extracts the file to a folder in /temp/plugin.
+# Extracts the file to a folder in /temp/plugin. For directories, copies the file instead.
 sub extract_file_from_archive ( $archive, $filename ) {
 
     my $path = get_temp . "/plugin";
     mkdir $path;
 
     my $tmp = tempdir( DIR => $path, CLEANUP => 1 );
+
+    if ( -d $archive ) {
+        my $src = "$archive/$filename";
+        my ( $name, $dir, $suffix ) = fileparse( $filename, qr/\.[^.]*/ );
+        my $destdir = "$tmp/$dir";
+        make_path($destdir);
+        my $dest = "$tmp/$filename";
+        File::Copy::cp( $src, $dest ) or die "Could not copy '$src' to '$dest': $!";
+        return $dest;
+    }
+
     return extract_single_file_to_file( $archive, $filename, $tmp );
 }
 

--- a/lib/LANraragi/Utils/Database.pm
+++ b/lib/LANraragi/Utils/Database.pm
@@ -7,7 +7,7 @@ use utf8;
 use feature qw(signatures);
 no warnings 'experimental::signatures';
 
-use Digest::SHA qw(sha256_hex);
+use Digest::SHA qw(sha256_hex sha1_hex);
 use Mojo::JSON  qw(decode_json);
 use Encode;
 use File::Basename;
@@ -17,12 +17,12 @@ use Unicode::Normalize;
 use List::Util      qw(max);
 use List::MoreUtils qw(uniq);
 
-use LANraragi::Utils::Generic qw(flat);
+use LANraragi::Utils::Generic qw(flat is_image);
 use LANraragi::Utils::String  qw(trim trim_CRLF trim_url);
 use LANraragi::Utils::Tags    qw(unflat_tagrules tags_rules_to_array restore_CRLF join_tags_to_string split_tags_to_array );
 use LANraragi::Utils::Archive qw(get_filelist);
 use LANraragi::Utils::Logging qw(get_logger);
-use LANraragi::Utils::Path    qw(create_path open_path_or_die date_modified get_archive_path);
+use LANraragi::Utils::Path    qw(create_path open_path_or_die date_modified get_archive_path find_path);
 
 use LANraragi::Model::Config;
 
@@ -34,12 +34,18 @@ our @EXPORT_OK = qw(
   redis_decode redis_encode
 );
 
-# Creates a DB entry for a file path with the given ID.
+# Creates a DB entry for a file/directory path with the given ID.
 # This function doesn't actually require the file to exist at its given location.
 sub add_archive_to_redis ( $id, $file, $redis, $redis_search ) {
 
     my $logger = get_logger( "Archive", "lanraragi" );
-    my ( $name, $path, $suffix ) = fileparse( $file, qr/\.[^.]*/ );
+
+    my $name;
+    if ( -d $file ) {
+        $name = File::Basename::basename($file);
+    } else {
+        ( $name, undef, undef ) = fileparse( $file, qr/\.[^.]*/ );
+    }
 
     # Initialize Redis hash for the added file
     $logger->debug("Pushing to redis on ID $id:");
@@ -51,7 +57,11 @@ sub add_archive_to_redis ( $id, $file, $redis, $redis_search ) {
     $redis->hset( $id, "summary", "" );
 
     if ( defined($file) && -e $file ) {
-        $redis->hset( $id, "arcsize", -s $file );
+        if ( -d $file ) {
+            $redis->hset( $id, "arcsize", _compute_dir_size($file) );
+        } else {
+            $redis->hset( $id, "arcsize", -s $file );
+        }
     }
 
     # Don't encode filenames.
@@ -268,6 +278,8 @@ sub build_json ( $id, %hash ) {
         $title = $name;
     }
 
+    my $extension = -d $file ? "folder" : lc( ( split( /\./, $file ) )[-1] );
+
     my $arcdata = {
         arcid        => $id,
         title        => $title,
@@ -275,7 +287,7 @@ sub build_json ( $id, %hash ) {
         tags         => $tags,
         summary      => $summary,
         isnew        => $isnew ? $isnew : "false",
-        extension    => lc( ( split( /\./, $file ) )[-1] ),
+        extension    => $extension,
         progress     => $progress     ? int($progress)     : 0,
         pagecount    => $pagecount    ? int($pagecount)    : 0,
         lastreadtime => $lastreadtime ? int($lastreadtime) : 0,
@@ -570,8 +582,12 @@ sub update_indexes ( $id, $oldtags, $newtags ) {
 }
 
 # This function is used for all ID computation in LRR.
-# Takes the path to the file as an argument.
+# Takes the path to the file or directory as an argument.
 sub compute_id ($file) {
+
+    if ( -d $file ) {
+        return _compute_id_directory($file);
+    }
 
     #Read the first 512 KBs only (allows for faster disk speeds )
     open_path_or_die( my $handle, '<:raw', $file );
@@ -590,6 +606,39 @@ sub compute_id ($file) {
 
     return $digest;
 
+}
+
+# Compute ID for a directory by concatenating the first 4KB of each file (sorted by relative path).
+sub _compute_id_directory ($dir) {
+
+    my @files;
+    find_path(
+        sub {
+            $_ = create_path($_);
+            return if -d $_;
+            my $rel = $_;
+            $rel =~ s/^\Q$dir\E[\/\\]?//;
+            push @files, $rel;
+        },
+        $dir
+    );
+
+    @files = sort { lc($a) cmp lc($b) } @files;
+
+    die "Computed ID is for an empty directory, invalid source." unless @files;
+
+    my $ctx = Digest::SHA->new(1);
+    for my $rel (@files) {
+        my $full = "$dir/$rel";
+        if ( open my $fh, '<:raw', $full ) {
+            my $buf;
+            read $fh, $buf, 16384;
+            close $fh;
+            $ctx->add($buf) if defined $buf && length $buf;
+        }
+    }
+
+    return $ctx->hexdigest;
 }
 
 # Bust the current search cache key in Redis.
@@ -641,7 +690,24 @@ sub get_computed_tagrules {
 
 sub add_arcsize ( $redis, $id ) {
     my $file = get_archive_path( $redis, $id );
-    $redis->hset( $id, "arcsize", -s $file );
+    if ( -d $file ) {
+        $redis->hset( $id, "arcsize", _compute_dir_size($file) );
+    } else {
+        $redis->hset( $id, "arcsize", -s $file );
+    }
+}
+
+sub _compute_dir_size ($dir) {
+    my $total = 0;
+    find_path(
+        sub {
+            $_ = create_path($_);
+            return if -d $_;
+            $total += -s $_ if -f $_;
+        },
+        $dir
+    );
+    return $total;
 }
 
 sub get_arcsize ( $redis, $id ) {

--- a/lib/LANraragi/Utils/Generic.pm
+++ b/lib/LANraragi/Utils/Generic.pm
@@ -31,7 +31,7 @@ BEGIN {
 
 # Generic Utility Functions.
 use Exporter 'import';
-our @EXPORT_OK = qw(is_image is_archive render_api_response get_tag_with_namespace shasum_str start_shinobu
+our @EXPORT_OK = qw(is_image is_archive is_content_folder render_api_response get_tag_with_namespace shasum_str start_shinobu
   split_workload_by_cpu start_minion get_css_list generate_themes_header flat get_bytelength array_difference
   intersect_arrays filter_hash_by_keys exec_with_lock exec_with_lock_pure generate_css_detail get_version);
 
@@ -47,6 +47,51 @@ sub is_image {
 # Checks if the provided file is an archive.
 sub is_archive {
     return $_[0] =~ /^.+\.(?:zip|rar|7z|tar|tar\.gz|lzma|xz|cbz|cbr|cb7|cbt|pdf|epub|tar\.zst|zst)$/i;
+}
+
+# Checks if the provided path is a leaf content folder:
+# a directory that contains image files and has no subdirectories containing images.
+sub is_content_folder {
+    my $path = $_[0];
+    return 0 unless -d $path;
+
+    my $has_images = 0;
+    opendir( my $dh, $path ) or return 0;
+    while ( my $entry = readdir($dh) ) {
+        next if $entry eq '.' || $entry eq '..';
+        my $full = "$path/$entry";
+        if ( -d $full ) {
+            if ( _dir_has_images($full) ) {
+                closedir($dh);
+                return 0;
+            }
+        } elsif ( is_image($entry) ) {
+            $has_images = 1;
+        }
+    }
+    closedir($dh);
+    return $has_images;
+}
+
+# Checks if the provided directory contains any image files. Probably shouldn't go recursively, since for now only leaf directories with images are considered content folders.
+sub _dir_has_images {
+    my $dir = shift;
+    opendir( my $dh, $dir ) or return 0;
+    while ( my $entry = readdir($dh) ) {
+        next if $entry eq '.' || $entry eq '..';
+        my $full = "$dir/$entry";
+        if ( -d $full ) {
+            if ( _dir_has_images($full) ) {
+                closedir($dh);
+                return 1;
+            }
+        } elsif ( is_image($entry) ) {
+            closedir($dh);
+            return 1;
+        }
+    }
+    closedir($dh);
+    return 0;
 }
 
 # Renders the basic success API JSON template, where the $mojo object inherits the openapi controller.

--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -31,7 +31,7 @@ use Encode;
 use LANraragi::Utils::Archive    qw(extract_thumbnail);
 use LANraragi::Utils::Database   qw(invalidate_cache compute_id change_archive_id get_arcsize add_timestamp_tag add_archive_to_redis add_arcsize add_pagecount);
 use LANraragi::Utils::Logging    qw(get_logger);
-use LANraragi::Utils::Generic    qw(is_archive exec_with_lock_pure);
+use LANraragi::Utils::Generic    qw(is_archive is_image is_content_folder exec_with_lock_pure);
 use LANraragi::Utils::Redis      qw(redis_encode);
 use LANraragi::Utils::Path       qw(create_path open_path find_path get_archive_path);
 
@@ -80,12 +80,12 @@ sub initialize_from_new_process {
     update_filemap();
     $logger->info("Initial scan complete! Adding watcher to content folder to monitor for further file edits.");
 
-    # Add watcher to content directory
+    # Add watcher to content directory -- also watch image files for content folder detection
     my $contentwatcher = File::ChangeNotify->instantiate_watcher(
         directories     => [$userdir],
-        filter          => qr/\.(?:zip|rar|7z|tar|tar\.gz|lzma|xz|cbz|cbr|cb7|cbt|pdf|epub|tar\.zst|zst)$/i,
+        filter          => qr/\.(?:zip|rar|7z|tar|tar\.gz|lzma|xz|cbz|cbr|cb7|cbt|pdf|epub|tar\.zst|zst|png|jpg|gif|bmp|jpeg|jfif|webp|avif|heif|heic|jxl)$/i,
         follow_symlinks => 1,
-        exclude         => [ 'thumb', '.' ],                                                                   #excluded subdirs
+        exclude         => [ 'thumb', '.' ],
     );
 
     my $class = ref($contentwatcher);
@@ -121,7 +121,7 @@ sub initialize_from_new_process {
 }
 
 # Update the filemap. This acts as a masterlist of what's in the content directory.
-# This computes IDs for all new archives and henceforth can get rather expensive!
+# This computes IDs for all new archives/content folders and henceforth can get rather expensive!
 sub update_filemap {
 
     $logger->info("Scanning content folder for changes...");
@@ -130,17 +130,23 @@ sub update_filemap {
     # Clear hash
     my $dirname = LANraragi::Model::Config->get_userdir;
     my @files;
+    my @dirs;
 
     # Get all files in content directory and subdirectories.
     find_path(
         sub {
             $_ = create_path($_);
-            return if -d $_;    #Directories are excluded on the spot
+            if ( -d $_ ) {
+                push @dirs, $_ if is_content_folder($_);
+                return;
+            }
             return unless is_archive($_);
-            push @files, $_;    #Push files to array
+            push @files, $_;
         },
         $dirname
     );
+
+    push @files, @dirs;
 
     # Cross-check with filemap to get recorded files that aren't on the FS, and new files that aren't recorded.
     my @filemapfiles = $redis->exists("LRR_FILEMAP") ? $redis->hkeys("LRR_FILEMAP") : ();
@@ -183,39 +189,43 @@ sub update_filemap {
 sub add_to_filemap ( $redis_cfg, $file ) {
 
     my $redis_arc = LANraragi::Model::Config->get_redis;
-    if ( is_archive($file) ) {
+    my $is_dir    = -d $file;
+
+    if ( is_archive($file) || $is_dir ) {
 
         $logger->debug("Adding $file to Shinobu filemap.");
 
-        #Freshly created files might not be complete yet.
-        #We have to wait before doing any form of calculation.
-        while (1) {
-            last unless -e $file;    # Sanity check to avoid sticking in this loop if the file disappears
-            last if open_path( my $handle, '<', $file );
-            $logger->debug("Waiting for file to be openable");
-            sleep(1);
+        unless ($is_dir) {
+            #Freshly created files might not be complete yet.
+            #We have to wait before doing any form of calculation.
+            while (1) {
+                last unless -e $file;    # Sanity check to avoid sticking in this loop if the file disappears
+                last if open_path( my $handle, '<', $file );
+                $logger->debug("Waiting for file to be openable");
+                sleep(1);
+            }
+
+            # Wait for file to be more than 512 KBs or bailout after 5s and assume that file is smaller
+            my $cnt = 0;
+            while (1) {
+                last if ( ( ( -s $file ) >= 512000 ) || $cnt >= 5 );
+                $logger->debug("Waiting for file to be fully written");
+                sleep(1);
+                $cnt++;
+            }
         }
 
-        # Wait for file to be more than 512 KBs or bailout after 5s and assume that file is smaller
-        my $cnt = 0;
-        while (1) {
-            last if ( ( ( -s $file ) >= 512000 ) || $cnt >= 5 );
-            $logger->debug("Waiting for file to be fully written");
-            sleep(1);
-            $cnt++;
-        }
-
-        #Compute the ID of the archive and add it to the hash
+        #Compute the ID of the archive/folder and add it to the hash
         my $id = "";
         eval { $id = compute_id($file); };
         my $compute_error = $@;
 
         if ($compute_error && -e $file) {
-            $logger->error("Couldn't open $file for ID computation: $compute_error");
+            $logger->error("Couldn't compute ID for $file: $compute_error");
             $logger->error("Giving up on adding it to the filemap.");
             return;
         } elsif ($compute_error) {
-            $logger->warn("File $file no longer exists; giving up on adding it to the filemap.");
+            $logger->warn("$file no longer exists; giving up on adding it to the filemap.");
             return;
         }
 
@@ -227,7 +237,7 @@ sub add_to_filemap ( $redis_cfg, $file ) {
         );
 
         if ( !$acquired ) {
-            $logger->warn("Write lock already acquired for archive $file with ID $id, skipping.");
+            $logger->warn("Write lock already acquired for $file with ID $id, skipping.");
         }
 
         # New file handling runs outside the lock so auto-plugin can acquire its own lock.
@@ -237,7 +247,7 @@ sub add_to_filemap ( $redis_cfg, $file ) {
         }
 
     } else {
-        $logger->debug("$file not recognized as archive, skipping.");
+        $logger->debug("$file not recognized as archive or content folder, skipping.");
     }
     $redis_arc->quit;
 }
@@ -289,7 +299,12 @@ sub update_filemap_entry ( $logger, $id, $file, $redis_cfg, $redis_arc ) {
             $logger->debug("File name discrepancy detected between DB and filesystem!");
             $logger->debug("Filesystem: $file");
             $logger->debug("Database: $filecheck");
-            my ( $name, $path, $suffix ) = fileparse( $file, qr/\.[^.]*/ );
+            my $name;
+            if ( -d $file ) {
+                $name = File::Basename::basename($file);
+            } else {
+                ( $name, undef, undef ) = fileparse( $file, qr/\.[^.]*/ );
+            }
             $redis_arc->hset( $id, "file", $file );
             $redis_arc->hset( $id, "name", redis_encode($name) );
             $redis_arc->wait_all_responses;
@@ -321,16 +336,30 @@ sub update_filemap_entry ( $logger, $id, $file, $redis_cfg, $redis_arc ) {
 sub new_file_callback ($name) {
 
     $logger->debug("New file detected: $name");
-    unless ( -d $name ) {
 
-        my $redis = LANraragi::Model::Config->get_redis_config;
+    if ( -d $name ) {
+        return;
+    }
+
+    my $redis = LANraragi::Model::Config->get_redis_config;
+
+    if ( is_archive($name) ) {
         eval { add_to_filemap( $redis, $name ); };
-        $redis->quit();
-
         if ($@) {
-            $logger->error("Error while handling new file: $@");
+            $logger->error("Error while handling new archive: $@");
+        }
+    } elsif ( is_image($name) ) {
+        my $parent = File::Basename::dirname($name);
+        if ( is_content_folder($parent) ) {
+            $logger->debug("Image added to content folder $parent, processing folder.");
+            eval { add_to_filemap( $redis, $parent ); };
+            if ($@) {
+                $logger->error("Error while handling content folder: $@");
+            }
         }
     }
+
+    $redis->quit();
 }
 
 # Deleted files are simply dropped from the filemap.
@@ -338,17 +367,15 @@ sub new_file_callback ($name) {
 sub deleted_file_callback ($name) {
 
     $logger->info("$name was deleted from the content folder!");
-    unless ( -d $name ) {
 
-        my $redis = LANraragi::Model::Config->get_redis_config;
+    my $redis = LANraragi::Model::Config->get_redis_config;
 
-        # Prune file from filemap
-        $redis->hdel( "LRR_FILEMAP", $name );
+    # Prune the path from filemap (works for both files and directories)
+    $redis->hdel( "LRR_FILEMAP", $name );
 
-        eval { invalidate_cache(); };
+    eval { invalidate_cache(); };
 
-        $redis->quit();
-    }
+    $redis->quit();
 }
 
 sub add_new_files (@files) {

--- a/tests/folder_support.t
+++ b/tests/folder_support.t
@@ -1,0 +1,110 @@
+use strict;
+use warnings;
+use utf8;
+use Cwd;
+
+use Test::More;
+use File::Path qw(make_path remove_tree);
+use File::Temp qw(tempdir);
+
+my $cwd = getcwd;
+require $cwd . "/tests/mocks.pl";
+setup_redis_mock();
+
+use_ok('LANraragi::Utils::Generic');
+use_ok('LANraragi::Utils::Database');
+use_ok('LANraragi::Utils::Archive');
+
+# Create a temporary directory structure for testing
+my $tmpdir = tempdir( CLEANUP => 1 );
+
+# Structure:
+#   leaf_with_images/       -> CONTENT (leaf, has images)
+#     page1.jpg
+#     page2.png
+#   series/                 -> NOT content (has subdirs with images)
+#     chapter1/             -> CONTENT (leaf, has images)
+#       page1.jpg
+#     chapter2/             -> CONTENT (leaf, has images)
+#       page1.jpg
+#   empty_folder/           -> NOT content (no images)
+#   leaf_no_images/         -> NOT content (files but no images)
+#     readme.txt
+
+make_path("$tmpdir/leaf_with_images");
+make_path("$tmpdir/series/chapter1");
+make_path("$tmpdir/series/chapter2");
+make_path("$tmpdir/empty_folder");
+make_path("$tmpdir/leaf_no_images");
+
+# Create dummy image files (just need to exist with correct extensions)
+for my $f ("$tmpdir/leaf_with_images/page1.jpg", "$tmpdir/leaf_with_images/page2.png",
+           "$tmpdir/series/chapter1/page1.jpg",
+           "$tmpdir/series/chapter2/page1.jpg") {
+    open my $fh, '>', $f or die "Cannot create $f: $!";
+    print $fh "fake image data for $f\n";
+    close $fh;
+}
+
+open my $fh, '>', "$tmpdir/leaf_no_images/readme.txt" or die $!;
+print $fh "not an image";
+close $fh;
+
+# Test is_content_folder
+subtest 'is_content_folder' => sub {
+    ok( LANraragi::Utils::Generic::is_content_folder("$tmpdir/leaf_with_images"),
+        "leaf_with_images is a content folder" );
+
+    ok( !LANraragi::Utils::Generic::is_content_folder("$tmpdir/series"),
+        "series is NOT a content folder (has subdirs with images)" );
+
+    ok( LANraragi::Utils::Generic::is_content_folder("$tmpdir/series/chapter1"),
+        "chapter1 is a content folder" );
+
+    ok( LANraragi::Utils::Generic::is_content_folder("$tmpdir/series/chapter2"),
+        "chapter2 is a content folder" );
+
+    ok( !LANraragi::Utils::Generic::is_content_folder("$tmpdir/empty_folder"),
+        "empty_folder is NOT a content folder" );
+
+    ok( !LANraragi::Utils::Generic::is_content_folder("$tmpdir/leaf_no_images"),
+        "leaf_no_images is NOT a content folder (no images)" );
+
+    ok( !LANraragi::Utils::Generic::is_content_folder("$tmpdir/nonexistent"),
+        "nonexistent path is NOT a content folder" );
+};
+
+# Test compute_id for directories
+subtest 'compute_id for directory' => sub {
+    my $id = LANraragi::Utils::Database::compute_id("$tmpdir/leaf_with_images");
+    ok( defined $id && length($id) == 40, "compute_id returns a 40-char hex digest for a directory" );
+
+    my $id2 = LANraragi::Utils::Database::compute_id("$tmpdir/leaf_with_images");
+    is( $id, $id2, "compute_id is deterministic for the same directory" );
+
+    my $id3 = LANraragi::Utils::Database::compute_id("$tmpdir/series/chapter1");
+    isnt( $id, $id3, "different directories produce different IDs" );
+};
+
+# Test get_filelist for directories
+subtest 'get_filelist for directory' => sub {
+    my @files = LANraragi::Utils::Archive::get_filelist("$tmpdir/leaf_with_images", "test");
+    is( scalar @files, 2, "leaf_with_images contains 2 image files" );
+
+    my @ch1_files = LANraragi::Utils::Archive::get_filelist("$tmpdir/series/chapter1", "test");
+    is( scalar @ch1_files, 1, "chapter1 contains 1 image file" );
+
+    # Filenames should be relative paths
+    for my $f (@files) {
+        ok( $f !~ /^\Q$tmpdir\E/, "File path '$f' is relative, not absolute" );
+    }
+};
+
+# Test extract_single_file for directories
+subtest 'extract_single_file for directory' => sub {
+    my @files = LANraragi::Utils::Archive::get_filelist("$tmpdir/leaf_with_images", "test");
+    my $content = LANraragi::Utils::Archive::extract_single_file("$tmpdir/leaf_with_images", $files[0]);
+    ok( defined $content && length($content) > 0, "extract_single_file returns content from directory" );
+};
+
+done_testing();


### PR DESCRIPTION
Treat leaf directories containing image files as first-class content items alongside compressed archives. A folder qualifies as content when it has images and no subdirectories that themselves contain images.

Changes:
- Utils/Generic: add is_content_folder() leaf-directory predicate, returns true for leaf directories containing images with no image-containing subdirectories
- Utils/Archive: add directory branches
- Utils/Database: directory-aware compute_id as SHA-1 of concat first 16KB per file in sorted order
- Shinobu: discover content folders during scan, watch for image file events to trigger folder detection, handle folder deletion
- Model/Archive: serve directory pages directly from disk
- Controller/Api/Archive: for now, block download for folder-based content, could try client-side download all then zip, or just server-side compression, leave for future developement
- tests/folder_support.t: I've no idea how to write tests with perl, purely ChatGPT's take