### PR TITLE
Move version cache buster to path for js

### DIFF
--- a/lib/LANraragi/Utils/Routing.pm
+++ b/lib/LANraragi/Utils/Routing.pm
@@ -3,6 +3,7 @@ package LANraragi::Utils::Routing;
 use strict;
 use warnings;
 use utf8;
+use v5.36;
 
 use Config;
 use Encode;
@@ -12,6 +13,8 @@ use Mojolicious::Plugin::Minion::Admin;
 
 use LANraragi::Utils::Login      qw(is_logged_in_api);
 use LANraragi::Utils::OpenAPI    qw(apply_openapi_mojo_overrides);
+
+use Cwd qw(abs_path);
 
 use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );
 
@@ -71,12 +74,17 @@ sub apply_routes {
     $public_routes->get( '/js/:version/*filepath' => [ version => qr/\d+\.\d+\.\d+/ ] )->to(
         cb => sub {
             my $c = shift;
+            my $static_dir = @{ $self->static->paths }[0];
+            my $allowed_directory = $static_dir ."/";
+            my $relative_path = Mojo::Path->new( "js/" . $c->stash('filepath') )->canonicalize;
+            my $path_to_test = $allowed_directory . $relative_path;
 
-            my $relFilePath = Mojo::Path->new( "/js/" . $c->stash('filepath') )->canonicalize;
-            return $c->reply->exception('Bad Request') unless is_traversal_safe($relFilePath);
+            if (!is_path_within($path_to_test, $allowed_directory)) {
+                return $c->reply->exception('Bad Request');
+            }
 
             $c->res->headers->cache_control('public, max-age=31536000, immutable');
-            $c->reply->static($relFilePath);
+            $c->reply->static($relative_path);
         }
     );
 
@@ -152,11 +160,18 @@ sub apply_routes {
 
 }
 
-sub is_traversal_safe {
-    my $filepath = shift;
+# Checks if path $path_to_test exists inside $allowed_directory.
+# It handles path traversal and symlinks.
+# Returns 0 if the file does not exist, either directory does not exist or if $path_to_test is not inside $allowed_directory.
+sub is_path_within($path_to_test, $allowed_directory) {
+    my $resolved_path_to_test = abs_path($path_to_test);
+    my $resolved_allowed_directory = abs_path($allowed_directory);
 
-    die("Incorrect parameter type, pass a Mojo::Path") if !( $filepath->isa('Mojo::Path') );
-    return index( $filepath->canonicalize, ".." ) == -1 ? 1 : 0;
+    return 0 unless defined $resolved_path_to_test && defined $resolved_allowed_directory;
+
+    $resolved_allowed_directory = $resolved_allowed_directory ."/";
+
+    return index( $resolved_path_to_test, $resolved_allowed_directory ) == 0 ? 1 : 0;
 }
 
 1;

--- a/lib/LANraragi/Utils/Routing.pm
+++ b/lib/LANraragi/Utils/Routing.pm
@@ -71,8 +71,12 @@ sub apply_routes {
     $public_routes->get( '/js/:version/*filepath' => [ version => qr/\d+\.\d+\.\d+/ ] )->to(
         cb => sub {
             my $c = shift;
+
+            my $relFilePath = Mojo::Path->new( "/js/" . $c->stash('filepath') )->canonicalize;
+            return $c->reply->exception('Bad Request') unless index( $relFilePath, ".." ) == -1;
+
             $c->res->headers->cache_control('public, max-age=31536000, immutable');
-            $c->reply->static( 'js/' . $c->stash('filepath') );
+            $c->reply->static($relFilePath);
         }
     );
 

--- a/lib/LANraragi/Utils/Routing.pm
+++ b/lib/LANraragi/Utils/Routing.pm
@@ -68,6 +68,14 @@ sub apply_routes {
     # Routers used for all loginless routes
     my $public_routes = $self->routes;
 
+    $public_routes->get( '/js/:version/*filepath' => [ version => qr/\d+\.\d+\.\d+/ ] )->to(
+        cb => sub {
+            my $c = shift;
+            $c->res->headers->cache_control('public, max-age=31536000, immutable');
+            $c->reply->static( 'js/' . $c->stash('filepath') );
+        }
+    );
+
     # Normal route to controller
     $public_routes->get('/login')->to('login#index');
     $public_routes->post('/login')->to('login#check');

--- a/lib/LANraragi/Utils/Routing.pm
+++ b/lib/LANraragi/Utils/Routing.pm
@@ -73,7 +73,7 @@ sub apply_routes {
             my $c = shift;
 
             my $relFilePath = Mojo::Path->new( "/js/" . $c->stash('filepath') )->canonicalize;
-            return $c->reply->exception('Bad Request') unless index( $relFilePath, ".." ) == -1;
+            return $c->reply->exception('Bad Request') unless is_traversal_safe($relFilePath);
 
             $c->res->headers->cache_control('public, max-age=31536000, immutable');
             $c->reply->static($relFilePath);
@@ -150,6 +150,13 @@ sub apply_routes {
 
     $search_api->get('/search')->to('api-search#handle_datatables');
 
+}
+
+sub is_traversal_safe {
+    my $filepath = shift;
+
+    die("Incorrect parameter type, pass a Mojo::Path") if !( $filepath->isa('Mojo::Path') );
+    return index( $filepath->canonicalize, ".." ) == -1 ? 1 : 0;
 }
 
 1;

--- a/public/js/backup.js
+++ b/public/js/backup.js
@@ -1,8 +1,8 @@
 /**
  * Backup Operations
  */
-import * as Server from "mod/server";
-import * as LRR from "mod/common";
+import * as Server from "./mod/server.js";
+import * as LRR from "./mod/common.js";
 import I18N from "i18n";
 
 let currentJob = null;

--- a/public/js/batch.js
+++ b/public/js/batch.js
@@ -1,8 +1,8 @@
 /**
  * Batch Operations
  */
-import * as LRR from "mod/common";
-import * as Server from "mod/server";
+import * as LRR from "./mod/common.js";
+import * as Server from "./mod/server.js";
 import I18N from "i18n";
 
 const Batch = {};

--- a/public/js/category.js
+++ b/public/js/category.js
@@ -2,8 +2,8 @@
  * Category Operations
  */
 
-import * as LRR from "mod/common";
-import * as Server from "mod/server";
+import * as LRR from "./mod/common.js";
+import * as Server from "./mod/server.js";
 import I18N from "i18n";
 
 const Category = {};

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -1,8 +1,8 @@
 /**
  * Config Operations
  */
-import * as Server from "mod/server";
-import * as LRR from "mod/common";
+import * as Server from "./mod/server.js";
+import * as LRR from "./mod/common.js";
 import I18N from "i18n";
 
 const Config = {};

--- a/public/js/duplicates.js
+++ b/public/js/duplicates.js
@@ -1,8 +1,8 @@
 /**
  * Duplicate Operations
  */
-import * as LRR from "mod/common";
-import * as Server from "mod/server";
+import * as LRR from "./mod/common.js";
+import * as Server from "./mod/server.js";
 import I18N from "i18n";
 
 const Duplicates = {};

--- a/public/js/edit.js
+++ b/public/js/edit.js
@@ -2,8 +2,8 @@
  * JS functions meant for use in the Edit page.
  * Mostly dealing with plugins.
  */
-import * as Server from "mod/server";
-import * as LRR from "mod/common";
+import * as Server from "./mod/server.js";
+import * as LRR from "./mod/common.js";
 import I18N from "i18n";
 
 const Edit = {};

--- a/public/js/logs.js
+++ b/public/js/logs.js
@@ -1,7 +1,7 @@
 /**
  * Logs Operations
  */
-import * as LRR from "mod/common";
+import * as LRR from "./mod/common.js";
 import I18N from "i18n";
 
 const Logs = {};

--- a/public/js/mod/index.js
+++ b/public/js/mod/index.js
@@ -2,9 +2,9 @@
  * Non-DataTables Index functions.
  * (The split is there to permit easier switch if we ever yeet datatables from the main UI)
  */
-import * as LRR from "mod/common";
-import * as Server from "mod/server";
-import * as IndexTable from "mod/index_datatables";
+import * as LRR from "./common.js";
+import * as Server from "./server.js";
+import * as IndexTable from "./index_datatables.js";
 import I18N from "i18n";
 import * as marked from "marked";
 import DOMPurify from "dompurify";

--- a/public/js/mod/index_contextmenu.js
+++ b/public/js/mod/index_contextmenu.js
@@ -1,10 +1,10 @@
 
 // #region Archive Context Menu
 
-import * as LRR from "mod/common";
-import * as Server from "mod/server";
-import * as Index from "mod/index";
-import * as IndexTable from "mod/index_datatables";
+import * as LRR from "./common.js";
+import * as Server from "./server.js";
+import * as Index from "./index.js";
+import * as IndexTable from "./index_datatables.js";
 import I18N from "i18n";
 
 let pseudoCopyBtn = undefined;

--- a/public/js/mod/index_datatables.js
+++ b/public/js/mod/index_datatables.js
@@ -1,8 +1,8 @@
 /**
  * All the Archive Index functions related to DataTables.
  */
-import * as LRR from "mod/common";
-import * as Index from "mod/index";
+import * as LRR from "./common.js";
+import * as Index from "./index.js";
 import I18N from "i18n";
 
 export let dataTable = {};

--- a/public/js/mod/server.js
+++ b/public/js/mod/server.js
@@ -1,7 +1,7 @@
 /**
  * Functions for Generic API calls.
  */
-import * as LRR from "mod/common";
+import * as LRR from "./common.js";
 import I18N from "i18n";
 
 let isScriptRunning = false;

--- a/public/js/plugins.js
+++ b/public/js/plugins.js
@@ -1,8 +1,8 @@
 /**
  * Plugins Operations
  */
-import * as Server from "mod/server";
-import * as LRR from "mod/common";
+import * as Server from "./mod/server.js";
+import * as LRR from "./mod/common.js";
 import I18N from "i18n";
 
 const Plugins = {};

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -2,8 +2,8 @@
  * Functions to navigate in reader with the keyboard.
  * Also handles the thumbnail archive explorer.
  */
-import * as Server from "mod/server";
-import * as LRR from "mod/common";
+import * as Server from "./mod/server.js";
+import * as LRR from "./mod/common.js";
 import I18N from "i18n";
 import fscreen from "fscreen";
 

--- a/public/js/stats.js
+++ b/public/js/stats.js
@@ -1,8 +1,8 @@
 /**
  * Stats Operations
  */
-import * as Server from "mod/server";
-import * as LRR from "mod/common";
+import * as Server from "./mod/server.js";
+import * as LRR from "./mod/common.js";
 import I18N from "i18n";
 
 const Stats = {};

--- a/public/js/upload.js
+++ b/public/js/upload.js
@@ -2,8 +2,8 @@
  * Scripting for the Upload page
 */
 
-import * as LRR from "mod/common";
-import * as Server from "mod/server";
+import * as LRR from "./mod/common.js";
+import * as Server from "./mod/server.js";
 import I18N from "i18n";
 
 let processingArchives = 0;

--- a/templates/common/importmap.html.tt2
+++ b/templates/common/importmap.html.tt2
@@ -1,28 +1,23 @@
 <script type="importmap">
     {
         "imports": {
-            "mod/common": "[% c.url_for("/js/mod/common.js?$version") %]",
-            "mod/server": "[% c.url_for("/js/mod/server.js?$version") %]",
-            "mod/index": "[% c.url_for("/js/mod/index.js?$version") %]",
-            "mod/index_datatables": "[% c.url_for("/js/mod/index_datatables.js?$version") %]",
-            "mod/index_contextmenu": "[% c.url_for("/js/mod/index_contextmenu.js?$version") %]",
             "i18n": "[% c.url_for("/js/i18n.js?$version") %]",
-            "fscreen": "[% c.url_for("/js/vendor/fscreen.esm.js") %]",
+            "fscreen": "[% c.url_for("/js/$version/vendor/fscreen.esm.js") %]",
 
-            "preact": "[% c.url_for("/js/vendor/preact.module.js") %]",
-            "preact/hooks": "[% c.url_for("/js/vendor/hooks.module.js") %]",
-            "preact/compat": "[% c.url_for("/js/vendor/compat.module.js") %]",
-            "htm": "[% c.url_for("/js/vendor/htm.js?$version") %]",
-            "clsx": "[% c.url_for("/js/vendor/clsx.m.js") %]",
-            "react-toastify": "[% c.url_for("/js/vendor/react-toastify.esm.js") %]",
+            "preact": "[% c.url_for("/js/$version/vendor/preact.module.js") %]",
+            "preact/hooks": "[% c.url_for("/js/$version/vendor/hooks.module.js") %]",
+            "preact/compat": "[% c.url_for("/js/$version/vendor/compat.module.js") %]",
+            "htm": "[% c.url_for("/js/$version/vendor/htm.js") %]",
+            "clsx": "[% c.url_for("/js/$version/vendor/clsx.m.js") %]",
+            "react-toastify": "[% c.url_for("/js/$version/vendor/react-toastify.esm.js") %]",
 
-			"react": "[% c.url_for("/js/vendor/compat.module.js") %]",
-			"react-dom": "[% c.url_for("/js/vendor/compat.module.js") %]",
+            "react": "[% c.url_for("/js/$version/vendor/compat.module.js") %]",
+            "react-dom": "[% c.url_for("/js/$version/vendor/compat.module.js") %]",
 
-            "marked": "[% c.url_for("/js/vendor/marked.esm.js?$version") %]",
-            "dompurify": "[% c.url_for("/js/vendor/purify.js?$version") %]",
+            "marked": "[% c.url_for("/js/$version/vendor/marked.esm.js?$version") %]",
+            "dompurify": "[% c.url_for("/js/$version/vendor/purify.js?$version") %]",
 
-			"sweetalert2": "[% c.url_for("/js/vendor/sweetalert2.esm.min.js") %]"
+            "sweetalert2": "[% c.url_for("/js/$version/vendor/sweetalert2.esm.min.js") %]"
         }
     }
 </script>

--- a/templates/edit.html.tt2
+++ b/templates/edit.html.tt2
@@ -32,7 +32,7 @@
 	<script src="[% c.url_for("/js/edit.js?$version") %]" type="module"></script>
 
 	<script type="module">
-		import * as IndexTable from "mod/index_datatables";
+		import * as IndexTable from "[% c.url_for("/js/$version/mod/index_datatables.js") %]";
 
 		jQuery(() => {
 			window.IndexTable = IndexTable;

--- a/templates/index.html.tt2
+++ b/templates/index.html.tt2
@@ -37,10 +37,10 @@
 	<script src="[% c.url_for("/js/vendor/clipboard.min.js") %]" type="text/JAVASCRIPT"></script>
 
 	<script type="module">
-		import * as Index from "mod/index";
-		import * as IndexTable from "mod/index_datatables";
-		import * as LRR from "mod/common";
-		import * as ContextMenu from "mod/index_contextmenu";
+		import * as Index from "[% c.url_for("/js/$version/mod/index.js") %]";
+		import * as IndexTable from "[% c.url_for("/js/$version/mod/index_datatables.js") %]";
+		import * as LRR from "[% c.url_for("/js/$version/mod/common.js") %]";
+		import * as ContextMenu from "[% c.url_for("/js/$version/mod/index_contextmenu.js") %]";
 
 		jQuery(() => {
 			[% IF usingdefpass %]

--- a/tests/LANraragi/Utils/Routing.t
+++ b/tests/LANraragi/Utils/Routing.t
@@ -8,34 +8,34 @@ use Mojo::Path;
 
 BEGIN { use_ok('LANraragi::Utils::Routing'); }
 
-note('testing is_traversal_safe ...');
+use Cwd qw(getcwd);
+
+my $cwd = getcwd();
+my $jsdir = $cwd."/tests/samples/routing/js";
+
+note('testing is_path_within ...');
 {
-    my $p = Mojo::Path->new("/js/safe/path");
-    my $result = LANraragi::Utils::Routing::is_traversal_safe($p);
+    my $result = LANraragi::Utils::Routing::is_path_within("$jsdir/safe/ok2.txt", $jsdir);
     is( $result, 1, "Simple safe path should pass" );
 }
 
 {
-    my $p = Mojo::Path->new("/js/../robots.txt");
-    my $result = LANraragi::Utils::Routing::is_traversal_safe($p);
+    my $result = LANraragi::Utils::Routing::is_path_within("$jsdir/safe/../ok.txt", $jsdir."/safe/../");
+    is( $result, 1, "Traversal within directory to test against should pass" );
+}
+
+{
+    my $result = LANraragi::Utils::Routing::is_path_within("$jsdir/safe/../ok.txt", $jsdir);
     is( $result, 1, "Traversal within directory should pass" );
 }
 
 {
-    my $p = Mojo::Path->new("/js/foo/./bar");
-    my $result = LANraragi::Utils::Routing::is_traversal_safe($p);
-    is( $result, 1, "Path with dot segments should pass" );
-}
-
-{
-    my $p = Mojo::Path->new("/js/../../etc/passwd");
-    my $result = LANraragi::Utils::Routing::is_traversal_safe($p);
+    my $result = LANraragi::Utils::Routing::is_path_within("$jsdir/../robots.txt", $jsdir);
     is( $result, 0, "Path traversing past root should be blocked" );
 }
 
 {
-    my $p = Mojo::Path->new("/../absolute");
-    my $result = LANraragi::Utils::Routing::is_traversal_safe($p);
+    my $result = LANraragi::Utils::Routing::is_path_within("/../absolute", $jsdir);
     is( $result, 0, "Path with leading parent traversal should be blocked" );
 }
 

--- a/tests/LANraragi/Utils/Routing.t
+++ b/tests/LANraragi/Utils/Routing.t
@@ -1,0 +1,42 @@
+use strict;
+use warnings;
+use utf8;
+
+use Test::More;
+use Test::Deep;
+use Mojo::Path;
+
+BEGIN { use_ok('LANraragi::Utils::Routing'); }
+
+note('testing is_traversal_safe ...');
+{
+    my $p = Mojo::Path->new("/js/safe/path");
+    my $result = LANraragi::Utils::Routing::is_traversal_safe($p);
+    is( $result, 1, "Simple safe path should pass" );
+}
+
+{
+    my $p = Mojo::Path->new("/js/../robots.txt");
+    my $result = LANraragi::Utils::Routing::is_traversal_safe($p);
+    is( $result, 1, "Traversal within directory should pass" );
+}
+
+{
+    my $p = Mojo::Path->new("/js/foo/./bar");
+    my $result = LANraragi::Utils::Routing::is_traversal_safe($p);
+    is( $result, 1, "Path with dot segments should pass" );
+}
+
+{
+    my $p = Mojo::Path->new("/js/../../etc/passwd");
+    my $result = LANraragi::Utils::Routing::is_traversal_safe($p);
+    is( $result, 0, "Path traversing past root should be blocked" );
+}
+
+{
+    my $p = Mojo::Path->new("/../absolute");
+    my $result = LANraragi::Utils::Routing::is_traversal_safe($p);
+    is( $result, 0, "Path with leading parent traversal should be blocked" );
+}
+
+done_testing();

--- a/tests/samples/routing/js/ok.txt
+++ b/tests/samples/routing/js/ok.txt
@@ -1,0 +1,1 @@
+okay to access

--- a/tests/samples/routing/js/safe/ok2.txt
+++ b/tests/samples/routing/js/safe/ok2.txt
@@ -1,0 +1,1 @@
+also ok to access

--- a/tests/samples/routing/secret.txt
+++ b/tests/samples/routing/secret.txt
@@ -1,0 +1,1 @@
+secrets here!


### PR DESCRIPTION
I wasn't 100% pleased with how importmap-reliant JS imports were, so I changed approach. It also prevented most IDEs from resolving the imports for autocomplete, so that works better now.

Now the version cache-buster is part of the path and doesn't require importmap-entries for "ordinary" non-vendor javascript files. This allows you to do relative imports (like `./server.js` instead of `mod/server`).

A disadvantage is that importing stuff from HTML files is a touch uglier again as you need to build the path each time rather than just once in the importmap.