### PR TITLE
Manga/comic support concept PR

### DIFF
--- a/lib/LANraragi.pm
+++ b/lib/LANraragi.pm
@@ -13,7 +13,7 @@ use Config;
 use URI::Escape;
 use Time::HiRes qw(gettimeofday);
 
-use LANraragi::Utils::Generic    qw(start_shinobu start_minion get_version);
+use LANraragi::Utils::Generic    qw(start_tsubasa start_shinobu start_minion get_version);
 use LANraragi::Utils::Logging    qw(get_logger get_logdir);
 use LANraragi::Utils::Plugins    qw(get_plugins);
 use LANraragi::Utils::TempFolder qw(get_temp);
@@ -194,6 +194,12 @@ sub startup {
         shutdown_from_pid( get_temp . "/shinobu.pid" );
     }
     start_shinobu($self);
+
+    # Start File Watcher
+    if ( IS_UNIX ) {
+        shutdown_from_pid( get_temp . "/tsubasa.pid" );
+    }
+    start_tsubasa($self);
 
     # Check if this is a first-time installation.
     first_install_actions();

--- a/lib/LANraragi/Utils/Database.pm
+++ b/lib/LANraragi/Utils/Database.pm
@@ -31,7 +31,7 @@ use Exporter 'import';
 our @EXPORT_OK = qw(
   invalidate_cache compute_id change_archive_id set_tags set_title set_summary set_isnew get_computed_tagrules save_computed_tagrules get_tankoubons_by_file update_indexes
   get_archive get_archive_json get_archive_json_multi get_tags get_arcsize add_arcsize add_pagecount add_timestamp_tag add_archive_to_redis
-  redis_decode redis_encode
+  redis_decode redis_encode add_chapter_to_redis set_pagecount
 );
 
 # Creates a DB entry for a file path with the given ID.
@@ -664,6 +664,48 @@ sub add_arcsize ( $redis, $id ) {
 
 sub get_arcsize ( $redis, $id ) {
     return $redis->hget( $id, "arcsize" );
+}
+
+# Creates a DB entry for a file path with the given ID.
+# This function doesn't actually require the file to exist at its given location.
+sub add_chapter_to_redis ( $id, $chapter, $redis, $redis_search ) {
+
+    my $logger = get_logger( "Manga", "lanraragi" );
+    my ( $name, $path ) = fileparse( $chapter, qr/\.[^.]*/ );
+
+    # Initialize Redis hash for the added file
+    $logger->debug("Pushing to redis on ID $id:");
+    $logger->debug("File Name: $name");
+    $logger->debug("Filesystem Path: $chapter");
+
+    $redis->hset( $id, "name",    LANraragi::Utils::Redis::redis_encode($name) );
+    $redis->hset( $id, "tags",    "" );
+    $redis->hset( $id, "summary", "" );
+
+    $redis->hset( $id, "arcsize", "0" );
+
+    # Don't encode filenames.
+    $redis->hset( $id, "file", $chapter );
+
+    # Set title so that index is updated
+    # Throw a decode in there just in case the filename is already UTF8
+    #set_title( $id, LANraragi::Utils::Redis::redis_decode($name) );
+    $redis->hset( $id, "title", LANraragi::Utils::Redis::redis_encode($name) );
+
+    # New chapters by default live inside a Tank.
+    #$redis_search->sadd( "LRR_TANKGROUPED", $id );
+
+    # New file in collection, so this flag is set.
+    set_isnew( $id, "true" );
+
+    return $name;
+}
+
+sub set_pagecount ( $redis, $id, $pages ) {
+
+    my $logger = get_logger( "Manga", "lanraragi" );
+
+    $redis->hset( $id, "pagecount", $pages );
 }
 
 # DEPRECATED - Please use LANraragi::Utils::Redis::redis_decode instead, this function will be removed at some point

--- a/lib/LANraragi/Utils/Generic.pm
+++ b/lib/LANraragi/Utils/Generic.pm
@@ -31,7 +31,7 @@ BEGIN {
 
 # Generic Utility Functions.
 use Exporter 'import';
-our @EXPORT_OK = qw(is_image is_archive render_api_response get_tag_with_namespace shasum_str start_shinobu
+our @EXPORT_OK = qw(is_image is_archive is_chapter render_api_response get_tag_with_namespace shasum_str start_shinobu start_tsubasa
   split_workload_by_cpu start_minion get_css_list generate_themes_header flat get_bytelength array_difference
   intersect_arrays filter_hash_by_keys exec_with_lock exec_with_lock_pure generate_css_detail get_version get_item_title);
 
@@ -47,6 +47,10 @@ sub is_image {
 # Checks if the provided file is an archive.
 sub is_archive {
     return $_[0] =~ /^.+\.(?:zip|rar|7z|tar|tar\.gz|lzma|xz|cbz|cbr|cb7|cbt|pdf|epub|tar\.zst|zst)$/i;
+}
+
+sub is_chapter {
+    return $_[0] =~ /^.+\/chapter[^\/]+$/i;
 }
 
 # Returns a human-readable title for the given ID (archive or tank).
@@ -184,6 +188,32 @@ sub start_shinobu {
         print $fh $proc->GetProcessID();
         close($fh);
         $mojo->LRR_LOGGER->debug( "Shinobu Worker new PID is " . $proc->GetProcessID() );
+        return $proc;
+    }
+}
+
+sub start_tsubasa {
+    my $mojo = shift;
+    if (IS_UNIX) {
+        my $proc = Proc::Simple->new();
+        $proc->start( $^X, "./lib/Tsubasa.pm" );
+        $proc->kill_on_destroy(0);
+
+        $mojo->LRR_LOGGER->debug( "Tsubasa Worker new PID is " . $proc->pid );
+
+        # Freeze the process object in the PID file
+        store \$proc, get_temp() . "/tsubasa.pid";
+        open( my $fh, ">", get_temp() . "/tsubasa.pid-s6" );
+        print $fh $proc->pid;
+        close($fh);
+        return $proc;
+    } else {
+        my $proc;
+        Win32::Process::Create( $proc, undef, "perl \"" . abs_path(".") . "/lib/Tsubasa.pm\"", 0, NORMAL_PRIORITY_CLASS, "." );
+        open( my $fh, ">", get_temp() . "/tsubasa.pid-s6" );
+        print $fh $proc->GetProcessID();
+        close($fh);
+        $mojo->LRR_LOGGER->debug( "Tsubasa Worker new PID is " . $proc->GetProcessID() );
         return $proc;
     }
 }

--- a/lib/Tsubasa.pm
+++ b/lib/Tsubasa.pm
@@ -1,4 +1,4 @@
-package Shinobu;
+package Tsubasa;
 
 # LANraragi File Watcher.
 #  Uses inotify watches to keep track of filesystem happenings.
@@ -28,25 +28,28 @@ BEGIN { unshift @INC, "$FindBin::Bin/../lib"; }
 use Mojolicious;    # Needed by Model::Config to read the Redis address/port.
 use File::ChangeNotify;
 use File::Basename;
+use File::Spec;
 use Encode;
+use UUID::Tiny ':std';
+use Unicode::Normalize qw(NFC);
 
 use LANraragi::Utils::Archive    qw(extract_thumbnail);
-use LANraragi::Utils::Database   qw(invalidate_cache compute_id change_archive_id get_arcsize add_timestamp_tag add_archive_to_redis add_arcsize add_pagecount);
+use LANraragi::Utils::Database   qw(invalidate_cache compute_id change_archive_id get_arcsize add_timestamp_tag add_archive_to_redis add_arcsize add_pagecount add_chapter_to_redis set_pagecount);
 use LANraragi::Utils::Logging    qw(get_logger);
-use LANraragi::Utils::Generic    qw(is_archive exec_with_lock_pure);
+use LANraragi::Utils::Generic    qw(is_image is_chapter exec_with_lock_pure);
 use LANraragi::Utils::Redis      qw(redis_encode);
 use LANraragi::Utils::Path       qw(create_path open_path find_path get_archive_path);
 
 use LANraragi::Model::Config;
 use LANraragi::Model::Plugins;
 use LANraragi::Model::Metrics;
-use LANraragi::Utils::Plugins;    # Needed here since Shinobu doesn't inherit from the main LRR package
+use LANraragi::Utils::Plugins;    # Needed here since Tsubasa doesn't inherit from the main LRR package
 use LANraragi::Model::Search;     # idem
 
 use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );
 
 # Logger and Database objects
-my $logger = get_logger( "Shinobu", "shinobu" );
+my $logger = get_logger( "Tsubasa", "tsubasa" );
 
 #Subroutine for new and deleted files that takes inotify events
 my $inotifysub = sub {
@@ -76,50 +79,105 @@ sub initialize_from_new_process {
     my $userdir = LANraragi::Model::Config->get_userdir;
     my $metrics_enabled = LANraragi::Model::Config->enable_metrics;
 
-    $logger->info("Shinobu File Watcher started.");
+    $logger->info("Tsubasa File Watcher started.");
     $logger->info("Content folder is $userdir.");
 
-    update_filemap();
-    $logger->info("Initial scan complete! Adding watcher to content folder to monitor for further file edits.");
+    my $local_folder_exists = check_local_folder($userdir, "local");
 
-    # Add watcher to content directory
-    my $contentwatcher = File::ChangeNotify->instantiate_watcher(
-        directories     => [$userdir],
-        filter          => qr/\.(?:zip|rar|7z|tar|tar\.gz|lzma|xz|cbz|cbr|cb7|cbt|pdf|epub|tar\.zst|zst)$/i,
-        follow_symlinks => 1,
-        exclude         => [ 'thumb', '.', 'local' ],                                                                   #excluded subdirs
+    if ( $local_folder_exists ) {
+        update_filemap();
+    } else {
+        $logger->info("Folder doesn't exist");
+    }
+
+    #update_filemap();
+    #$logger->info("Initial scan complete! Adding watcher to content folder to monitor for further file edits.");
+}
+
+sub check_local_folder ( $path, $folder_name ) {
+    # Verify the base path is a directory
+    return 0 unless defined $path && -d $path;
+
+    opendir(my $dh, $path)
+        or return 0;
+
+    while (my $entry = readdir($dh)) {
+        next if $entry eq '.' || $entry eq '..';
+
+        if ($entry eq $folder_name && -d "$path/$entry") {
+            closedir($dh);
+            return 1;
+        }
+    }
+
+    closedir($dh);
+    return 0;
+}
+
+sub count_files ($path) {
+    return 0 unless defined $path && -d $path;
+
+    opendir(my $dh, $path)
+        or return 0;
+
+    my $count = 0;
+
+    while (my $entry = readdir($dh)) {
+        next if $entry eq '.' || $entry eq '..';
+
+        my $full_path = "$path/$entry";
+        $count++ if -f $full_path;
+    }
+
+    closedir($dh);
+
+    return $count;
+}
+
+sub get_manga_identifiers ( $path ) {
+    my $dirname = LANraragi::Model::Config->get_userdir . "/local";
+    $path =~ s/$dirname//;
+
+    my @parts = File::Spec->splitdir(
+        File::Spec->canonpath($path)
     );
+    my $depth = scalar @parts;
 
-    my $class = ref($contentwatcher);
-    $logger->debug("Watcher class is $class");
-
-    # manual event loop
-    $logger->info("All done! Now dutifully watching your files. ");
-
-    my $running = 1;
-    my $metrics_counter = 0;
-
-    while ($running) {
-        local $SIG{INT} = sub { $running = 0 };
-
-        # Check events on files
-        for my $event ( $contentwatcher->new_events ) {
-            $inotifysub->($event);
-        }
-
-        # Collect metrics every 30 seconds (30 * 1 second intervals)
-        if ( $metrics_enabled && ++$metrics_counter >= 30 ) {
-            LANraragi::Model::Metrics::collect_process_metrics( "shinobu" );
-            $metrics_counter = 0;
-        }
-
-        sleep 1;
+    if ( $depth == 3 ) {
+        return (1, $parts[1], $parts[2]);
+    } else {
+        return (0, "", "");
     }
+}
 
-    if ( !IS_UNIX ) {
-        # Cleanly shutdown filewatcher
-        $contentwatcher->dispose;
+sub get_random_UUID ( $prefix=undef ) {
+    my $v4_rand_UUID_2  = create_uuid(UUID_RANDOM);
+    my $str_appendix = uuid_to_string($v4_rand_UUID_2);
+
+    if ( defined($prefix) ) {
+        return $prefix . "_" . $str_appendix;
+    } else {
+        return $str_appendix;
     }
+}
+
+sub print_files(@files) {
+    my $remove = LANraragi::Model::Config->get_userdir . "/local/";
+    foreach my $file (@files) {
+        $file =~ s/$remove//; 
+        $logger->info("$file");
+    }
+}
+
+sub is_second_level( $file, $remove ) {
+    $file =~ s/$remove//;
+
+    my @parts = File::Spec->splitdir(
+        File::Spec->canonpath($file)
+    );
+    my $depth = scalar @parts;
+
+    return $depth == 3
 }
 
 # Update the filemap. This acts as a masterlist of what's in the content directory.
@@ -130,22 +188,24 @@ sub update_filemap {
     my $redis = LANraragi::Model::Config->get_redis_config;
 
     # Clear hash
-    my $dirname = LANraragi::Model::Config->get_userdir;
+    my $dirname = LANraragi::Model::Config->get_userdir . "/local";
     my @files;
 
     # Get all files in content directory and subdirectories.
     find_path(
         sub {
             $_ = create_path($_);
-            return if -d $_;    #Directories are excluded on the spot
-            return unless is_archive($_);
+            return unless is_chapter($_);
+            return unless is_second_level($_, $dirname);
             push @files, $_;    #Push files to array
         },
         $dirname
     );
 
+    print_files(@files);
+
     # Cross-check with filemap to get recorded files that aren't on the FS, and new files that aren't recorded.
-    my @filemapfiles = $redis->exists("LRR_FILEMAP") ? $redis->hkeys("LRR_FILEMAP") : ();
+    my @filemapfiles = $redis->exists("LRR_LOCALFILEMAP") ? $redis->hkeys("LRR_LOCALFILEMAP") : ();
 
     my %filemaphash = map { $_ => 1 } @filemapfiles;
     my %fshash      = map { $_ => 1 } @files;
@@ -159,7 +219,7 @@ sub update_filemap {
     # Delete old files from filemap
     foreach my $deletedfile (@deletedfiles) {
         $logger->debug("Removing $deletedfile from filemap.");
-        $redis->hdel( "LRR_FILEMAP", $deletedfile ) || $logger->warn("Couldn't delete previous filemap data.");
+        $redis->hdel( "LRR_LOCALFILEMAP", $deletedfile ) || $logger->warn("Couldn't delete previous filemap data.");
     }
 
     $redis->quit();
@@ -182,64 +242,39 @@ sub update_filemap {
     }
 }
 
-sub add_to_filemap ( $redis_cfg, $file ) {
+sub add_to_filemap ( $redis_cfg, $chapter, $manga_id ) {
 
     my $redis_arc = LANraragi::Model::Config->get_redis;
-    if ( is_archive($file) ) {
+    if ( is_chapter($chapter) ) {
 
-        $logger->debug("Adding $file to Shinobu filemap.");
-
-        #Freshly created files might not be complete yet.
-        #We have to wait before doing any form of calculation.
-        while (1) {
-            last unless -e $file;    # Sanity check to avoid sticking in this loop if the file disappears
-            last if open_path( my $handle, '<', $file );
-            $logger->debug("Waiting for file to be openable");
-            sleep(1);
-        }
-
-        # Wait for file to be more than 512 KBs or bailout after 5s and assume that file is smaller
-        my $cnt = 0;
-        while (1) {
-            last if ( ( ( -s $file ) >= 512000 ) || $cnt >= 5 );
-            $logger->debug("Waiting for file to be fully written");
-            sleep(1);
-            $cnt++;
-        }
+        $logger->debug("Adding $chapter to Tsubasa filemap.");
 
         #Compute the ID of the archive and add it to the hash
-        my $id = "";
-        eval { $id = compute_id($file); };
-        my $compute_error = $@;
-
-        if ($compute_error && -e $file) {
-            $logger->error("Couldn't open $file for ID computation: $compute_error");
-            $logger->error("Giving up on adding it to the filemap.");
-            return;
-        } elsif ($compute_error) {
-            $logger->warn("File $file no longer exists; giving up on adding it to the filemap.");
-            return;
-        }
+        # TODO: Check if folder has an LRR.json with the ID, otherwise create a new ID.
+        my $chapter_id = get_random_UUID("CHAPTER");
+        # Add the id to the folder as a LRR.json
 
         # Acquire exclusive metadata and file write access for archive by ID with 1m timeout
         my ($acquired, $is_new) = exec_with_lock_pure(
-            [ "archive-write:$id" ],
-            sub { update_filemap_entry( $logger, $id, $file, $redis_cfg, $redis_arc ) },
+            [ "archive-write:$chapter_id" ],
+            sub { update_filemap_entry( $logger, $chapter_id, $chapter, $redis_cfg, $redis_arc ) },
             undef, 60
         );
 
         if ( !$acquired ) {
-            $logger->warn("Write lock already acquired for archive $file with ID $id, skipping.");
+            $logger->warn("Write lock already acquired for archive $chapter with ID $chapter_id, skipping.");
         }
 
         # New file handling runs outside the lock so auto-plugin can acquire its own lock.
         if ( $acquired && $is_new ) {
-            add_new_file( $id, $file );
+            add_new_file( $chapter_id, $chapter );
             invalidate_cache();
         }
 
+        # Add Chapter to the manga Tank
+
     } else {
-        $logger->debug("$file not recognized as archive, skipping.");
+        $logger->debug("$chapter not recognized as archive, skipping.");
     }
     $redis_arc->quit;
 }
@@ -249,14 +284,14 @@ sub update_filemap_entry ( $logger, $id, $file, $redis_cfg, $redis_arc ) {
     $logger->debug("Computed ID is $id.");
     unless ( -e $file ) {
         # A race condition check, if the file was deleted after ID computation but before a lock was acquired.
-        $logger->warn("File does not exist; giving up on adding it to the filemap: $file");
+        $logger->warn("Folder does not exist; giving up on adding it to the filemap: $file");
         return;
     }
 
     # If the id already exists on the server, throw a warning about duplicates
-    if ( $redis_cfg->hexists( "LRR_FILEMAP", $file ) ) {
+    if ( $redis_cfg->hexists( "LRR_LOCALFILEMAP", $file ) ) {
 
-        my $filemap_id = $redis_cfg->hget( "LRR_FILEMAP", $file );
+        my $filemap_id = $redis_cfg->hget( "LRR_LOCALFILEMAP", $file );
 
         $logger->debug("$file was logged but is already in the filemap!");
 
@@ -266,12 +301,14 @@ sub update_filemap_entry ( $logger, $id, $file, $redis_cfg, $redis_arc ) {
 
             # Note: The logic here is technically different than the one in Upload.pm.
             # Upload.pm checks replace_duplicates and wipes the previous ID/metadata. 
-            # Shinobu just updates the ID in the database and leaves the old metadata in place.
+            # Tsubasa just updates the ID in the database and leaves the old metadata in place.
             # There's no way to assess user intent just from a filewatcher though, so we act non-destructively.
-            change_archive_id( $filemap_id, $id );
+            # -------------------------------------------------------------------------------
+            # change_chapter_id( $filemap_id, $id );
+            # -------------------------------------------------------------------------------
 
             # Don't forget to update the filemap, later operations will behave incorrectly otherwise
-            $redis_cfg->hset( "LRR_FILEMAP", $file, $id );
+            $redis_cfg->hset( "LRR_LOCALFILEMAP", $file, $id );
         } else {
             $logger->debug(
                 "$file has the same ID as the one in the filemap. Duplicate inotify events? Cleaning cache just to make sure");
@@ -281,7 +318,7 @@ sub update_filemap_entry ( $logger, $id, $file, $redis_cfg, $redis_arc ) {
         return;
 
     } else {
-        $redis_cfg->hset( "LRR_FILEMAP", $file, $id );    # raw FS path so no encoding/decoding whatsoever
+        $redis_cfg->hset( "LRR_LOCALFILEMAP", $file, $id );    # raw FS path so no encoding/decoding whatsoever
     }
 
     # Filename sanity check
@@ -302,15 +339,11 @@ sub update_filemap_entry ( $logger, $id, $file, $redis_cfg, $redis_arc ) {
             invalidate_cache();
         }
 
-        unless ( get_arcsize( $redis_arc, $id ) ) {
-            $logger->debug("arcsize is not set for $id, storing now!");
-            add_arcsize( $redis_arc, $id );
-        }
-
         # Set pagecount in case it's not already there
         unless ( $redis_arc->hget( $id, "pagecount" ) ) {
             $logger->debug("Pagecount not calculated for $id, doing it now!");
-            add_pagecount( $redis_arc, $id );
+            my $num_files = count_files($file);
+            set_pagecount( $redis_arc, $id, $num_files );
         }
 
     } else {
@@ -349,7 +382,7 @@ sub deleted_file_callback ($name) {
         my $redis = LANraragi::Model::Config->get_redis_config;
 
         # Prune file from filemap
-        $redis->hdel( "LRR_FILEMAP", $name );
+        $redis->hdel( "LRR_LOCALFILEMAP", $name );
 
         eval { invalidate_cache(); };
 
@@ -359,12 +392,26 @@ sub deleted_file_callback ($name) {
 
 sub add_new_files (@files) {
     my $redis = LANraragi::Model::Config->get_redis_config;
+    my $current_manga = "";
 
     foreach my $file (@files) {
         $logger->debug("Processing $file");
 
+        my ( $found, $name, $chapter ) = get_manga_identifiers( $file );
+        my $manga_id;
+
+        if ($name ne $current_manga) {
+            # TODO: Check if folder has an LRR.json with the ID, otherwise create a new ID.
+
+            $manga_id = get_random_UUID("MANGA");
+
+            # Validate if the ID exists in the DB, otherwise create a new "Tank"
+
+            # Add the id to the folder as an LRR.json
+        }
+
         # Individual files are also eval'd so we can keep scanning
-        eval { add_to_filemap( $redis, $file ); };
+        eval { add_to_filemap( $redis, $file, $manga_id ); };
 
         if ($@) {
             $logger->error("Error scanning $file: $@");
@@ -382,16 +429,17 @@ sub add_new_file ( $id, $file ) {
     $logger->info("Adding new file $file with ID $id");
 
     eval {
-        add_archive_to_redis( $id, $file, $redis, $redis_search );
+        add_chapter_to_redis( $id, $file, $redis, $redis_search );
         add_timestamp_tag( $redis, $id );
-        add_pagecount( $redis, $id );
+        my $num_files = count_files($file);
+        set_pagecount( $redis, $id, $num_files );
 
         # Generate thumbnail
-        my $thumbdir = LANraragi::Model::Config->get_thumbdir;
-        extract_thumbnail( $thumbdir, $id, 1, 1, 1 );
+        # Same idea as archives thumbnail, but we can skip uncompress step.
+        #my $thumbdir = LANraragi::Model::Config->get_thumbdir;
+        #extract_thumbnail( $thumbdir, $id, 1, 1, 1 );
 
-        # AutoTagging using enabled plugins goes here!
-        LANraragi::Model::Plugins::exec_enabled_plugins_on_file($id);
+        # No plugins compatible
     };
 
     if ($@) {

--- a/tools/cpanfile
+++ b/tools/cpanfile
@@ -57,6 +57,9 @@ requires 'MCE::Shared',        1.893;
 requires 'Sys::CpuAffinity',   1.12;
 requires 'File::ChangeNotify', 0.31;
 
+# Background Worker (Tsubasa)
+requires 'UUID::Tiny',  1.04;
+
 # Plugin system
 requires 'Module::Pluggable', 5.2;
 


### PR DESCRIPTION
This is a simple PR to present a possible integration of uncompressed, ongoing type of comics. The idea behind this is that there are some cases that are not covered by the current archive and tanks, like ongoing comic and mangas, that might require to add new files every week/2 weeks/month, but you don't want to either add new zips, that later you have to manually add to a Tank to group them, nor add more files to an existent file, just for the first KBs to be modified, and the metadata to be erased. What this feature attempts is to provide a self organizing tool, that is idempotent to adding new files to it, and also doesn't spam the search results if you added a manga with a 1000 chapters.

For the base design, I'm using Tachiyomi/Mihon local source as the inspiration. Here we have a local folder, ignored by Shinobu, where the user has to follow a structure like:

<img width="316" height="299" alt="image" src="https://github.com/user-attachments/assets/c49d4957-d9b5-4961-af64-c02cf1a1c9c8" />

Then we would have a new Minion that goes through this structure and creates the files and tanks on the DB. I'm using a new minion for this, because it has a slightly different logic than Shinobu, so better not try to mess the logic there, and since this workflow would only work if the local folder exists, then this second minion would be able to sleep if said folder does not exist on the content dir, otherwise it would work as a File Watcher, that only reacts when a new chapter folder gets added to add new entries to the DB, when you add a new image file, it would only update the pagecount of its parent file.

<img width="1165" height="230" alt="image" src="https://github.com/user-attachments/assets/753b2b9c-a25f-48a7-9958-d7f10abfd0e9" />

The most problematic part is how to create IDs for folders, that can be regenerated between all devices without anything to hash, which is basically impossible, so I gave up on that idea, and though of something else. This instead creates a UUID for each folder, and then saves it inside inside a LRR.json(Yet to add to the code), which then, if you decide to move your LRR installation from a Windows computer to a Linux one, with a different encoding, then there would not be a problem, because the JSON will remain utf8 encoded, so you can load the ID from there, and assign the already existent object in the DB to the new folder path; this also works for renaming the folder. The exact same logic applies for the chapters and their IDs.

While I mentioned that that these create archives and tanks, I want to clarify that these are not the same Archive and Tankoubon objects, but new hash tables that will share the same structure, for the purpose of being compatibles with some of the fetch endpoints for search and reader, but by itself these should not be compatible with other tools for management, since the minion should be the main path to manage the files and chapters, based on the file structure. In other words, these would be compatible with the structure response of the GETs for Archive and Tanks(But for a few differences, like there being no need to uncompress the file first, since it'd already be), so the already existent interfaces from the Frontend can be reused, but will require their own management endpoints, being the minion the main tool to maintain them(Chapters also won't be possible to be obtained from the search, since they won't be added to either the archive cache, nor be separated from their Tank, only the tank will be added to the search like the original tanks do).

<img width="477" height="597" alt="image" src="https://github.com/user-attachments/assets/7b85eb08-b9db-414f-b8e0-4ea29e167781" />

This is a simple example PR, nothing works yet, basically this only provides the minion to explore the file structure, and create the chapter objects(Haven't added the manga tanks), but wanted to present it to get opinions about if this is worth to give a shot, because if I continue, it will definitely be a lot of work to do(And probably will separate in multiple PR, with this only providing the new Minion). If this sounds too complex, or doesn't fit with the platform, then it would be better to know now so I don't continue working on it.

PS: This refers to uncompressed folder, but has the potential to be extended with compressed cbz/zip idempotent chapter files in the future... But that is outside this original concept.