### PR TITLE
Fix archive replacement when uploading different content with the same filename

### DIFF
--- a/lib/LANraragi/Model/Upload.pm
+++ b/lib/LANraragi/Model/Upload.pm
@@ -83,8 +83,21 @@ sub handle_incoming_file ( $tempfile, $catid, $tags, $title, $summary ) {
 
     # If we are replacing an existing one, just remove the old one first.
     if ($replace_dupe) {
-        $logger->debug("Delete archive $id before replacing it.");
-        LANraragi::Model::Archive::delete_archive($id);
+        my $redis_config = LANraragi::Model::Config->get_redis_config;
+        my $encoded_output_file = IS_UNIX ? encode_utf8( $output_file ) : $output_file;
+        my $old_id = $redis_config->hget( "LRR_FILEMAP", $encoded_output_file );
+        
+        # Same filename, different content: old_id found via filemap
+        if ( $old_id && $old_id ne $id ) {
+            $logger->debug("Delete archive $old_id before replacing it.");
+            LANraragi::Model::Archive::delete_archive($old_id);
+            $redis_config->hset( "LRR_FILEMAP", $encoded_output_file, $id );
+        } else {
+            $logger->debug("Delete archive $id before replacing it.");
+            LANraragi::Model::Archive::delete_archive($id);
+        }
+
+        $redis_config->quit();
     }
 
     # Add the file to the database ourselves so Shinobu doesn't do it


### PR DESCRIPTION
When uploading an archive through the `api/archives/upload` endpoint with the same filename but different file content, metadata provided in the request (such as tags) is not applied correctly. The archive ultimately continues to display the metadata from the previously uploaded archive.

If the exact same file is uploaded again (same filename and same content), the behavior is correct.

Cause:
In `lib/LANraragi/Model/Upload.pm`:

```perl
# If we are replacing an existing one, just remove the old one first.
if ($replace_dupe) {
    $logger->debug("Delete archive $id before replacing it.");
    LANraragi::Model::Archive::delete_archive($id);
}
```

The `$id` passed to `delete_archive()` is the ID computed for the newly uploaded archive, rather than the ID of the existing archive currently associated with that filename.
When the uploaded content is identical, both the old and new archives generate the same ID, so the issue does not become visible.

This fix only addresses that specific scenario. All other existing replacement behavior remains unchanged.