### PR TITLE
Fix tank-related bugs

### DIFF
--- a/lib/LANraragi/Controller/Api/Tankoubon.pm
+++ b/lib/LANraragi/Controller/Api/Tankoubon.pm
@@ -44,7 +44,7 @@ sub get_tankoubon_full {
     my $tank_id = $self->stash('id');
     my $req     = $self->req;
 
-    my $fulldata = ( $self->req->param('include_full_data') && $self->req->param('include_full_data') ne "false" ) ? 1 : 0;
+    my $fulldata = 1;
     my $page     = $req->param('page') // -1;
 
     my ( $total, $filtered, %tankoubon );

--- a/templates/reader.html.tt2
+++ b/templates/reader.html.tt2
@@ -93,7 +93,7 @@
             <br>
             <div style="margin-bottom:16px;">
                 <div class="id3 nocrop reader-thumbnail">
-                    <img id="reader-overview-thumbnail" src="[% c.url_for("/api/archives/$id/thumbnail") %]" />
+                    <img id="reader-overview-thumbnail" src="[% IF is_tank %][% c.url_for("/api/tankoubons/$id/thumbnail") %][% ELSE %][% c.url_for("/api/archives/$id/thumbnail") %][% END %]" />
                 </div>
 
                 [% IF userlogged %]

--- a/tools/openapi.yaml
+++ b/tools/openapi.yaml
@@ -3549,10 +3549,10 @@ paths:
         - name: page
           in: query
           required: false
-          description: Page of the Archives list. You can use -1 to return all archives, but this might take a while.
+          description: Page of the Archives list. Defaults to -1, which returns all archives.
           schema:
             type: integer
-            default: 1
+            default: -1
       responses:
         '200':
           description: Tankoubon


### PR DESCRIPTION
Two bugs.

Bug 1: Tank currently breaks: in safari if you open a tank you get:

```
Unhandled Promise Rejection: TypeError: undefined is not an object (evaluating 'pages[index].split')
```

because "/full" doesn't necessarily return fulldata...

Bug 2: after fixing bug 1, if you open a tank, the thumbnail API will 400, due to OpenAPI validation. Hence the fix at templates/reader.html.tt2