### PR TITLE
RotatingLog probe check and lock directory configuration

### DIFF
--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -89,7 +89,7 @@ sub get_logger {
                         path    => $logpath,
                         level   => 'info',
                         logfile => $logfile,
-                        tempdir => $tempdir
+                        lockdir => $tempdir
                     );
                 };
                 $retry_error = $@;

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -72,8 +72,8 @@ sub get_logger {
         undef $log;
     }
 
-    my $tempdir         = get_temp();
-    my $rlog_supported  = LANraragi::Utils::RotatingLog::is_supported($tempdir);
+    my $lockdir         = $ENV{LRR_LOG_LOCK_DIRECTORY} // get_temp();
+    my $rlog_supported  = LANraragi::Utils::RotatingLog::is_supported($lockdir);
 
     my $tries           = 0;
     my $first_error;
@@ -89,7 +89,7 @@ sub get_logger {
                         path    => $logpath,
                         level   => 'info',
                         logfile => $logfile,
-                        lockdir => $tempdir
+                        lockdir => $lockdir
                     );
                 };
                 $retry_error = $@;
@@ -119,7 +119,7 @@ sub get_logger {
         if ( !$rlog_supported ) {
             $LOGGER_CACHE{$cache_key} = $log;
             unless ( $RLOG_UNSUPPORTED_WARNED ) {
-                $log->warn("RotatingLog not supported on $tempdir; using Mojo::Log without log rotation.");
+                $log->warn("RotatingLog not supported on $lockdir; using Mojo::Log without log rotation.");
                 $RLOG_UNSUPPORTED_WARNED = 1;
             }
         } else {

--- a/lib/LANraragi/Utils/Logging.pm
+++ b/lib/LANraragi/Utils/Logging.pm
@@ -28,6 +28,7 @@ use Exporter 'import';
 our @EXPORT_OK = qw(get_logger get_plugin_logger get_logdir get_lines_from_file);
 
 our %LOGGER_CACHE;
+our $RLOG_UNSUPPORTED_WARNED = 0;
 
 # Get the Log folder.
 sub get_logdir {
@@ -71,45 +72,59 @@ sub get_logger {
         undef $log;
     }
 
-    # Create and cache logger with retry + backoff + jitter
-    # Report the first logger init failure if exists
-    my $tries = 0;
+    my $tempdir         = get_temp();
+    my $rlog_supported  = LANraragi::Utils::RotatingLog::is_supported($tempdir);
+
+    my $tries           = 0;
     my $first_error;
-    while ( $tries < 3 ) {
-        my $retry_error;
-        {
-            local $@;
-            eval {
-                $log = LANraragi::Utils::RotatingLog->new(
-                    path    => $logpath,
-                    level   => 'info',
-                    logfile => $logfile,
-                    tempdir => get_temp()
-                );
-            };
-            $retry_error = $@;
+    if ( $rlog_supported ) {
+        # Create and cache RotatingLog with retry + backoff + jitter
+        # Report the first logger init failure if exists
+        while ( $tries < 3 ) {
+            my $retry_error;
+            {
+                local $@;
+                eval {
+                    $log = LANraragi::Utils::RotatingLog->new(
+                        path    => $logpath,
+                        level   => 'info',
+                        logfile => $logfile,
+                        tempdir => $tempdir
+                    );
+                };
+                $retry_error = $@;
+            }
+
+            unless ( $retry_error ) {
+                configure_logger( $log );
+                $LOGGER_CACHE{$cache_key} = $log;
+                last;
+            }
+
+            $first_error //= $retry_error;
+            Time::HiRes::sleep(rand());
+            $tries++;
+
         }
-
-        unless ( $retry_error ) {
-            configure_logger( $log );
-            $LOGGER_CACHE{$cache_key} = $log;
-            last;
-        }
-
-        $first_error //= $retry_error;
-        Time::HiRes::sleep(rand());
-        $tries++;
-
     }
 
-    # Fall back to Mojo::Log if retry doesn't work
+    # Fall back to Mojo::Log if RotatingLog isn't supported or failed to initialize
     if ( !$log ) {
         $log = Mojo::Log->new(
             path    => $logpath,
             level   => 'info'
         );
         configure_logger( $log );
-        $log->error("RotatingLog init failed, falling back to Mojo::Log. First error: $first_error");
+
+        if ( !$rlog_supported ) {
+            $LOGGER_CACHE{$cache_key} = $log;
+            unless ( $RLOG_UNSUPPORTED_WARNED ) {
+                $log->warn("RotatingLog not supported on $tempdir; using Mojo::Log without log rotation.");
+                $RLOG_UNSUPPORTED_WARNED = 1;
+            }
+        } else {
+            $log->error("RotatingLog init failed, falling back to Mojo::Log. First error: $first_error");
+        }
     } elsif ( $tries > 0 ) {
         $log->warn("RotatingLog initialized after $tries failures. First error: $first_error");
     }

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -317,10 +317,13 @@ sub get_win32_fh {
 
 # Check whether filesystem supports flock.
 # https://github.com/Difegue/LANraragi/issues/1556
+our $SUPPORTED;
 sub is_supported {
-    my $tempdir     = shift;
+    return $SUPPORTED if defined $SUPPORTED;
+
+    my $lockdir     = shift;
     my $supported   = 0;
-    my $probe_path  = "$tempdir/.lrr-flock-probe.$$";
+    my $probe_path  = "$lockdir/.lrr-flock-probe.$$";
 
     # do a flock hit
     if ( open( my $fh, '>', $probe_path ) ) {
@@ -329,7 +332,8 @@ sub is_supported {
         unlink $probe_path;
     }
 
-    return $supported;
+    $SUPPORTED = $supported;
+    return $SUPPORTED;
 }
 
 1;

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -315,4 +315,21 @@ sub get_win32_fh {
     return *FH;
 }
 
+# Check whether filesystem supports flock.
+# https://github.com/Difegue/LANraragi/issues/1556
+sub is_supported {
+    my $tempdir     = shift;
+    my $supported   = 0;
+    my $probe_path  = "$tempdir/.lrr-flock-probe.$$";
+
+    # do a flock hit
+    if ( open( my $fh, '>', $probe_path ) ) {
+        $supported = flock( $fh, LOCK_EX | LOCK_NB ) ? 1 : 0;
+        close $fh;
+        unlink $probe_path;
+    }
+
+    return $supported;
+}
+
 1;

--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -20,7 +20,7 @@ BEGIN {
 }
 
 has 'logfile';
-has 'tempdir';  # Where to store lockfiles
+has 'lockdir';  # Where to store lockfiles
 has 'lockpid';  # Track which PID opened the current lock file handle.
 
 has counter => sub { 0 }; # number of logs emitted
@@ -45,7 +45,7 @@ has lockpath => sub {
     my $path        = $self->path;
     my $mf          = Mojo::File->new($path);
     my $base        = $mf->basename;
-    my $lockpath    = $self->tempdir . "/$base.lock";
+    my $lockpath    = $self->lockdir . "/$base.lock";
     return $lockpath;
 };
 


### PR DESCRIPTION
Issue: https://github.com/Difegue/LANraragi/issues/1556

Add a flock probe check at the start of `get_logger`. If probe fails, fallback to mojo log. Probe check is cached per-process.

Also add suggested `LRR_LOG_LOCK_DIRECTORY` configuration.