### PR TITLE
Fix tank progress updates

### DIFF
--- a/lib/LANraragi/Controller/Api/Tankoubon.pm
+++ b/lib/LANraragi/Controller/Api/Tankoubon.pm
@@ -27,12 +27,34 @@ sub get_tankoubon {
 
     my $self    = shift->openapi->valid_input or return;
     my $tank_id = $self->stash('id');
+
+    my %tankoubon = LANraragi::Model::Tankoubon::get_tankoubon($tank_id);
+
+    unless (%tankoubon) {
+        render_api_response( $self, "get_tankoubon", "The given tankoubon does not exist." );
+        return;
+    }
+
+    $self->render( openapi => \%tankoubon );
+}
+
+sub get_tankoubon_full {
+
+    my $self    = shift->openapi->valid_input or return;
+    my $tank_id = $self->stash('id');
     my $req     = $self->req;
 
     my $fulldata = ( $self->req->param('include_full_data') && $self->req->param('include_full_data') ne "false" ) ? 1 : 0;
-    my $page     = $req->param('page');
+    my $page     = $req->param('page') // -1;
 
-    my ( $total, $filtered, %tankoubon ) = LANraragi::Model::Tankoubon::get_tankoubon( $tank_id, $fulldata, $page );
+    my ( $total, $filtered, %tankoubon );
+    if ( $page < 0 ) {
+        %tankoubon = LANraragi::Model::Tankoubon::get_tankoubon( $tank_id, $fulldata, $page );
+        $total    = scalar @{ $tankoubon{archives} // [] };
+        $filtered = $total;
+    } else {
+        ( $total, $filtered, %tankoubon ) = LANraragi::Model::Tankoubon::get_tankoubon( $tank_id, $fulldata, $page );
+    }
 
     unless (%tankoubon) {
         render_api_response( $self, "get_tankoubon", "The given tankoubon does not exist." );

--- a/lib/LANraragi/Controller/Edit.pm
+++ b/lib/LANraragi/Controller/Edit.pm
@@ -68,7 +68,9 @@ sub edit_tankoubon {
         return;
     }
 
-    my ( $total, $filtered, %tank ) = LANraragi::Model::Tankoubon::get_tankoubon( $id, 1 );
+    # Note: We only use full_data here to get the archive titles. If this proves to be too slow for large tanks,
+    # we could discard this and do separate API calls to get the titles in the client. 
+    my %tank = LANraragi::Model::Tankoubon::get_tankoubon( $id, 1 );
     my @archives   = @{ $tank{archives}  // [] };
     my @full_data  = @{ $tank{full_data} // [] };
 

--- a/lib/LANraragi/Model/Tankoubon.pm
+++ b/lib/LANraragi/Model/Tankoubon.pm
@@ -43,7 +43,7 @@ sub get_tankoubon_list ( $page = 0 ) {
     # Jam tanks into an array of hashes
     my @result;
     foreach my $key ( sort @tanks ) {
-        my ( $total, $filtered, %data ) = get_tankoubon($key);
+        my %data = get_tankoubon($key);
         push( @result, \%data );
     }
 
@@ -180,7 +180,11 @@ sub get_tankoubon ( $tank_id, $fulldata = 0, $page = -1 ) {
 
     my $total = $redis->zcount($tank_id, 1, "+inf");
 
-    return ( $total, $#archives + 1, %tank );
+    if ( $page < 0 ) {
+        return %tank;
+    } else {
+        return ( $total, $#archives + 1, %tank );
+    }
 }
 
 # delete_tankoubon(tankoubonid)

--- a/lib/LANraragi/Utils/Database.pm
+++ b/lib/LANraragi/Utils/Database.pm
@@ -291,7 +291,7 @@ sub build_json ( $id, %hash ) {
 
 # Ditto for Tank IDs.
 sub build_tank_json ($id) {
-    my ( $total_archives, $filtered, %tank ) = LANraragi::Model::Tankoubon::get_tankoubon( $id, 1 );
+    my %tank = LANraragi::Model::Tankoubon::get_tankoubon( $id, 1 );
 
     # Aggregate data of all archives in the tank
     my $aggregate_names     = "";
@@ -328,7 +328,7 @@ sub build_tank_json ($id) {
         pagecount     => $aggregate_pagecount,
         lastreadtime  => $latest_readtime,
         size          => $aggregate_size,
-        archive_count => $total_archives
+        archive_count => scalar @{ $tank{archives} }
     };
 
     return $arcdata;

--- a/public/js/batch.js
+++ b/public/js/batch.js
@@ -87,8 +87,8 @@ Batch.loadSelectionOnly = function (ids) {
 
     // Acquire archive IDs from Tanks and merge with directly selected archive IDs, then fetch metadata for each archive ID
     const tankFetches = tankIds.map((id) => 
-        Server.callAPI(`/api/tankoubons/${id}?page=-1`, "GET", null, I18N.ArchiveListLoadFailure, (data) => {
-            archiveIds.push(...(data.result.archives || []));
+        Server.callAPI(`/api/tankoubons/${id}`, "GET", null, I18N.ArchiveListLoadFailure, (data) => {
+            archiveIds.push(...(data.archives || []));
         }));
         
     Promise.all(tankFetches).then(() => {

--- a/public/js/mod/index.js
+++ b/public/js/mod/index.js
@@ -792,7 +792,7 @@ function mergeSelectionIntoTankoubon() {
         // Fold non-tank archives into the existing tankoubon
         const tankId = tankIds[0];
         Server.callAPI(`/api/tankoubons/${tankId}`, "GET", null, I18N.MSMMergeError, (data) => {
-            const tankName = data.result.name;
+            const tankName = data.name;
             LRR.showPopUp({
                 text: I18N.MSMMergeExistingConfirmText(archiveIds.length, tankName),
                 showCancelButton: true,
@@ -992,7 +992,7 @@ export function migrateProgress() {
                 .then((data) => {
                     if (!data) return;
 
-                    const serverProgress = isTank ? data.result.progress : data.progress;
+                    const serverProgress = data.progress;
 
                     // Don't migrate if the server progress is already further
                     if (progress !== null

--- a/public/js/mod/index.js
+++ b/public/js/mod/index.js
@@ -964,23 +964,40 @@ export function migrateProgress() {
 
         const promises = [];
         localProgressKeys.forEach((id) => {
-            const progress = localStorage.getItem(`${id}-reader`);
-            const metadataUrl = id.startsWith("TANK_") ? 
+            const progress  = localStorage.getItem(`${id}-reader`);
+            const isTank    = id.startsWith("TANK_");
+
+            const metadataUrl = isTank ? 
                 new LRR.ApiURL(`api/tankoubons/${id}`) : 
                 new LRR.ApiURL(`api/archives/${id}/metadata`);
 
-            const progressUrl = id.startsWith("TANK_") ? 
+            const progressUrl = isTank ? 
                 `api/tankoubons/${id}/progress/${progress}?force=1` : 
                 `api/archives/${id}/progress/${progress}?force=1`;
 
             const promise = fetch(metadataUrl, { method: "GET" })
-                .then((response) => response.json())
+                .then((response) => {
+                    if (response.status === 404) {
+                        localStorage.removeItem(`${id}-reader`);
+                        localStorage.removeItem(`${id}-totalPages`);
+                        return null;
+                    }
+                    if (!response.ok) {
+                        // eslint-disable-next-line no-console
+                        console.warn(`Failed to migrate progress for ${id} (status ${response.status})`);
+                        return null;
+                    }
+                    return response.json();
+                })
                 .then((data) => {
+                    if (!data) return;
+
+                    const serverProgress = isTank ? data.result.progress : data.progress;
+
                     // Don't migrate if the server progress is already further
                     if (progress !== null
-                        && data !== undefined
-                        && data !== null
-                        && progress > data.progress) {
+                        && serverProgress !== undefined
+                        && progress > serverProgress) {
                         Server.callAPI(progressUrl, "PUT", null, I18N.LocalProgressionError, null);
                     }
 

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -367,7 +367,7 @@ export function loadContentData() {
     // If the ID is a Tank ID (TANK_xxxx), use the Tankoubon API for metadata
     if (id.startsWith("TANK_")) {
 
-        return fetch(new LRR.ApiURL(`/api/tankoubons/${id}?include_full_data=true&page=-1`))
+        return fetch(new LRR.ApiURL(`/api/tankoubons/${id}/full`))
             .then(r => r.ok ? r.json() : Promise.reject(new Error(I18N.ServerInfoError)))
             .then(data => {
                 const tank = data.result;

--- a/tests/tankoubon.t
+++ b/tests/tankoubon.t
@@ -31,12 +31,17 @@ my ( $total, $filtered, @rgs );
 my %tankoubon;
 
 # Get Tankoubon
-( $total, $filtered, %tankoubon ) = LANraragi::Model::Tankoubon::get_tankoubon("TANK_1589141306", 0, 0);
+%tankoubon = LANraragi::Model::Tankoubon::get_tankoubon("TANK_1589141306");
 is($tankoubon{id}, "TANK_1589141306", 'ID test');
 is($tankoubon{name}, "Hello", 'Name test');
-is($total, 2, 'Total Test');
-is($filtered, 2, 'Count Test');
+is(scalar @{$tankoubon{archives}}, 2, 'Archive count test');
 ok($tankoubon{archives}[0] eq "28697b96f0ac5858be2666ed10ca47742c955555", 'Archives test');
+
+# Get Tankoubon (paged, page=0 returns $total/$filtered alongside tank data)
+my ($tp, $fp, %tankoubon_paged) = LANraragi::Model::Tankoubon::get_tankoubon("TANK_1589141306", 0, 0);
+is($tankoubon_paged{id}, "TANK_1589141306", 'Paged ID test');
+is($tp, 2, 'Total Test');
+is($fp, 2, 'Count Test');
 
 # List Tankoubon
 ( $total, $filtered, @rgs ) = LANraragi::Model::Tankoubon::get_tankoubon_list(0);
@@ -69,9 +74,9 @@ my $new_tank_id = LANraragi::Model::Tankoubon::create_tankoubon("Test Tank", "")
 ok($new_tank_id =~ /^TANK_\d{10}$/, 'Create tankoubon returns valid ID');
 
 # Verify it exists and has correct name
-my ($t, $f, %new_tank) = LANraragi::Model::Tankoubon::get_tankoubon($new_tank_id);
+my %new_tank = LANraragi::Model::Tankoubon::get_tankoubon($new_tank_id);
 is($new_tank{name}, "Test Tank", 'Created tankoubon has correct name');
-is($t, 0, 'New tankoubon has 0 archives');
+is(scalar @{$new_tank{archives}}, 0, 'New tankoubon has 0 archives');
 
 # Test: Add 12 archives to tank
 foreach my $arc_id (@archive_ids) {
@@ -80,8 +85,8 @@ foreach my $arc_id (@archive_ids) {
 }
 
 # Test: Verify ordering with 12 archives (critical test for cmp vs <=> fix)
-my ($total_12, $filtered_12, %tank_12) = LANraragi::Model::Tankoubon::get_tankoubon($new_tank_id, 0, -1);
-is($total_12, 12, 'Tank has 12 archives');
+my %tank_12 = LANraragi::Model::Tankoubon::get_tankoubon($new_tank_id);
+is(scalar @{$tank_12{archives}}, 12, 'Tank has 12 archives');
 
 # Verify archives are in correct insertion order (not string-sorted)
 for my $i (0 .. $#archive_ids) {
@@ -91,16 +96,16 @@ for my $i (0 .. $#archive_ids) {
 # Test: Adding duplicate archive
 my ($dup_result, $dup_err) = LANraragi::Model::Tankoubon::add_to_tankoubon($new_tank_id, $archive_ids[0]);
 ok($dup_result, 'Adding duplicate archive returns success');
-my ($t_dup, $f_dup, %tank_dup) = LANraragi::Model::Tankoubon::get_tankoubon($new_tank_id, 0, -1);
-is($t_dup, 12, 'Tank still has 12 archives after duplicate add');
+my %tank_dup = LANraragi::Model::Tankoubon::get_tankoubon($new_tank_id);
+is(scalar @{$tank_dup{archives}}, 12, 'Tank still has 12 archives after duplicate add');
 
 # Test: Remove from tankoubon
 my ($rm_result, $rm_err) = LANraragi::Model::Tankoubon::remove_from_tankoubon($new_tank_id, $archive_ids[1]);
 ok($rm_result, 'Removed archive from tankoubon');
 is($rm_result, 2, 'Removed archive was at position 2');
 
-my ($t_rm, $f_rm, %tank_rm) = LANraragi::Model::Tankoubon::get_tankoubon($new_tank_id, 0, -1);
-is($t_rm, 11, 'Tank now has 11 archives');
+my %tank_rm = LANraragi::Model::Tankoubon::get_tankoubon($new_tank_id);
+is(scalar @{$tank_rm{archives}}, 11, 'Tank now has 11 archives');
 is($tank_rm{archives}[0], $archive_ids[0], 'First archive unchanged after removal');
 is($tank_rm{archives}[1], $archive_ids[2], 'Second archive is now what was third');
 
@@ -110,7 +115,7 @@ my @reversed = reverse @current_archives;
 my ($reorder_result, $reorder_err) = LANraragi::Model::Tankoubon::update_archive_list($new_tank_id, { archives => \@reversed });
 ok($reorder_result, 'Reordered archive list');
 
-my ($t_rev, $f_rev, %tank_rev) = LANraragi::Model::Tankoubon::get_tankoubon($new_tank_id, 0, -1);
+my %tank_rev = LANraragi::Model::Tankoubon::get_tankoubon($new_tank_id);
 is_deeply($tank_rev{archives}, \@reversed, 'Archives are in reversed order');
 
 # Test: Update metadata
@@ -123,7 +128,7 @@ my ($meta_result, $meta_err) = LANraragi::Model::Tankoubon::update_metadata($new
 });
 ok($meta_result, 'Updated metadata');
 
-my ($t_meta, $f_meta, %tank_meta) = LANraragi::Model::Tankoubon::get_tankoubon($new_tank_id);
+my %tank_meta = LANraragi::Model::Tankoubon::get_tankoubon($new_tank_id);
 is($tank_meta{name}, "Updated Tank Name", 'Name updated correctly');
 is($tank_meta{summary}, "A test summary", 'Summary updated correctly');
 is($tank_meta{tags}, "test,tankoubon", 'Tags updated correctly');
@@ -137,21 +142,21 @@ ok((grep { $_ eq $new_tank_id } @containing_tanks), 'Found tank containing archi
 #################################
 
 # Test: New tankoubon has progress=0
-my ($t_prog0, $f_prog0, %tank_prog0) = LANraragi::Model::Tankoubon::get_tankoubon($new_tank_id);
+my %tank_prog0 = LANraragi::Model::Tankoubon::get_tankoubon($new_tank_id);
 is($tank_prog0{progress}, 0, 'New tankoubon starts with progress=0');
 
 # Test: update_tank_progress stores the page
 my ($prog_result, $prog_err) = LANraragi::Model::Tankoubon::update_tank_progress($new_tank_id, 7);
 ok($prog_result, 'update_tank_progress returns success');
 
-my ($t_prog7, $f_prog7, %tank_prog7) = LANraragi::Model::Tankoubon::get_tankoubon($new_tank_id);
+my %tank_prog7 = LANraragi::Model::Tankoubon::get_tankoubon($new_tank_id);
 is($tank_prog7{progress}, 7, 'Tank progress updated to 7');
 
 # Test: Delete tankoubon
 my $del_result = LANraragi::Model::Tankoubon::delete_tankoubon($new_tank_id);
 ok($del_result, 'Deleted tankoubon');
 
-my ($t_del, $f_del, %tank_del) = LANraragi::Model::Tankoubon::get_tankoubon($new_tank_id);
+my %tank_del = LANraragi::Model::Tankoubon::get_tankoubon($new_tank_id);
 ok(!%tank_del, 'Tankoubon no longer exists after deletion');
 
 #################################

--- a/tools/openapi.yaml
+++ b/tools/openapi.yaml
@@ -2359,7 +2359,7 @@ paths:
                     type: array
                     description: Array of tankoubon metadata
                     items:
-                      $ref: '#/components/schemas/TankoubonMetadataJson'
+                      $ref: '#/components/schemas/TankoubonBackupJson'
                 example:
                   archives:
                     - arcid: 28697b96f0ac5858be2614ed10ca47742c9522fd
@@ -3384,25 +3384,9 @@ paths:
       x-mojo-to: api-tankoubon#get_tankoubon
       summary: Get a single Tankoubon
       description: >-
-        Get the details of the specified tankoubon ID, with the archives list paginated.  
-
-        The amount of archives per page depends on the server `archives_per_page` setting.
+         Get the details of the specified tankoubon ID.
       tags:
         - tankoubons
-      parameters:
-        - name: include_full_data
-          in: query
-          required: false
-          description: If set to true, a `full_data` array will be added to the response with full Archive metadata.
-          schema:
-            type: boolean
-        - name: page
-          in: query
-          required: false
-          description: Page of the Archives list. You can use -1 to return all archives if needed.  
-          schema:
-            type: integer
-            default: -1
       responses:
         '200':
           description: Tankoubon
@@ -3411,32 +3395,32 @@ paths:
               schema:
                 type: object
                 properties:
-                  result:
-                    type: object
-                    properties:
-                      archives:
-                        type: array
-                        description: Paginated list of archive IDs or tankoubon IDs.
-                        items:
-                          type: string
-                          oneOf:
-                            - minLength: 40
-                              maxLength: 40
-                              pattern: "^[0-9a-f]{40}$"
-                            - minLength: 15
-                              maxLength: 15
-                              pattern: "^TANK_[0-9]{10}$"
-                        uniqueItems: true
-                      full_data:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/ArchiveMetadataJson'
-                  total:
+                  id:
+                    type: string
+                    description: ID of this Tankoubon.
+                  name:
+                    type: string
+                    description: Name of this Tankoubon.
+                  summary:
+                    type: string
+                  tags:
+                    type: string
+                  archives:
+                    type: array
+                    description: Full list of archive IDs contained in this Tankoubon.
+                    items:
+                      type: string
+                      oneOf:
+                        - minLength: 40
+                          maxLength: 40
+                          pattern: "^[0-9a-f]{40}$"
+                        - minLength: 15
+                          maxLength: 15
+                          pattern: "^TANK_[0-9]{10}$"
+                    uniqueItems: true
+                  progress:
                     type: integer
-                    description: The total amount of archives in this Tankoubon.
-                  filtered:
-                    type: integer
-                    description: The amount of archives in the current page.
+                    description: Reading progress (page number) for this Tankoubon.
         '400':
           description: Error response
           content:
@@ -3539,6 +3523,85 @@ paths:
                 $ref: '#/components/schemas/OperationResponse'
         '423':
           description: The Tankoubon is currently locked for modification
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OperationResponse'
+  /tankoubons/{id}/full:
+    parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of the Tankoubon desired
+          schema:
+            type: string
+    get:
+      operationId: getTankoubonFull
+      x-mojo-to: api-tankoubon#get_tankoubon_full
+      summary: Get a single Tankoubon with full detail
+      description: >-
+        Get the details of the specified tankoubon ID with paginated archive metadata.
+
+        The amount of archives per page depends on the server `archives_per_page` setting.
+      tags:
+        - tankoubons
+      parameters:
+        - name: page
+          in: query
+          required: false
+          description: Page of the Archives list. You can use -1 to return all archives, but this might take a while.
+          schema:
+            type: integer
+            default: 1
+      responses:
+        '200':
+          description: Tankoubon
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        description: ID of this Tankoubon.
+                      name:
+                        type: string
+                        description: Name of this Tankoubon.
+                      summary:
+                        type: string
+                      tags:
+                        type: string
+                      progress:
+                        type: integer
+                        description: Reading progress (page number) for this Tankoubon.
+                      archives:
+                        type: array
+                        description: Paginated list of archive IDs contained in this Tankoubon.
+                        items:
+                          type: string
+                          oneOf:
+                            - minLength: 40
+                              maxLength: 40
+                              pattern: "^[0-9a-f]{40}$"
+                            - minLength: 15
+                              maxLength: 15
+                              pattern: "^TANK_[0-9]{10}$"
+                        uniqueItems: true
+                      full_data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/ArchiveMetadataJson'
+                  total:
+                    type: integer
+                    description: The total amount of archives in this Tankoubon.
+                  filtered:
+                    type: integer
+                    description: The amount of archives in the current page.
+        '400':
+          description: Error response
           content:
             application/json:
               schema:
@@ -4267,10 +4330,22 @@ components:
           - 7f03b8b1f337e1e42b2c2890533c0de7479d41ca
     TankoubonMetadataJson:
       type: object
-      description: Tankoubon metadata
+      description: Tankoubon metadata as returned by the list endpoint
       required:
-        - tankid
+        - id
       properties:
+        id:
+          type: string
+          description: ID of the tankoubon
+        name:
+          type: string
+          description: Name of the tankoubon
+        summary:
+          type: string
+          description: Summary of the tankoubon
+        tags:
+          type: string
+          description: Tags associated with the tankoubon
         archives:
           type: array
           description: Array of archive IDs
@@ -4278,12 +4353,43 @@ components:
             type: string
             minLength: 40
             maxLength: 40
+        progress:
+          type: integer
+          description: Reading progress (page number) for this Tankoubon
+      example:
+        id: TANK_1749925516
+        name: sailor moon
+        summary: ""
+        tags: ""
+        archives:
+          - e69e43e1355267f7d32a4f9b7f2fe108d2401ebf
+          - e69e43e1355267f7d32a4f9b7f2fe108d2401ebg
+        progress: 0
+    TankoubonBackupJson:
+      type: object
+      description: Tankoubon metadata as returned in a backup
+      required:
+        - tankid
+      properties:
         tankid:
           type: string
           description: ID of the tankoubon
         name:
           type: string
           description: Name of the tankoubon
+        summary:
+          type: string
+          description: Summary of the tankoubon
+        tags:
+          type: string
+          description: Tags associated with the tankoubon
+        archives:
+          type: array
+          description: Array of archive IDs
+          items:
+            type: string
+            minLength: 40
+            maxLength: 40
       example:
         tankid: TANK_1749925516
         name: sailor moon


### PR DESCRIPTION
There is a logic error with tanks where `&& progress > data.progress` is always false. See Model::Tankoubon::get_tankoubon:

```perl
$tank{progress} = int( $tank{progress} || 0 );
```

This means the condition never updates, which means that tank progress is never updated. A couple edits to harden the contract:

1. explicitly handle tank progress status codes
2. pull `id.startsWith` into an indicator
3. define `serverProgress` based on isTank.

The `data.progress` and `data.result.progress` inconsistency is probably going to bite us again though.