### PR TITLE
Keep display on when using auto next page

### DIFF
--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -1977,12 +1977,6 @@ async function requestWakeLock() {
         console.error("Error acquiring wake lock:", err);
     }
 }
-// Browser releases the wake lock when the tab is hidden so we need to reacquire it
-document.addEventListener("visibilitychange", async () => {
-    if (autoNextPage && wakeLock !== null && document.visibilityState === "visible") {
-        await requestWakeLock();
-    }
-});
 
 function releaseWakeLock() {
     if (wakeLock !== null) {

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -51,6 +51,7 @@ let markersVisible = false;
 let markers = [];
 let overlayFiltered = false;
 let pageNaviState = true;
+let wakeLock = null;
 
 export function initializeAll(trackProgressLocally, authenticateProgress) {
     state.trackProgressLocally = trackProgressLocally;
@@ -1562,6 +1563,8 @@ function startAutoNextPage() {
         autoNextPageCountdown -= 1;
         aEls.text(autoNextPageCountdown);
     }, 1000);
+
+    requestWakeLock();
 }
 
 function stopAutoNextPage() {
@@ -1569,6 +1572,8 @@ function stopAutoNextPage() {
     clearInterval(autoNextPageCountdownTaskId);
     $(".toggle-auto-next-page").addClass("fa-stopwatch");
     $(".toggle-auto-next-page").text("");
+
+    releaseWakeLock();
 }
 
 function toggleAutoNextPage() {
@@ -1952,3 +1957,36 @@ jQuery(() => {
         }
     });
 });
+
+async function requestWakeLock() {
+    if (wakeLock !== null) {
+        return;
+    }
+    if (!("wakeLock" in navigator)) {
+        console.error("Wake Lock API is not available.");
+        return;
+    }
+
+    try {
+        wakeLock = await navigator.wakeLock.request();
+
+        wakeLock.addEventListener("release", () => {
+            wakeLock = null;
+        });
+    } catch (err) {
+        console.error("Error acquiring wake lock:", err);
+    }
+}
+// Browser releases the wake lock when the tab is hidden so we need to reacquire it
+document.addEventListener("visibilitychange", async () => {
+    if (autoNextPage && wakeLock !== null && document.visibilityState === "visible") {
+        await requestWakeLock();
+    }
+});
+
+function releaseWakeLock() {
+    if (wakeLock !== null) {
+        wakeLock.release();
+    }
+}
+

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -1963,7 +1963,7 @@ async function requestWakeLock() {
         return;
     }
     if (!("wakeLock" in navigator)) {
-        console.error("Wake Lock API is not available.");
+        console.error("Wake Lock API is not available. You're likely running in an outdated browser or without HTTPS.");
         return;
     }
 


### PR DESCRIPTION
Auto next page is a great feature, but I got tired of tapping on my phone when it was about to sleep. This uses [WakeLock](https://developer.mozilla.org/en-US/docs/Web/API/WakeLock) to keep the device screen on while auto next page is being used. It is supported by latest devices and browser versions, but the only caveat is that it requires an HTTPS connection.

Tested on a couple of browsers on Android and Windows.