### PR TITLE
Stamp hotfixes

### DIFF
--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -222,8 +222,18 @@ export function initializeAll(trackProgressLocally, authenticateProgress) {
             markerMode = false;
             if (result.isConfirmed && result.value.trim() !== "") {
                 const { arcId, localPage } = getArchiveForPage(page);
-                Server.callAPI(`/api/archives/${arcId}/stamps/${localPage}?position=${markerData.x},${markerData.y}&content=${result.value}`, "PUT", "Stamp added!", I18N.StampError,
+                Server.callAPI(`/api/archives/${arcId}/stamps/${localPage}?position=${markerData.x},${markerData.y}&content=${result.value}`, "PUT", null, I18N.StampError,
                     (data) => {
+                        if (["error", "errors"].some(prop => Object.hasOwn(data, prop))) {
+                            LRR.showErrorToast(I18N.StampError, data.error ?? "Authentication required."); // If OpenAPI returns its own responses for other cases, then this will not be correct.
+                            return;
+                        }
+
+                        LRR.toast({
+                            heading: "Stamp added!",
+                            icon: "success",
+                            hideAfter: 7000,
+                        });
                         markerData.id = data["stamp_id"];
                         markerData.name = result.value;
 
@@ -636,7 +646,7 @@ export function initializeSettings() {
 
 function initFullscreen() {
     // Apply full-screen utility
-    // F11 Fullscreen is totally another "Fullscreen", so its support is beyong consideration.
+    // F11 Fullscreen is totally another "Fullscreen", so its support is beyond consideration.
     // Small override function, always returns boolean
     fscreen.inFullscreen = () => !!fscreen.fullscreenElement;
     if (!fscreen.fullscreenEnabled) {
@@ -954,7 +964,6 @@ function createMarkerElement(markerData, index) {
     const xPx = (markerData.x / 100) * rect.width;
     const yPx = (markerData.y / 100) * rect.height;
 
-    const displayRect = display.getBoundingClientRect();
     const containerRect = container.getBoundingClientRect();
 
     let leftFix = rect.left - containerRect.left;
@@ -966,8 +975,8 @@ function createMarkerElement(markerData, index) {
         leftFix += img.width+2;
     }
 
-    marker.style.left = `${rect.left + xPx - displayRect.left + leftFix}px`;
-    marker.style.top = `${rect.top + yPx - displayRect.top + topFix}px`;
+    marker.style.left = `${leftFix + xPx}px`;
+    marker.style.top = `${topFix + yPx}px`;
 
     marker.title = markerData.name;
     marker.dataset.index = index;
@@ -1041,7 +1050,7 @@ function createMarkerElement(markerData, index) {
 }
 
 function renderMarkers() {
-    if (infiniteScroll) return;
+    if (infiniteScroll || fscreen.inFullscreen()) return;
     // Clean markers
     const existing = document.querySelectorAll(".marker");
     existing.forEach(el => el.remove());

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -224,8 +224,8 @@ export function initializeAll(trackProgressLocally, authenticateProgress) {
                 const { arcId, localPage } = getArchiveForPage(page);
                 Server.callAPI(`/api/archives/${arcId}/stamps/${localPage}?position=${markerData.x},${markerData.y}&content=${result.value}`, "PUT", null, I18N.StampError,
                     (data) => {
-                        if (["error", "errors"].some(prop => Object.hasOwn(data, prop))) {
-                            LRR.showErrorToast(I18N.StampError, data.error ?? "Authentication required."); // If OpenAPI returns its own responses for other cases, then this will not be correct.
+                        if (Object.hasOwn(data, "errors")) {
+                            LRR.showErrorToast(I18N.StampError, "Authentication required."); // If OpenAPI returns its own responses for other cases, then this will not be exact.
                             return;
                         }
 

--- a/tools/openapi.yaml
+++ b/tools/openapi.yaml
@@ -1855,7 +1855,7 @@ paths:
     get:
       operationId: stampedPages
       x-mojo-to: api-stamp#get_stamped_pages
-      summary: 🔑 Get pages that contain at least one stamp in the archive
+      summary: Get pages that contain at least one stamp in the archive
       description: Get pages that contain at least one stamp in the archive.
       tags:
         - stamps
@@ -1883,7 +1883,7 @@ paths:
     get:
       operationId: stampsByPage
       x-mojo-to: api-stamp#get_stamps_by_page
-      summary: 🔑 Get the stamps linked to the page
+      summary: Get the stamps linked to the page
       description: Get the stamps linked to the page.
       tags:
         - stamps


### PR DESCRIPTION
This is just a provisional PR, so I don't forget the required changes needed to fix #1586  , #1587 , and #1588 . This could either be merged now, or we could wait until the reader modernization PRs merge, so this gets reworked on the new style. Either way is ok with me.

While working on this I also met with a behavioral error with server.callAPI, where this fail safe for unauthorized calls, because OpenAPI returns an error response that is not caught in said function, hence leading to make an error look like a correct response. I did not do anything in this PR to fix that function, since is a shared function for multiple type of responses, hence it should be looked more deeply. In the meantime, I just added a workaround to my use of said function, although is not the most beautiful solution.