### PR TITLE
Manually pin Minion to ver 11.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,6 +30,9 @@ RUN wget -P /tools https://raw.githubusercontent.com/Difegue/LANraragi/dev/tools
 RUN cd Crypt-DES-2.07 && patch -p1 < ../tools/perl-Crypt-DES-fedora-c99.patch && perl Makefile.PL && make install 
 RUN rm -rf Crypt-DES-2.07
 
+# cpanm can't find the correct version so manually download and install it
+RUN cpanm --notest https://cpan.metacpan.org/authors/id/S/SR/SRI/Minion-11.0.tar.gz
+
 # Just re-grab cpanfile/install.pl/package.json from the online repo as codespaces' build context is super fucked and I don't get it at all
 # Dropping copies of the files in the .devcontainer folder should also work, but I cba to duplicate my build files for this and symlinks aint working I hate computers
 RUN wget -P /tools https://raw.githubusercontent.com/Difegue/LANraragi/dev/tools/cpanfile \

--- a/tools/build/docker/install-everything.sh
+++ b/tools/build/docker/install-everything.sh
@@ -49,6 +49,9 @@ patch -p1 < ../perl-JSON-Validator.patch
 perl Makefile.PL && make install
 cd ../ && rm -rf JSON-Validator-5.15
 
+# cpanm can't find the correct version so manually download and install it
+cpanm --notest https://cpan.metacpan.org/authors/id/S/SR/SRI/Minion-11.0.tar.gz
+
 # Install the LRR dependencies proper
 cpanm --notest --installdeps . -M https://cpan.metacpan.org
 

--- a/tools/build/homebrew/Lanraragi.rb
+++ b/tools/build/homebrew/Lanraragi.rb
@@ -35,6 +35,11 @@ class Lanraragi < Formula
     sha256 "eab57676bd3c7c318bc99118754e7f973259792f1ca13099e041938dd515bc05"
   end
 
+  resource "Minion" do
+    url "https://cpan.metacpan.org/authors/id/S/SR/SRI/Minion-11.0.tar.gz"
+    sha256 "f84ef5ab2d6cb94b32efde8331553b925343a900707355d18205dc2a3dacf3ac"
+  end
+
   def install
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
     ENV["OPENSSL_PREFIX"] = Formula["openssl@3"].opt_prefix

--- a/tools/cpanfile
+++ b/tools/cpanfile
@@ -46,7 +46,7 @@ requires 'IO::Socket::SSL',                      2.067;
 requires 'Cpanel::JSON::XS',                     4.06;
 
 # Job Queue (Minion)
-requires 'Minion',                 10.31;
+requires 'Minion',                 '>= 10.31, < 12.0';
 requires 'Minion::Backend::Redis', 0.002;
 
 # Background Worker (Shinobu)


### PR DESCRIPTION
Had to manually reference Minion 11.0 because cpanm refused to install the correct version.