### PR TITLE
Fix OpenAPI validation bypass

### DIFF
--- a/tools/build/all/perl-JSON-Validator.patch
+++ b/tools/build/all/perl-JSON-Validator.patch
@@ -1,9 +1,9 @@
 https://github.com/jhthorsen/json-validator/pull/289
 diff --git a/lib/JSON/Validator/Schema/OpenAPIv3.pm b/lib/JSON/Validator/Schema/OpenAPIv3.pm
-index 7325eb7..493d804 100644
+index 7325eb7..1ca92fb 100644
 --- a/lib/JSON/Validator/Schema/OpenAPIv3.pm
 +++ b/lib/JSON/Validator/Schema/OpenAPIv3.pm
-@@ -279,22 +279,33 @@ sub _validate_body {
+@@ -279,22 +279,35 @@ sub _validate_body {
      $val->{valid}        = $val->{content_type} ? 1 : 0;
      return E "/header/Accept", [join(', ', @{$param->{accepts}}), type => $val->{accept}] unless $val->{valid};
    }
@@ -29,6 +29,8 @@ index 7325eb7..493d804 100644
 +    # Mutate request content-type if one was not set
 +    $val->{content_type} //= $negotiated_content_type;
 +
++    return if $val->{content_type} =~ m!^multipart/form-data!;
++
      local $self->{coerce}{arrays} = 1
 -      if $val->{content_type} =~ m!^(application/x-www-form-urlencoded|multipart/form-data)$!;
 +      if $val->{content_type} =~ m!^(application/x-www-form-urlencoded|multipart/form-data)\s*(;|$)!;
@@ -43,7 +45,7 @@ index 7325eb7..493d804 100644
      $val->{valid} = @errors ? 0 : 1;
      return @errors;
    }
-@@ -528,4 +539,4 @@ Shares the same interface as L<JSON::Validator::Schema::OpenAPIv2/validate_respo
+@@ -528,4 +541,4 @@ Shares the same interface as L<JSON::Validator::Schema::OpenAPIv2/validate_respo
  L<JSON::Validator::Schema>, L<JSON::Validator::Schema::OpenAPIv2> and and
  L<JSON::Validator>.
  

--- a/tools/build/all/perl-JSON-Validator.patch
+++ b/tools/build/all/perl-JSON-Validator.patch
@@ -1,0 +1,52 @@
+https://github.com/jhthorsen/json-validator/pull/289
+diff --git a/lib/JSON/Validator/Schema/OpenAPIv3.pm b/lib/JSON/Validator/Schema/OpenAPIv3.pm
+index 7325eb7..493d804 100644
+--- a/lib/JSON/Validator/Schema/OpenAPIv3.pm
++++ b/lib/JSON/Validator/Schema/OpenAPIv3.pm
+@@ -279,22 +279,33 @@ sub _validate_body {
+     $val->{valid}        = $val->{content_type} ? 1 : 0;
+     return E "/header/Accept", [join(', ', @{$param->{accepts}}), type => $val->{accept}] unless $val->{valid};
+   }
++  my $negotiated_content_type;
+   if (@{$param->{accepts}} and $val->{content_type}) {
+-    my $negotiated = negotiate_content_type($param->{accepts}, $val->{content_type});
+-    $val->{valid} = $negotiated ? 1 : 0;
+-    return E "/$param->{name}", [join(', ', @{$param->{accepts}}) => type => $val->{content_type}] unless $negotiated;
++    $negotiated_content_type = negotiate_content_type($param->{accepts}, $val->{content_type});
++    $val->{valid} = $negotiated_content_type ? 1 : 0;
++    return E "/$param->{name}", [join(', ', @{$param->{accepts}}) => type => $val->{content_type}] unless $negotiated_content_type;
+   }
+   if ($param->{required} and !$val->{exists}) {
+     $val->{valid} = 0;
+     return E "/$param->{name}", [qw(object required)];
+   }
+   if ($val->{exists}) {
+-    $val->{content_type} //= $param->{accepts}[0];
++    # Ensures we have a valid content-type so we can select a schema
++    # This can happen if the negotiation fails (e.g. content-type is empty)
++    $negotiated_content_type //= $param->{accepts}[0];
++
++    # Mutate request content-type if one was not set
++    $val->{content_type} //= $negotiated_content_type;
++
+     local $self->{coerce}{arrays} = 1
+-      if $val->{content_type} =~ m!^(application/x-www-form-urlencoded|multipart/form-data)$!;
++      if $val->{content_type} =~ m!^(application/x-www-form-urlencoded|multipart/form-data)\s*(;|$)!;
++
+     local $self->{"validate_$direction"} = 1;
++
++    my $body_params = $param->{content}{$negotiated_content_type};
+     my @errors = map { $_->path(_prefix_error_path($param->{name}, $_->path)); $_ }
+-      $self->validate($val->{value}, $param->{content}{$val->{content_type}}{schema});
++      $self->validate($val->{value}, $body_params->{schema});
++
+     $val->{valid} = @errors ? 0 : 1;
+     return @errors;
+   }
+@@ -528,4 +539,4 @@ Shares the same interface as L<JSON::Validator::Schema::OpenAPIv2/validate_respo
+ L<JSON::Validator::Schema>, L<JSON::Validator::Schema::OpenAPIv2> and and
+ L<JSON::Validator>.
+ 
+-=cut
++=cut
+\ No newline at end of file

--- a/tools/build/docker/install-everything.sh
+++ b/tools/build/docker/install-everything.sh
@@ -42,6 +42,13 @@ patch -p1 < ../perl-Crypt-DES-fedora-c99.patch
 perl Makefile.PL && make install
 cd ../ && rm -rf Crypt-DES-2.07
 
+cpanm --notest --installdeps JSON::Validator -M https://cpan.metacpan.org
+curl -L -s https://cpan.metacpan.org/authors/id/J/JH/JHTHORSEN/JSON-Validator-5.15.tar.gz | tar -xz
+cd JSON-Validator-5.15
+patch -p1 < ../perl-JSON-Validator.patch
+perl Makefile.PL && make install
+cd ../ && rm -rf JSON-Validator-5.15
+
 # Install the LRR dependencies proper
 cpanm --notest --installdeps . -M https://cpan.metacpan.org
 

--- a/tools/build/homebrew/Lanraragi.rb
+++ b/tools/build/homebrew/Lanraragi.rb
@@ -30,6 +30,11 @@ class Lanraragi < Formula
     sha256 "bc54137346c1d45626e7075015f7d1dae813394af885457499f54878cfc19e0b"
   end
 
+  resource "JSON::Validator" do
+    url "https://cpan.metacpan.org/authors/id/J/JH/JHTHORSEN/JSON-Validator-5.15.tar.gz"
+    sha256 "eab57676bd3c7c318bc99118754e7f973259792f1ca13099e041938dd515bc05"
+  end
+
   def install
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
     ENV["OPENSSL_PREFIX"] = Formula["openssl@3"].opt_prefix
@@ -42,6 +47,13 @@ class Lanraragi < Formula
                 "/usr/local/include/ImageMagick-#{imagemagick.version.major}",
                 "#{imagemagick.opt_include}/ImageMagick-#{imagemagick.version.major}"
 
+      system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
+      system "make"
+      system "make", "install"
+    end
+
+    resource("JSON::Validator").stage do
+      system "patch", "-p1", "-i", buildpath/"tools/build/all/perl-JSON-Validator.patch"
       system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
       system "make"
       system "make", "install"

--- a/tools/build/windows/install.sh
+++ b/tools/build/windows/install.sh
@@ -19,6 +19,13 @@ patch -p1 < ../build/all/perl-Crypt-DES-fedora-c99.patch
 perl Makefile.PL && mingw32-make install
 cd ../ && rm -rf Crypt-DES-2.07
 
+cpanm --notest --installdeps JSON::Validator -M https://cpan.metacpan.org
+curl -L -s https://cpan.metacpan.org/authors/id/J/JH/JHTHORSEN/JSON-Validator-5.15.tar.gz | tar -xz
+cd JSON-Validator-5.15
+patch -p1 < ../build/all/perl-JSON-Validator.patch
+perl Makefile.PL && mingw32-make install
+cd ../ && rm -rf JSON-Validator-5.15
+
 cpanm --notest --installdeps Minion -M https://cpan.metacpan.org
 curl -L -s https://cpan.metacpan.org/authors/id/S/SR/SRI/Minion-11.0.tar.gz | tar -xz
 cd Minion-11.0

--- a/tools/cpanfile
+++ b/tools/cpanfile
@@ -40,6 +40,7 @@ requires 'Mojolicious',                          9.39;
 requires 'Mojolicious::Plugin::TemplateToolkit', 0.005;
 requires 'Mojolicious::Plugin::RenderFile',      0.12;
 requires 'Mojolicious::Plugin::OpenAPI',         5.11;
+requires 'JSON::Validator',                      5.13;
 requires 'IO::Socket::Socks',                    0.74;
 requires 'IO::Socket::SSL',                      2.067;
 requires 'Cpanel::JSON::XS',                     4.06;


### PR DESCRIPTION
Bug found by @Guerra24 , please clarify if needed.

It is possible to bypass OpenAPI validation even when it's enabled with `Content-Type: application/json; charset=utf-8`. The bug is in JSON::Validator, thanks to archey347 in related PR: https://github.com/jhthorsen/json-validator/pull/289 and PR 266.

For the sake of simplicity, multipart-bypass is applied, as applying the 289 fix would introduce another issue as discussed in 266 (which we might also bring in). We may also consider vendoring source + tests depending on how much we want to handle this problem.

Also explicitly added JSON::Validator.