### PR TITLE
Encode archive title

### DIFF
--- a/public/js/edit.js
+++ b/public/js/edit.js
@@ -95,7 +95,7 @@ Edit.addArchiveToTank = function () {
         (data) => {
             const li = $(`<li data-id="${arcId}">
                 <i class="fas fa-grip-vertical drag-handle"></i>
-                <span class="arc-title" onmouseover="IndexTable.buildImageTooltip(this)">${data.title}</span>
+                <span class="arc-title" onmouseover="IndexTable.buildImageTooltip(this)">${LRR.encodeHTML(data.title)}</span>
                 <div class="caption" style="display: none;">
                     <img style="height:300px" src='${new LRR.ApiURL("/api/archives/"+arcId+"/thumbnail")}'
                         onerror="this.src='${new LRR.ApiURL("/img/noThumb.png")}'">

--- a/templates/edit.html.tt2
+++ b/templates/edit.html.tt2
@@ -145,7 +145,7 @@
 								<li data-id="[% archive.arcid %]">
 									<i class="fas fa-grip-vertical drag-handle"></i>
 									<span class="arc-title" onmouseover="IndexTable.buildImageTooltip(this)">
-										[% archive.title %]
+										[% archive.title | html %]
 									</span>
 									<div class="caption" style="display: none;">
 										<img style="height:300px" src='[% c.url_for("/api/archives/$archive.arcid/thumbnail") %]'


### PR DESCRIPTION
Given archive title could be anything and could come from untrusted places, we should probably encode this.

<img width="1642" height="840" alt="Screenshot 2026-05-28 at 12 12 46 AM" src="https://github.com/user-attachments/assets/0b6851b8-fa5c-4815-b6af-acc71c8d8106" />
