### PR TITLE
Address the probe part of the 1556 problem

### DIFF
--- a/lib/LANraragi/Utils/RotatingLog.pm
+++ b/lib/LANraragi/Utils/RotatingLog.pm
@@ -326,8 +326,8 @@ sub is_supported {
     my $probe_path  = "$lockdir/.lrr-flock-probe.$$";
 
     # do a flock hit
-    if ( open( my $fh, '>', $probe_path ) ) {
-        $supported = flock( $fh, LOCK_EX | LOCK_NB ) ? 1 : 0;
+    if ( open( my $fh, '+>>', $probe_path ) ) {
+        $supported = flock( $fh, LOCK_SH | LOCK_NB ) ? 1 : 0;
         close $fh;
         unlink $probe_path;
     }


### PR DESCRIPTION
Issue: https://github.com/Difegue/LANraragi/issues/1556

The probe should check that "+>>" works as intended. Of course, this assumes that "+>>" is applied to all instantiating cases of RotatingLog (which part of https://github.com/Difegue/LANraragi/pull/1590 covers).