### PR TITLE
Open lockfile with read access to fix flock on NFS

### DIFF
--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use utf8;
 
-use Fcntl qw(:flock O_CREAT O_RDWR);
+use Fcntl qw(:flock);
 use Compress::Zlib;
 use Config;
 
@@ -53,7 +53,7 @@ has lockpath => sub {
 has lockfh => sub {
     my $self = shift;
     my $lockpath = $self->lockpath;
-    open( my $fh, '>>', $lockpath ) or die "Could not open lockfile '$lockpath': $!";
+    open( my $fh, '+>>', $lockpath ) or die "Could not open lockfile '$lockpath': $!";
     $self->lockpid($$);
     return $fh;
 };
@@ -267,7 +267,7 @@ sub ensure_lock {
     if ( !defined $self->{lockfh} || !defined $self->{lockpid} || $self->{lockpid} != $$ ) {
         eval { close $self->{lockfh} } if defined $self->{lockfh};
         my $lockpath = $self->lockpath;
-        open( my $fh, '>>', $lockpath ) or die "Could not open lockfile '$lockpath': $!";
+        open( my $fh, '+>>', $lockpath ) or die "Could not open lockfile '$lockpath': $!";
         $self->lockfh($fh);
         $self->lockpid($$);
     }


### PR DESCRIPTION
Fixes #1556

Narrows the original #1561: just the `+>>` lockfile open mode fix as suggested by @psilabs-dev.

Since #1406, `RotatingLog` dies on `LOCK_SH` in `append()` when the log volume is NFS - the fd was opened write-only (`>>`), which does not satisfy NFS flock requirements for shared locks per [`perldoc flock`](https://perldoc.perl.org/functions/flock).

**Changes:**
- `+>>` open mode on lockfile handles (`lockfh` and `ensure_lock`) so the fd has read intent
- Remove unused `O_CREAT` and `O_RDWR` imports from `Fcntl`