### PR TITLE
Extract index context menu to a separate module

### DIFF
--- a/public/js/mod/common.js
+++ b/public/js/mod/common.js
@@ -5,9 +5,6 @@ import { createElement, render } from "preact";
 import Swal from "sweetalert2";
 import { ToastContainer, toast as emitToast } from "react-toastify";
 
-import * as Index from "mod/index";
-import * as Server from "mod/server";
-import * as IndexTable from "mod/index_datatables";
 import I18N from "i18n";
 
 let toastsInitialized = false;
@@ -580,111 +577,6 @@ export function toast(c) {
             };
         })());
 }
-
-// #region Context Menu Functions
-
-/**
- * Build category list for contextMenu and checkoff the ones the given ID belongs to.
- * @param {*} catList The list of categories, obtained statically
- * @param {*} id The ID of the archive or tankoubon to check
- * @returns Categories
- */
-export function loadContextMenuCategories(catList, id){
-    return Server.callAPI(`/api/archives/${id}/categories`, "GET", null, I18N.IndexIdLoadError(id),
-        (data) => {
-            const items = {};
-
-            for (let i = 0; i < catList.length; i++) {
-                const catId = catList[i].id;
-
-                // If the category is also in the API results,
-                // we can pre-check it when creating the checkbox
-                const isSelected = data.categories.map((x) => x.id).includes(catId);
-                items[catId] = { name: catList[i].name, type: "checkbox" };
-                if (isSelected) { items[catId].selected = true; }
-
-                items[catId].events = {
-                    click() {
-                        if ($(this).is(":checked")) {
-                            Server.addArchiveToCategory(id, catId);
-                            if (typeof Index !== "undefined" && catId === localStorage.getItem("bookmarkCategoryId")) {
-                                Index.bookmarkIconOn(id);
-                            }
-                        } else {
-                            Server.removeArchiveFromCategory(id, catId);
-                            if (typeof Index !== "undefined" && catId === localStorage.getItem("bookmarkCategoryId")) {
-                                Index.bookmarkIconOff(id);
-                            }
-                        }
-                    },
-                };
-            }
-
-            if (Object.keys(items).length === 0) {
-                items.noop = { name: I18N.IndexNoCategories, icon: "far fa-sad-cry" };
-            }
-
-            return items;
-        },
-    );
-}
-
-/**
- * Build rating options for contextMenu and select the one for the current ID.
- * @param {*} id The ID of the archive to check
- * @param {*} refreshCallback Optional callback to refresh the view after rating change
- * @returns Ratings
- */
-export function loadContextMenuRatings(id, refreshCallback) {
-    return Server.callAPI(`/api/archives/${id}/metadata`, "GET", null, I18N.IndexIdLoadError(id),
-        (data) => {
-            const items = {};
-            const ratings = [{
-                name: I18N.IndexRemoveRating
-            }, {
-                name: "⭐",
-            }, {
-                name: "⭐⭐",
-            }, {
-                name: "⭐⭐⭐",
-            }, {
-                name: "⭐⭐⭐⭐",
-            }, {
-                name: "⭐⭐⭐⭐⭐",
-            }];
-            const tags = splitTagsByNamespace(data.tags);
-            const hasRating = Object.keys(tags).some(x => x === "rating");
-            const ratingValue = hasRating ? tags["rating"] : [0];
-
-            for (let i = 0; i < ratings.length; i++) {
-                items[i] = ratings[i];
-                items[i].type = "checkbox";
-
-                if (items[i].name === ratingValue[0]) { items[i].selected = true; }
-                items[i].events = {
-                    click() {
-                        if(i === 0) delete tags["rating"];
-                        else tags["rating"] = [ratings[i].name];
-
-                        Server.updateTagsFromArchive(id, buildTagList(tags));
-
-                        if (refreshCallback) {
-                            refreshCallback();
-                        } else if (IndexTable.dataTable) {
-                            IndexTable.dataTable.ajax.reload(null, false);
-                            Index.updateCarousel();
-                        }
-                        $(this).parents("ul.context-menu-list").find("input[type='checkbox']").toArray().filter((x) => x !== this).forEach(x => x.checked = false);
-                    },
-                };
-            }
-
-            return items;
-        },
-    );
-}
-
-// #endregion
 
 export function initializeToasts() {
     // Initialize toast.

--- a/public/js/mod/index.js
+++ b/public/js/mod/index.js
@@ -16,10 +16,8 @@ let swiper = {};
 let serverVersion = "";
 let debugMode = false;
 export let pageSize = 100;
-let pseudoCopyBtn = undefined;
-let isMultiSelectMode = false;
+export let isMultiSelectMode = false;
 export let selectedArchives = new Set();
-let clipboard;
 
 /**
  * Initialize the Archive Index.
@@ -241,26 +239,6 @@ export function initializeAll() {
 
     updateTableHeaders();
     resizableColumns();
-
-    pseudoCopyBtn = $("#pseudo-copy-btn")
-    clipboard = new window.ClipboardJS("#pseudo-copy-btn");
-
-    clipboard.on("success", function (e) {
-        LRR.toast({
-            heading: I18N.IndexCopyLinkSuccess,
-            icon: "info",
-            hideAfter: 3000,
-        });
-        e.clearSelection();
-    });
-
-    clipboard.on("error", function (e) {
-        LRR.toast({
-            heading: I18N.IndexCopyLinkFail,
-            icon: "error",
-            hideAfter: false,
-        });
-    });
 }
 
 export function toggleOrder(e) {
@@ -1005,61 +983,7 @@ export function migrateProgress() {
 
 // #endregion
 
-// #region Archive Context Menu
 
-/**
- * Handle context menu clicks.
- * @param {*} option The clicked option
- * @param {*} id The Archive ID
- * @returns
- */
-export function handleContextMenu(option, id) {
-    switch (option) {
-        case "edit":
-            LRR.openInNewTab(new LRR.ApiURL(`/edit?id=${id}`));
-            break;
-        case "delete": {
-            const isTank = id.startsWith("TANK_");
-            LRR.showPopUp({
-                text: isTank ? I18N.ConfirmTankoubonDeletion : I18N.ConfirmArchiveDeletion,
-                icon: "warning",
-                showCancelButton: true,
-                focusConfirm: false,
-                confirmButtonText: I18N.ConfirmYes,
-                reverseButtons: true,
-                confirmButtonColor: "#d33",
-            }).then((result) => {
-                if (result.isConfirmed) {
-                    if (isTank) Server.deleteTankoubon(id, () => {
-                        document.location.reload(true);
-                    });
-                    else Server.deleteArchive(id, () => {
-                        document.location.reload(true);
-                    });
-                }
-            });
-            break;
-        }
-        case "read":
-            LRR.openInNewTab(new LRR.ApiURL(`/reader?id=${id}`));
-            break;
-        case "download":
-            LRR.openInNewTab(new LRR.ApiURL(`/api/archives/${id}/download`));
-            break;
-        case "copy link":
-            pseudoCopyBtn.attr("data-clipboard-text", `${window.location.origin}${new LRR.ApiURL(`/reader?id=${id}`).toString()}`);
-            pseudoCopyBtn.click()
-            break;
-        case "msm-toggle-archive":
-            if (!isMultiSelectMode) toggleMultiSelectMode();
-            toggleArchiveSelection(id);
-            break;
-        default:
-            break;
-    }
-}
-
-// #endregion
 
 // #region Category buttons
 

--- a/public/js/mod/index_contextmenu.js
+++ b/public/js/mod/index_contextmenu.js
@@ -174,7 +174,7 @@ function loadContextMenuRatings(id, refreshCallback) {
 
 export function initialize(catListData) {
     const catList = catListData || [];
-    pseudoCopyBtn = $("#pseudo-copy-btn")
+    pseudoCopyBtn = $("#pseudo-copy-btn");
     const clipboard = new window.ClipboardJS("#pseudo-copy-btn");
 
     clipboard.on("success", function (e) {

--- a/public/js/mod/index_contextmenu.js
+++ b/public/js/mod/index_contextmenu.js
@@ -1,0 +1,261 @@
+
+// #region Archive Context Menu
+
+import * as LRR from "mod/common";
+import * as Server from "mod/server";
+import * as Index from "mod/index";
+import * as IndexTable from "mod/index_datatables";
+import I18N from "i18n";
+
+let pseudoCopyBtn = undefined;
+
+function handleDelete(id) {
+    const isTank = id.startsWith("TANK_");
+    LRR.showPopUp({
+        text: isTank ? I18N.ConfirmTankoubonDeletion : I18N.ConfirmArchiveDeletion,
+        icon: "warning",
+        showCancelButton: true,
+        focusConfirm: false,
+        confirmButtonText: I18N.ConfirmYes,
+        reverseButtons: true,
+        confirmButtonColor: "#d33",
+    })
+        .then((result) => {
+            if (result.isConfirmed) {
+                if (isTank) Server.deleteTankoubon(id, () => {
+                    document.location.reload();
+                });
+                else Server.deleteArchive(id, () => {
+                    document.location.reload();
+                });
+            }
+        });
+}
+
+/**
+ * Handle context menu clicks.
+ * @param {*} option The clicked option
+ * @param {*} id The Archive ID
+ * @returns
+ */
+function handleContextMenu(option, id) {
+    switch (option) {
+        case "edit":
+            LRR.openInNewTab(new LRR.ApiURL(`/edit?id=${id}`));
+            break;
+        case "delete":
+            handleDelete(id);
+            break;
+        case "read":
+            LRR.openInNewTab(new LRR.ApiURL(`/reader?id=${id}`));
+            break;
+        case "download":
+            LRR.openInNewTab(new LRR.ApiURL(`/api/archives/${id}/download`));
+            break;
+        case "copy link":
+            pseudoCopyBtn.attr("data-clipboard-text", `${window.location.origin}${new LRR.ApiURL(`/reader?id=${id}`).toString()}`);
+            pseudoCopyBtn.click();
+            break;
+        case "msm-toggle-archive":
+            if (!Index.isMultiSelectMode) Index.toggleMultiSelectMode();
+            Index.toggleArchiveSelection(id);
+            break;
+        default:
+            break;
+    }
+}
+
+// #endregion
+
+// #region Context Menu Functions
+
+/**
+ * Build category list for contextMenu and checkoff the ones the given ID belongs to.
+ * @param {*} catList The list of categories, obtained statically
+ * @param {*} id The ID of the archive or tankoubon to check
+ * @returns Categories
+ */
+function loadContextMenuCategories(catList, id){
+    return Server.callAPI(`/api/archives/${id}/categories`, "GET", null, I18N.IndexIdLoadError(id),
+        (data) => {
+            const items = {};
+
+            for (let i = 0; i < catList.length; i++) {
+                const catId = catList[i].id;
+
+                // If the category is also in the API results,
+                // we can pre-check it when creating the checkbox
+                const isSelected = data.categories.map((x) => x.id).includes(catId);
+                items[catId] = { name: catList[i].name, type: "checkbox" };
+                if (isSelected) { items[catId].selected = true; }
+
+                items[catId].events = {
+                    click() {
+                        if ($(this).is(":checked")) {
+                            Server.addArchiveToCategory(id, catId);
+                            if (catId === localStorage.getItem("bookmarkCategoryId")) {
+                                Index.bookmarkIconOn(id);
+                            }
+                        } else {
+                            Server.removeArchiveFromCategory(id, catId);
+                            if (catId === localStorage.getItem("bookmarkCategoryId")) {
+                                Index.bookmarkIconOff(id);
+                            }
+                        }
+                    },
+                };
+            }
+
+            if (Object.keys(items).length === 0) {
+                items.noop = { name: I18N.IndexNoCategories, icon: "far fa-sad-cry" };
+            }
+
+            return items;
+        },
+    );
+}
+
+/**
+ * Build rating options for contextMenu and select the one for the current ID.
+ * @param {*} id The ID of the archive to check
+ * @param {*} refreshCallback Optional callback to refresh the view after rating change
+ * @returns Ratings
+ */
+function loadContextMenuRatings(id, refreshCallback) {
+    return Server.callAPI(`/api/archives/${id}/metadata`, "GET", null, I18N.IndexIdLoadError(id),
+        (data) => {
+            const items = {};
+            const ratings = [{
+                name: I18N.IndexRemoveRating
+            }, {
+                name: "⭐",
+            }, {
+                name: "⭐⭐",
+            }, {
+                name: "⭐⭐⭐",
+            }, {
+                name: "⭐⭐⭐⭐",
+            }, {
+                name: "⭐⭐⭐⭐⭐",
+            }];
+            const tags = LRR.splitTagsByNamespace(data.tags);
+            const hasRating = Object.keys(tags).some(x => x === "rating");
+            const ratingValue = hasRating ? tags["rating"] : [0];
+
+            for (let i = 0; i < ratings.length; i++) {
+                items[i] = ratings[i];
+                items[i].type = "checkbox";
+
+                if (items[i].name === ratingValue[0]) { items[i].selected = true; }
+                items[i].events = {
+                    click() {
+                        if(i === 0) delete tags["rating"];
+                        else tags["rating"] = [ratings[i].name];
+
+                        Server.updateTagsFromArchive(id, LRR.buildTagList(tags));
+
+                        if (refreshCallback) {
+                            refreshCallback();
+                        } else if (IndexTable.dataTable) {
+                            IndexTable.dataTable.ajax.reload(null, false);
+                            Index.updateCarousel();
+                        }
+                        $(this).parents("ul.context-menu-list").find("input[type='checkbox']").toArray().filter((x) => x !== this).forEach(x => x.checked = false);
+                    },
+                };
+            }
+
+            return items;
+        },
+    );
+}
+
+// #endregion
+
+export function initialize(catListData) {
+    const catList = catListData || [];
+    pseudoCopyBtn = $("#pseudo-copy-btn")
+    const clipboard = new window.ClipboardJS("#pseudo-copy-btn");
+
+    clipboard.on("success", function (e) {
+        LRR.toast({
+            heading: I18N.IndexCopyLinkSuccess,
+            icon: "info",
+            hideAfter: 3000,
+        });
+        e.clearSelection();
+    });
+
+    clipboard.on("error", function (_e) {
+        LRR.toast({
+            heading: I18N.IndexCopyLinkFail,
+            icon: "error",
+            hideAfter: false,
+        });
+    });
+
+    // Initialize context menu
+    $.contextMenu({
+        selector: ".context-menu",
+        build: ($trigger, _e) => {
+            const id = $trigger.attr("id");
+            const isTankoubon = id && id.startsWith("TANK_");
+
+            let items = {
+                "read": {
+                    name: I18N.Read,
+                    icon: "fas fa-book"
+                },
+                ...(!isTankoubon ? {
+                    "download": {
+                        name: I18N.Download,
+                        icon: "fas fa-save"
+                    }
+                } : {}),
+                "copy link": {
+                    name: I18N.CopyLink,
+                    icon: "fas fa-link"
+                },
+                "msm-toggle-archive": {
+                    name: Index.selectedArchives.has(id)
+                        ? I18N.MSMRemoveFromSelection
+                        : I18N.MSMAddToSelection,
+                    icon: "fas fa-check-square"
+                }
+            };
+
+            if (LRR.isUserLogged()) {
+                let moreItems = {
+                    "sep1": "---------",
+                    "edit": {
+                        name: I18N.EditMetadata,
+                        icon: "fas fa-pencil-alt"
+                    },
+                    "delete": {
+                        name: I18N.Delete,
+                        icon: "fas fa-trash-alt"
+                    },
+                    "rating": {
+                        "name": I18N.AddRating,
+                        "icon": "fas fa-star",
+                        "items": loadContextMenuRatings(id)
+                    },
+                    "collections": {
+                        "name": I18N.AddToCategory,
+                        "icon": "fas fa-search-plus",
+                        "items": loadContextMenuCategories(catList, id)
+                    }
+                }
+                Object.assign(items, moreItems);
+            }
+
+            return {
+                callback: function (key, _options) {
+                    handleContextMenu(key, $(this)
+                        .attr("id"));
+                },
+                items: items,
+            }
+        }
+    });
+}

--- a/templates/common/importmap.html.tt2
+++ b/templates/common/importmap.html.tt2
@@ -5,6 +5,7 @@
             "mod/server": "[% c.url_for("/js/mod/server.js?$version") %]",
             "mod/index": "[% c.url_for("/js/mod/index.js?$version") %]",
             "mod/index_datatables": "[% c.url_for("/js/mod/index_datatables.js?$version") %]",
+            "mod/index_contextmenu": "[% c.url_for("/js/mod/index_contextmenu.js?$version") %]",
             "i18n": "[% c.url_for("/js/i18n.js?$version") %]",
             "fscreen": "[% c.url_for("/js/vendor/fscreen.esm.js") %]",
 

--- a/templates/i18n.html.tt2
+++ b/templates/i18n.html.tt2
@@ -233,4 +233,12 @@ I18N.ClickToEdit = "[% c.lh("Click here to edit metadata.") %]";
 I18N.UploadError = "[% c.lh("Error while processing file.") %]";
 I18N.DownloadError = "[% c.lh("Error while downloading file.") %]";
 
+I18N.Read = "[% c.lh('Read') %]";
+I18N.Download = "[% c.lh('Download') %]";
+I18N.CopyLink = "[% c.lh('Copy link') %]";
+I18N.EditMetadata = "[% c.lh('Edit Metadata') %]";
+I18N.Delete = "[% c.lh('Delete') %]";
+I18N.AddRating = "[% c.lh('Add Rating') %]";
+I18N.AddToCategory = "[% c.lh('Add to Category') %]";
+
 export default I18N;

--- a/templates/index.html.tt2
+++ b/templates/index.html.tt2
@@ -40,9 +40,32 @@
 		import * as Index from "mod/index";
 		import * as IndexTable from "mod/index_datatables";
 		import * as LRR from "mod/common";
+		import * as ContextMenu from "mod/index_contextmenu";
 
 		jQuery(() => {
+			[% IF usingdefpass %]
+			LRR.toast({
+				heading: "[% c.lh('You\'re using the default password and that\'s super baka of you') %]",
+				text: '[% c.lh("Login with password \"kamimamita\" and change that shit on the double. ...Or just disable it! Why not check the configuration options afterwards, while you\'re at it?") %]',
+				icon: 'warning',
+				hideAfter: 25000,
+				closeOnClick: false,
+				draggable: false,
+			});
+			[% END %]
+
+			const catList = [];
+			[% IF categories.size > 0 %]
+			[% FOREACH categories %]
+			catList.push({
+				name: "[% name %]",
+				id: "[% id %]",
+			});
+			[% END %]
+			[% END %]
+
 			Index.initializeAll();
+			ContextMenu.initialize(catList);
 			window.Index = Index;
 			window.IndexTable = IndexTable;
 			window.LRR = LRR;
@@ -193,78 +216,6 @@
 	[% INCLUDE footer %]
 
 	<button id="pseudo-copy-btn" data-clipboard-text="" style="display: none">click me</button>
-
-	<script type="module">
-		import * as Index from "mod/index";
-		import I18N from "i18n";
-
-		// Last few remains of JS using server-provided data
-		jQuery(() => {
-
-			[% IF usingdefpass %]
-			//If the json has the "default password" flag, flash a friendly notification inviting the user to change his password
-			LRR.toast({
-				heading: "[% c.lh('You\'re using the default password and that\'s super baka of you') %]",
-				text: '[% c.lh("Login with password \"kamimamita\" and change that shit on the double. ...Or just disable it! Why not check the configuration options afterwards, while you\'re at it?") %]',
-				icon: 'warning',
-				hideAfter: 25000,
-				closeOnClick: false,
-				draggable: false,
-			});
-			[% END %]
-
-			const catList = [];
-			[% IF categories.size > 0 %]
-			[% FOREACH categories %]
-			// Push a tuple into catList
-			catList.push({
-				name: "[% name %]",
-				id: "[% id %]",
-			});
-			[% END %]
-			[% END %]
-
-			// Initialize context menu
-			$.contextMenu({
-				selector: '.context-menu',
-				build: ($trigger, e) => {
-					const id = $trigger.attr("id");
-					const isTankoubon = id && id.startsWith("TANK_");
-					return {
-						callback: function (key, options) {
-							Index.handleContextMenu(key, $(this).attr("id"));
-						},
-						items: {
-							"read": { name: "[% c.lh('Read') %]", icon: "fas fa-book" },
-							...(!isTankoubon ? { "download": { name: "[% c.lh('Download') %]", icon: "fas fa-save" } } : {}),
-							"copy link": { name: "[% c.lh('Copy link') %]", icon: "fas fa-link" },
-							"msm-toggle-archive": {
-								name: Index.selectedArchives.has(id)
-									? I18N.MSMRemoveFromSelection
-									: I18N.MSMAddToSelection,
-								icon: "fas fa-check-square"
-							},
-							[% IF userlogged %]
-							"sep1": "---------",
-							"edit": { name: "[% c.lh('Edit Metadata') %]", icon: "fas fa-pencil-alt" },
-							"delete": { name: "[% c.lh('Delete') %]", icon: "fas fa-trash-alt" },
-								"rating": {
-								    "name": "[% c.lh('Add Rating') %]",
-								    "icon": "fas fa-star",
-								    "items": LRR.loadContextMenuRatings(id)
-								},
-							"collections": {
-								"name": "[% c.lh('Add to Category') %]",
-								"icon": "fas fa-search-plus",
-								"items": LRR.loadContextMenuCategories(catList, id)
-							}
-							[% END %]
-						}
-					}
-				}
-			});
-		});
-	</script>
 
 	<div id="overlay-shade"> </div>
 


### PR DESCRIPTION
Move context menu code for the index page into a separate module. Reduces size of thicc JS and moves some JS out of a template file.