### PR TITLE
Fix incorrect param type preventing VIPS functionality for non-64bit OS

### DIFF
--- a/lib/LANraragi/Utils/Vips.pm
+++ b/lib/LANraragi/Utils/Vips.pm
@@ -80,7 +80,7 @@ if ($VIPS_LOADED) {
     $vips_ffi->attach( vips_crop => ['VipsImage', 'VipsImage*', 'int', 'int', 'int', 'int'] => ['opaque'] => 'int' );
     $vips_ffi->attach( vips_colourspace => ['VipsImage', 'VipsImage*', 'int'] => ['opaque'] => 'int' );
     $vips_ffi->attach( vips_pngsave => ['VipsImage', 'string'] => ['opaque'] => 'int' );
-    $vips_ffi->attach( vips_thumbnail_buffer => ['string', 'uint64', 'VipsImage*', 'int'] => ['string', 'int', 'string', 'int', 'opaque'] => 'int' );
+    $vips_ffi->attach( vips_thumbnail_buffer => ['string', 'size_t', 'VipsImage*', 'int'] => ['string', 'int', 'string', 'int', 'opaque'] => 'int' );
 } else {
     # Dummy functions if libvips is not loaded
     *vips_init = sub { die "libvips is not loaded. Cannot call vips_init." };
@@ -188,7 +188,7 @@ sub fit_resize($buffer, $target_width, $target_height) {
 # Resize the image, respecting aspect ratio and cropping if needed (focus on center)
 sub cover_resize($buffer, $target_width, $target_height) {
     my $out;
-    my $func = $vips_ffi->function( 'vips_thumbnail_buffer' => ['string', 'uint64', 'VipsImage*', 'int'] => ['string', 'int', 'string', 'int', 'opaque'] => 'int' );
+    my $func = $vips_ffi->function( 'vips_thumbnail_buffer' => ['string', 'size_t', 'VipsImage*', 'int'] => ['string', 'int', 'string', 'int', 'opaque'] => 'int' );
 
     my $ret = $func->call($buffer, length($buffer), \$out, $target_width, 'height', $target_height, 'crop', VIPS_INTERESTING_CENTRE, undef);
     die "Error resizing image to width: ".fetch_and_clear_error() if ($ret != 0);
@@ -198,7 +198,7 @@ sub cover_resize($buffer, $target_width, $target_height) {
 # Resize the image, respecting aspect ratio
 sub resize_to_width($buffer, $target_width) {
     my $out;
-    my $func = $vips_ffi->function( 'vips_thumbnail_buffer' => ['string', 'uint64', 'VipsImage*', 'int'] => ['opaque'] => 'int' );
+    my $func = $vips_ffi->function( 'vips_thumbnail_buffer' => ['string', 'size_t', 'VipsImage*', 'int'] => ['opaque'] => 'int' );
 
     my $ret = $func->call($buffer, length($buffer), \$out, $target_width, undef);
     die "Error resizing image to width: ".fetch_and_clear_error() if ($ret != 0);


### PR DESCRIPTION
Hopefully fixes #1562, only tested on x86 but it would surprise me if this didn't help.