### PR TITLE
Fix OpenAPI validation error if tags are undefined

### DIFF
--- a/lib/LANraragi/Utils/Database.pm
+++ b/lib/LANraragi/Utils/Database.pm
@@ -275,7 +275,7 @@ sub build_json ( $id, %hash ) {
         arcid        => $id,
         title        => $title,
         filename     => $name,
-        tags         => $tags,
+        tags         => $tags // "",
         summary      => $summary,
         isnew        => $isnew ? $isnew : "false",
         extension    => lc( ( split( /\./, $file ) )[-1] ),


### PR DESCRIPTION
I started beating up my dev environment a bit, and ended up with `/api/archives` erroring out with `{"errors":[{"message":"Expected string - got null.","path":"\/body\/1922\/tags"}],"status":500}`.

This PR prevents this by ensuring that tags are set to an empty string if undefined for any reason.