### PR TITLE
Clarify Proxy Setup example headers

### DIFF
--- a/tools/Documentation/advanced-usage/proxy-setup.md
+++ b/tools/Documentation/advanced-usage/proxy-setup.md
@@ -10,6 +10,12 @@ http {
     client_max_body_size 0;   <----------------------- This line here
 }
 
+# Upgrade and Connection proxy header defaults
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 server {
     listen 80;
 


### PR DESCRIPTION
Add default mapping for the Upgrade and Connection proxy headers, used for the batch tagger under SSL.

This resolves the error code 1006 that can be seen when LANraragi is behind a reverse proxy, and was my fix after coming across issue #1275