### PR TITLE
Fix category filtering by allowing doSearch to access selectedCategory

### DIFF
--- a/public/js/mod/index.js
+++ b/public/js/mod/index.js
@@ -9,7 +9,7 @@ import I18N from "i18n";
 import * as marked from "marked";
 import DOMPurify from "dompurify";
 
-let selectedCategory = "";
+export let selectedCategory = "";
 let awesomplete = {};
 let carouselInitialized = false;
 let swiper = {};


### PR DESCRIPTION
Filtering on a category like "Favorites" didn't work as the relevant variable was not exported. Fixed now!