### PR TITLE
Update Integration Tests

### DIFF
--- a/.github/workflows/push-continuous-integration.yml
+++ b/.github/workflows/push-continuous-integration.yml
@@ -10,11 +10,11 @@ on:
       integration_test_ref:
         description: 'Integration testing repository git commit hash or branch'
         required: true
-        default: 'dfdcd948cbc6d6bbd2db6620d8499bc8698843e3'
+        default: '66628bd19bee75bc1685e41965fb436d1476f9ee'
 
 env:
   INTEGRATION_TEST_REPOSITORY: ${{ github.event.inputs.integration_test_repository || 'psilabs-dev/aio-lanraragi' }}
-  INTEGRATION_TEST_REF: ${{ github.event.inputs.integration_test_ref || 'dfdcd948cbc6d6bbd2db6620d8499bc8698843e3' }}
+  INTEGRATION_TEST_REF: ${{ github.event.inputs.integration_test_ref || '66628bd19bee75bc1685e41965fb436d1476f9ee' }}
 
 name: "Continuous Integration \U0001F44C\U0001F440"
 jobs:
@@ -85,18 +85,27 @@ jobs:
         run: |
           mkdir -p "$GITHUB_WORKSPACE/staging"
       - name: Run integration tests against local LANraragi build
-        timeout-minutes: 30
+        timeout-minutes: 70
         run: |
           cd aio-lanraragi/integration_tests
           export CI=true
           uv run pytest tests --log-cli-level=INFO \
             --image lanraragi:ci \
             --staging "$GITHUB_WORKSPACE/staging" \
+            --server-logs "$GITHUB_WORKSPACE/server-logs" \
+            --cache-backend valkey \
             --playwright \
-            --npseed 42 \
-            -k "not test_double_page_navigation and not test_handler_resource_management"
+            --no-rate-limit \
+            --npseed 42
         env:
           DOCKER_HOST: unix:///var/run/docker.sock
+      - name: Upload server logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-logs-ubuntu
+          path: ${{ github.workspace }}/server-logs/
+          retention-days: 14
 
   integrationTestsWindows:
     name: Run Windows Integration Tests
@@ -215,13 +224,21 @@ jobs:
           New-Item -ItemType Directory -Path "$env:GITHUB_WORKSPACE\staging" -Force | Out-Null
       - name: Run integration tests against local LANraragi build
         working-directory: aio-lanraragi/integration_tests
-        timeout-minutes: 50
+        timeout-minutes: 100
         run: |
           $env:CI='true'
           uv run pytest tests `
           --log-cli-level=INFO `
           --windist "$env:GITHUB_WORKSPACE\LANraragi\win-dist" `
           --staging "$env:GITHUB_WORKSPACE\staging" `
+          --server-logs "$env:GITHUB_WORKSPACE\server-logs" `
           --playwright `
-          --npseed 42 `
-          -k "not test_double_page_navigation and not test_handler_resource_management"
+          --no-rate-limit `
+          --npseed 42
+      - name: Upload server logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-logs-windows
+          path: ${{ github.workspace }}\server-logs\
+          retention-days: 14


### PR DESCRIPTION
- compare: https://github.com/psilabs-dev/aio-lanraragi/compare/dfdcd948cbc6d6bbd2db6620d8499bc8698843e3...66628bd19bee75bc1685e41965fb436d1476f9ee
- PRs: https://github.com/psilabs-dev/aio-lanraragi/pull/168, https://github.com/psilabs-dev/aio-lanraragi/pull/171, https://github.com/psilabs-dev/aio-lanraragi/pull/179, https://github.com/psilabs-dev/aio-lanraragi/pull/181, https://github.com/psilabs-dev/aio-lanraragi/pull/182, https://github.com/psilabs-dev/aio-lanraragi/pull/183

Added a bunch of tests and fixes. Extended timeouts, and moved log outputs to persistent artifacts for debugging.

Docker-related:

- Docker buildx will be used via raw subprocess command execution. Python docker SDK does not actually use buildx because the project doesn't support docker buildx, and `DOCKER_BUILDKIT=1` does nothing.
- Database/cache backend is changed to use Valkey by default.
- Fixed a test bug where test-time docker doesn't use LRR redis.conf.

Added tests for:

- plugins
- openapi bypass
- reader
- local progress/auth
- index page
- slideshow
- navigation

And more... well, there are many many tests.

Tests marked `--dev` and `--regression` will be skipped. If there are too many tests or tests are taking too long we can put them behind a gate.