### PR TITLE
Build stability fixes

### DIFF
--- a/tools/build/docker/Dockerfile
+++ b/tools/build/docker/Dockerfile
@@ -80,6 +80,8 @@ RUN apk add --no-cache \
     perl-dev \
     libarchive-dev \
     linux-headers \
+    libffi-dev \
+    pkgconf \
     patch \
     perl-config-autoconf
 

--- a/tools/build/docker/install-perl-deps.sh
+++ b/tools/build/docker/install-perl-deps.sh
@@ -25,7 +25,7 @@ cd ../ && rm -rf Crypt-DES-2.07
 cpanm --notest ETHER/Net-IDN-Encode-2.501-TRIAL.tar.gz
 
 # Install the LRR dependencies proper
-cpanm --notest --installdeps .
+cpanm --notest --installdeps . --configure-timeout 300
 
 cd ..
 


### PR DESCRIPTION
This improves build stability in two ways:

Firstly, it installs libffi-dev AND pkg-config. Without these packages, Platypus builds Alien::FFI which in turn downloads/builds libffi. There have been failures here, so bypassing that entirely should be a net win.

Secondly, it bumps up the default timeout on configure steps. Truly potato devices (such as my original RPi  model B+) can struggle with this for some packages.