### PR TITLE
Degrade gracefully when flock is unavailable on NFS-backed log volumes

### DIFF
--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use utf8;
 
+use Errno qw(EBADF ENOLCK);
 use Fcntl qw(:flock O_CREAT O_RDWR);
 use Compress::Zlib;
 use Config;
@@ -25,6 +26,8 @@ has 'lockpid';  # Track which PID opened the current lock file handle.
 
 has counter => sub { 0 }; # number of logs emitted
 
+has flock_disabled => sub { 0 };  # set true on first EBADF/ENOLCK; disables locking and rotation for this process
+
 # max number of archived logfiles to retain for log rotation (defaults to 7 files).
 has retention_count => sub {
     my $count = 0 + ($ENV{LRR_LOGROTATE_FILES} // 7);
@@ -39,13 +42,14 @@ has max_rotation_size => sub {
     return $size;
 };
 
-# Logfile lock path
+# LRR_LOG_LOCK_DIRECTORY relocates the lockfile off NFS volumes where flock() is unreliable.
 has lockpath => sub {
     my $self        = shift;
     my $path        = $self->path;
     my $mf          = Mojo::File->new($path);
     my $base        = $mf->basename;
-    my $lockpath    = $self->tempdir . "/$base.lock";
+    my $lockdir     = $ENV{LRR_LOG_LOCK_DIRECTORY} || $self->tempdir;
+    my $lockpath    = "$lockdir/$base.lock";
     return $lockpath;
 };
 
@@ -85,12 +89,21 @@ sub append {
 
     $self->counter( $self->counter+1 );
 
+    # flock unavailable; still refresh inode in case another host rotated the file.
+    if ( $self->flock_disabled ) {
+        eval { refresh_logger_handle($self) };
+        return $self->SUPER::append($msg);
+    }
+
     ensure_lock($self);
     my $path   = $self->path;
     my $lockfh = $self->lockfh;
 
     # Acquire shared lock to serialize with rotation EX lock.
-    flock( $lockfh, LOCK_SH ) or die "Failed to acquire shared log lock: $!";
+    unless ( $self->_try_flock( $lockfh, LOCK_SH ) ) {
+        die "Failed to acquire shared log lock: $!" unless $self->flock_disabled;
+        return $self->SUPER::append($msg);
+    }
 
     my $ret;
     eval {
@@ -126,7 +139,7 @@ sub new {
     # handle logpath existence cases.
     # case 1 (logfile DNE):     create new logfile under exclusive lock
     # case 2 (logfile exist):   no action needed, just get the logfile handle
-    if ( !-e $path && flock( $lockfh, LOCK_EX | LOCK_NB ) ) {
+    if ( !-e $path && $self->_try_flock( $lockfh, LOCK_EX | LOCK_NB ) ) {
         my $logfile_create_error;
         eval {
             # Re-check inside lock in case another process created the file
@@ -156,17 +169,21 @@ sub maybe_rotate {
     my $path    = $self->path;
     my $lockfh  = $self->lockfh;
 
+    return if $self->flock_disabled;
+
     ensure_lock($self);
     # Try to acquire a file lock between two rotation condition checks.
     if ( should_rotate($self, $path) ) {
-        # unlock-then-lock to upgrade from shared to exclusive lock; 
+        # unlock-then-lock to upgrade from shared to exclusive lock;
         # "Converting a lock (shared to exclusive, or vice versa) is not guaranteed to be atomic"
         # - https://man7.org/linux/man-pages/man2/flock.2.html
         flock( $lockfh, LOCK_UN );
-        if ( !flock( $lockfh, LOCK_EX | LOCK_NB ) ) {
-            # Another process is rotating, skip rotation attempt
-            # Re-acquire shared lock and continue
-            flock( $lockfh, LOCK_SH ) or die "Failed to re-acquire shared log lock (1): $!";
+        unless ( $self->_try_flock( $lockfh, LOCK_EX | LOCK_NB ) ) {
+            # another process is rotating, or lock backend degraded
+            return if $self->flock_disabled;
+            unless ( $self->_try_flock( $lockfh, LOCK_SH ) ) {
+                die "Failed to re-acquire shared log lock (1): $!" unless $self->flock_disabled;
+            }
             return;
         }
 
@@ -189,10 +206,14 @@ sub maybe_rotate {
         # Downgrade back to SH for the write
         flock( $lockfh, LOCK_UN );
         if ( $rotation_error ) {
-            flock( $lockfh, LOCK_SH ) or die "Failed to re-acquire shared log lock (2): $!";
+            unless ( $self->_try_flock( $lockfh, LOCK_SH ) ) {
+                die "Failed to re-acquire shared log lock (2): $!" unless $self->flock_disabled;
+            }
             die $rotation_error;
         }
-        flock( $lockfh, LOCK_SH ) or die "Failed to re-acquire shared log lock (3): $!";
+        unless ( $self->_try_flock( $lockfh, LOCK_SH ) ) {
+            die "Failed to re-acquire shared log lock (3): $!" unless $self->flock_disabled;
+        }
     }
 }
 
@@ -247,6 +268,7 @@ sub refresh_logger_handle {
         if ( !defined $cached_inode || !defined $path_inode || $cached_inode != $path_inode ) {
             close($logger->handle) if defined $logger->{handle};
             open( my $fh, '>>', $path ) or die "Could not open logfile '$path': $!";
+            $fh->autoflush(1);  # prevent losing the last buffer of log lines on SIGKILL/OOMKill
             $logger->handle($fh);
         }
     } else {
@@ -254,6 +276,29 @@ sub refresh_logger_handle {
         eval { close $logger->handle } if defined $logger->{handle};
         $logger->handle($fh);
     }
+}
+
+# flock() returns EBADF/ENOLCK on NFS without a lock manager; treat as permanent and degrade.
+sub _try_flock {
+    my ($self, $fh, $op) = @_;
+    return 1 if flock($fh, $op);
+
+    my $errno = $! + 0;
+    if ( ($errno == EBADF || $errno == ENOLCK) && !$self->flock_disabled ) {
+        my $errstr = "$!";
+        # set before warn() to prevent recursive re-entry via append()
+        $self->flock_disabled(1);
+        $self->warn(
+            "RotatingLog: log rotation locking is unavailable on "
+            . $self->lockpath
+            . " (errno $errno: $errstr). "
+            . "Logs will continue to be written, but rotation is disabled in this process. "
+            . "Set LRR_LOG_LOCK_DIRECTORY to a local-filesystem path (e.g. /tmp), "
+            . "or mount the log volume with the NFS local_lock=flock option, "
+            . "to restore log rotation."
+        );
+    }
+    return 0;
 }
 
 # Ensure each process owns its lock file handle after a fork.
@@ -288,6 +333,7 @@ sub get_handle {
     # Fallback with default UTF-8 handle.
     $fh = Mojo::File->new($path)->open('>>');
     $fh->binmode(':encoding(UTF-8)');
+    $fh->autoflush(1);  # prevent losing the last buffer of log lines on SIGKILL/OOMKill
     return $fh;
 }
 
@@ -312,6 +358,7 @@ sub get_win32_fh {
 
     Win32API::File::OsFHandleOpen( *FH, $h, "w" ) or die "OsFHandleOpen failed for $sPath; $!";
     binmode *FH, ':encoding(UTF-8)';
+    *FH->autoflush(1);  # prevent losing the last buffer of log lines on SIGKILL/OOMKill
     return *FH;
 }
 

--- a/tests/LANraragi/Utils/RotatingLog.t
+++ b/tests/LANraragi/Utils/RotatingLog.t
@@ -1,0 +1,270 @@
+use strict;
+use warnings;
+use utf8;
+
+# Override flock() before loading RotatingLog — Test::MockModule can't redefine builtins.
+# $mock_flock_behavior: coderef ($fh, $op) -> (ok, errno); undef = real flock.
+our $mock_flock_behavior;
+
+BEGIN {
+    *CORE::GLOBAL::flock = sub {
+        my ( $fh, $op ) = @_;
+        if ( defined $mock_flock_behavior ) {
+            my ( $ok, $errno ) = $mock_flock_behavior->( $fh, $op );
+            $! = $errno if defined $errno;
+            return $ok ? 1 : 0;
+        }
+        return CORE::flock( $fh, $op );
+    };
+}
+
+use Test::More;
+use File::Temp qw(tempdir);
+use File::Spec;
+use Errno qw(EBADF ENOLCK);
+use Fcntl qw(:flock);
+
+BEGIN { use_ok('LANraragi::Utils::RotatingLog'); }
+
+sub with_suppressed_stdout {
+    my ($code) = @_;
+    local *STDOUT;
+    open STDOUT, '>', '/dev/null';
+    $code->();
+}
+
+sub fresh_logger {
+    my $dir     = tempdir( CLEANUP => 1 );
+    my $logpath = File::Spec->catfile( $dir, 'lanraragi.log' );
+
+    local $mock_flock_behavior = undef;
+    my $log = LANraragi::Utils::RotatingLog->new(
+        path    => $logpath,
+        level   => 'debug',
+        logfile => 'lanraragi',
+        tempdir => $dir,
+    );
+    return ( $log, $logpath, $dir );
+}
+
+sub capture_log_messages {
+    my ($log) = @_;
+    my @messages;
+    $log->on(
+        message => sub {
+            my ( $self, $level, @lines ) = @_;
+            push @messages, { level => $level, lines => [@lines] };
+        }
+    );
+    return \@messages;
+}
+
+sub slurp_log {
+    my ( $log, $path ) = @_;
+    # flush before reading — writes may still be in PerlIO buffer
+    if ( defined $log ) {
+        my $h = $log->handle;
+        $h->flush if $h && $h->can('flush');
+    }
+    return '' unless -e $path;
+    open my $fh, '<:encoding(UTF-8)', $path or die "open $path: $!";
+    local $/;
+    my $content = <$fh>;
+    close $fh;
+    return $content;
+}
+
+# --- append survives EBADF: degrades to unlocked mode, logs kept, one warn ---
+note('testing append survives flock EBADF (NFS without lockd)...');
+{
+    my ( $log, $logpath ) = fresh_logger();
+    my $messages = capture_log_messages($log);
+
+    # LOCK_UN stays working — production speculatively unlocks even after a failed lock.
+    local $mock_flock_behavior = sub {
+        my ( $fh, $op ) = @_;
+        return ( 1, undef ) if ( $op & LOCK_UN );
+        return ( 0, EBADF );
+    };
+
+    my $appended;
+    eval {
+        with_suppressed_stdout( sub {
+            $log->info("hello-1");
+            $log->info("hello-2");
+            $log->info("hello-3");
+        } );
+        $appended = 1;
+    };
+    my $err = $@;
+
+    ok( $appended, 'three info() calls completed without dying' )
+      or diag("die was: $err");
+
+    my $content = slurp_log( $log, $logpath );
+    like( $content, qr/hello-1/, 'first line written to logfile' );
+    like( $content, qr/hello-2/, 'second line written to logfile' );
+    like( $content, qr/hello-3/, 'third line written to logfile' );
+
+    my @warns = grep { $_->{level} eq 'warn' } @$messages;
+    is( scalar @warns, 1, 'exactly one warn emitted across multiple appends' );
+
+    if ( $log->can('flock_disabled') ) {
+        ok( $log->flock_disabled, 'flock_disabled flipped to truthy' );
+    }
+}
+
+# --- same as above but ENOLCK (newer kernels' errno for missing lock manager) ---
+note('testing append survives flock ENOLCK...');
+{
+    my ( $log, $logpath ) = fresh_logger();
+    my $messages = capture_log_messages($log);
+
+    local $mock_flock_behavior = sub {
+        my ( $fh, $op ) = @_;
+        return ( 1, undef ) if ( $op & LOCK_UN );
+        return ( 0, ENOLCK );
+    };
+
+    my $appended;
+    eval {
+        with_suppressed_stdout( sub {
+            $log->info("nolock-1");
+            $log->info("nolock-2");
+        } );
+        $appended = 1;
+    };
+    my $err = $@;
+
+    ok( $appended, 'appends completed without dying on ENOLCK' )
+      or diag("die was: $err");
+
+    my $content = slurp_log( $log, $logpath );
+    like( $content, qr/nolock-1/, 'first line written' );
+    like( $content, qr/nolock-2/, 'second line written' );
+
+    my @warns = grep { $_->{level} eq 'warn' } @$messages;
+    is( scalar @warns, 1, 'exactly one warn emitted on ENOLCK' );
+}
+
+# --- lockpath + logpath both on NFS: 5 appends survive, one warn total ---
+note('testing lockpath + logpath both on simulated NFS...');
+{
+    my ( $log, $logpath, $dir ) = fresh_logger();
+    my $messages = capture_log_messages($log);
+
+    is( $log->tempdir, $dir, 'tempdir matches' );
+    like( $log->lockpath, qr/\Q$dir\E/, 'lockpath under tempdir' );
+
+    local $mock_flock_behavior = sub {
+        my ( $fh, $op ) = @_;
+        return ( 1, undef ) if ( $op & LOCK_UN );
+        return ( 0, EBADF );
+    };
+
+    my $err;
+    with_suppressed_stdout( sub {
+        for my $i ( 1 .. 5 ) {
+            eval { $log->info("nfs-line-$i"); 1 } or do { $err //= $@; };
+        }
+    } );
+    ok( !$err, '5 sequential appends all survived' )
+      or diag("first die was: $err");
+
+    my $content = slurp_log( $log, $logpath );
+    for my $i ( 1 .. 5 ) {
+        like( $content, qr/nfs-line-$i/, "line $i present in logfile" );
+    }
+
+    my @warns = grep { $_->{level} eq 'warn' } @$messages;
+    is( scalar @warns, 1, 'one warn for the whole 5-append sequence' );
+}
+
+# --- LRR_LOG_LOCK_DIRECTORY: lockfile lands on local FS, logfile stays on NFS volume ---
+note('testing LRR_LOG_LOCK_DIRECTORY relocates lockfile, logfile unaffected...');
+{
+    my $logdir  = tempdir( CLEANUP => 1 );
+    my $lockdir = tempdir( CLEANUP => 1 );
+    my $logpath = File::Spec->catfile( $logdir, 'lanraragi.log' );
+
+    # set before construction — lockpath is lazy, read on first access inside new()
+    local $ENV{LRR_LOG_LOCK_DIRECTORY} = $lockdir;
+    local $mock_flock_behavior = undef;
+
+    my $log = LANraragi::Utils::RotatingLog->new(
+        path    => $logpath,
+        level   => 'debug',
+        logfile => 'lanraragi',
+        tempdir => $logdir,
+    );
+
+    like( $log->lockpath, qr{^\Q$lockdir\E/}, 'lockpath under LRR_LOG_LOCK_DIRECTORY' );
+    unlike( $log->lockpath, qr{^\Q$logdir\E/}, 'lockpath NOT under tempdir' );
+    ok( -e $log->lockpath, 'lockfile created at relocated path' );
+
+    ok( flock( $log->lockfh, LOCK_EX | LOCK_NB ),
+        'real flock LOCK_EX succeeds on relocated lockfile' )
+      or diag("flock errno: $!");
+    ok( flock( $log->lockfh, LOCK_UN ),
+        'LOCK_UN succeeds' );
+
+    my $survived;
+    with_suppressed_stdout( sub {
+        eval { $log->info("t5-line"); $survived = 1 };
+    } );
+    ok( $survived, 'info() succeeds with normal flock + relocated lockpath' );
+
+    my $content = slurp_log( $log, $logpath );
+    like( $content, qr/t5-line/, 'log line lands in logfile under tempdir' );
+}
+
+# --- end-to-end via get_logger: skipped if full dep stack not loadable ---
+note('testing get_logger end-to-end with simulated NFS + flock failure...');
+SKIP: {
+    my $require_err;
+    {
+        local $@;
+        eval { require LANraragi::Utils::Logging; 1 } or $require_err = $@;
+    }
+    skip "LANraragi::Utils::Logging not loadable: $require_err", 3 if $require_err;
+
+    my $tmpdir = tempdir( CLEANUP => 1 );
+    local $ENV{LRR_LOG_DIRECTORY}  = $tmpdir;
+    local $ENV{LRR_TEMP_DIRECTORY} = $tmpdir;
+    local $ENV{LRR_FORCE_DEBUG}    = 1;
+    local %LANraragi::Utils::Logging::LOGGER_CACHE;
+    %LANraragi::Utils::Logging::LOGGER_CACHE = ();
+
+    # LOCK_UN stays working — production speculatively unlocks even after a failed lock.
+    local $mock_flock_behavior = sub {
+        my ( $fh, $op ) = @_;
+        return ( 1, undef ) if ( $op & LOCK_UN );
+        return ( 0, EBADF );
+    };
+
+    my $log;
+    my $get_err;
+    with_suppressed_stdout( sub {
+        eval {
+            $log = LANraragi::Utils::Logging::get_logger( 'test-t11', 'lanraragi' );
+            1;
+        } or do { $get_err = $@ };
+    } );
+    ok( !$get_err, 'get_logger did not die under flock-EBADF' )
+      or diag("get_logger die was: $get_err");
+    ok( defined $log, 'get_logger returned a logger' );
+
+    my $survived;
+    my $err;
+    with_suppressed_stdout( sub {
+        eval {
+            $log->info("hello-from-t11");
+            $survived = 1;
+        };
+        $err = $@;
+    } );
+    ok( $survived, 'info() did not die under flock-EBADF' )
+      or diag("info die was: $err");
+}
+
+done_testing();


### PR DESCRIPTION
Fixes #1556

Since #1406, `RotatingLog` dies on every `append()` when the log volume is NFS without a working lock manager (`EBADF`/`ENOLCK` from `flock(2)`), crashing Mojolicious workers on every log write.

**Changes:**
- `_try_flock()`: wraps all `flock()` calls; on first `EBADF`/`ENOLCK`, sets a sticky `flock_disabled` flag, emits one `warn()` with remediation hints, and falls back to best-effort unlocked logging for that process
- `LRR_LOG_LOCK_DIRECTORY`: env var to relocate the `.lock` file to a local path when the log volume is NFS
- `autoflush(1)` on all handle-creation paths to avoid losing log lines on SIGKILL/OOMKill

Tests in `tests/LANraragi/Utils/RotatingLog.t`.

This is the alternative approach to #1559 — detection at the point of first `flock()` failure rather than a startup probe, which also handles the case where flock degrades mid-process. Happy to consolidate if you prefer one approach.