### PR TITLE
Disable vips cache and add poppler dependency to windows

### DIFF
--- a/lib/LANraragi/Utils/Vips.pm
+++ b/lib/LANraragi/Utils/Vips.pm
@@ -66,6 +66,7 @@ if ($VIPS_LOADED) {
     $vips_ffi->attach( vips_init => ['string'] => 'int' );
     $vips_ffi->attach( vips_error_buffer => [] => 'string' );
     $vips_ffi->attach( vips_error_clear => [] => 'void' );
+    $vips_ffi->attach( vips_cache_set_max => ['int'] => 'void' );;
     $vips_ffi->attach( vips_image_new_from_file => ['string'] => ['opaque'] => 'VipsImage' );
     $vips_ffi->attach( vips_resize => ['VipsImage', 'VipsImage*', 'double'] => ['opaque'] => 'int' );
     $vips_ffi->attach( vips_jpegsave => ['VipsImage', 'string'] => ['opaque'] => 'int' );
@@ -87,6 +88,7 @@ if ($VIPS_LOADED) {
     *vips_init = sub { die "libvips is not loaded. Cannot call vips_init." };
     *vips_error_buffer = sub { die "libvips is not loaded. Cannot call vips_error_buffer." };
     *vips_error_clear = sub { die "libvips is not loaded. Cannot call vips_error_clear." };
+    *vips_cache_set_max = sub { die "libvips is not loaded. Cannot call vips_cache_set_max." };
     *vips_image_new_from_file = sub { die "libvips is not loaded. Cannot call vips_image_new_from_file." };
     *vips_jpegsave = sub { die "libvips is not loaded. Cannot call vips_jpegsave." };
     *vips_image_write_to_buffer = sub { die "libvips is not loaded. Cannot call vips_image_write_to_buffer." };
@@ -122,6 +124,7 @@ sub init ($program_name) {
         my $ret = vips_init($program_name);
         die "Error initializing libvips: ".fetch_and_clear_error() if $ret != 0;
         $initialized = 1;
+        vips_cache_set_max(0); # Disable cache
     }
     return 1;
 }

--- a/tools/build/windows/create-dist.sh
+++ b/tools/build/windows/create-dist.sh
@@ -25,7 +25,6 @@ find ./win-dist/runtime/lib/ImageMagick-7.1.2/ -name "*.a" -type f -delete
 cp -R /ucrt64/lib/vips-modules-8.18 ./win-dist/runtime/lib
 
 # Remove unused vips modules
-rm ./win-dist/runtime/lib/vips-modules-8.18/vips-poppler.dll
 rm ./win-dist/runtime/lib/vips-modules-8.18/vips-openslide.dll
 
 # Copy more openssl stuff

--- a/tools/build/windows/install-deps.sh
+++ b/tools/build/windows/install-deps.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Install deps that will persist into the vfs
-pacman --needed -S mingw-w64-ucrt-x86_64-perl mingw-w64-ucrt-x86_64-perl-win32-api mingw-w64-ucrt-x86_64-openssl mingw-w64-ucrt-x86_64-imagemagick mingw-w64-ucrt-x86_64-libjxl mingw-w64-ucrt-x86_64-libheif mingw-w64-ucrt-x86_64-zlib mingw-w64-ucrt-x86_64-lzo2 mingw-w64-ucrt-x86_64-libarchive mingw-w64-ucrt-x86_64-ca-certificates mingw-w64-ucrt-x86_64-libvips libxcrypt unzip --noconfirm
+pacman --needed -S mingw-w64-ucrt-x86_64-perl mingw-w64-ucrt-x86_64-perl-win32-api mingw-w64-ucrt-x86_64-openssl mingw-w64-ucrt-x86_64-imagemagick mingw-w64-ucrt-x86_64-libjxl mingw-w64-ucrt-x86_64-libheif mingw-w64-ucrt-x86_64-zlib mingw-w64-ucrt-x86_64-lzo2 mingw-w64-ucrt-x86_64-libarchive mingw-w64-ucrt-x86_64-ca-certificates mingw-w64-ucrt-x86_64-libvips mingw-w64-ucrt-x86_64-poppler libxcrypt unzip --noconfirm
 
 # Install temporary deps for compilation
 pacman --needed -S mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-make make mingw-w64-ucrt-x86_64-diffutils libbz2-devel patch mingw-w64-ucrt-x86_64-nodejs mingw-w64-ucrt-x86_64-tools --noconfirm


### PR DESCRIPTION
The cache is not useful in this case because it is kept per-processes and only used with PDFs. From testing it can peak at around 2.5gb per process and it will not go down unless there is enough variance in files to flush what is being kept in memory.