### PR TITLE
Fix errors on index page due to tanks

### DIFF
--- a/public/js/mod/index_contextmenu.js
+++ b/public/js/mod/index_contextmenu.js
@@ -245,11 +245,13 @@ export function initialize(catListData) {
                         name: I18N.Delete,
                         icon: "fas fa-trash-alt"
                     },
-                    "rating": {
-                        "name": I18N.AddRating,
-                        "icon": "fas fa-star",
-                        "items": loadContextMenuRatings(id)
-                    },
+                    ...(!isTankoubon ? {
+                        "rating": {
+                            "name": I18N.AddRating,
+                            "icon": "fas fa-star",
+                            "items": loadContextMenuRatings(id)
+                        }
+                    } : {}),
                     "collections": {
                         "name": I18N.AddToCategory,
                         "icon": "fas fa-search-plus",

--- a/tools/openapi.yaml
+++ b/tools/openapi.yaml
@@ -1228,8 +1228,13 @@ paths:
           description: ID of the Archive to process.
           schema:
             type: string
-            minLength: 40
-            maxLength: 40
+            oneOf:
+              - minLength: 40
+                maxLength: 40
+                pattern: "^[0-9a-f]{40}$"
+              - minLength: 15
+                maxLength: 15
+                pattern: "^TANK_[0-9]{10}$"
       responses:
         '200':
           description: Archive categories
@@ -4418,8 +4423,13 @@ components:
           description: Array of archive IDs (if this is a static category, empty otherwise)
           items:
             type: string
-            minLength: 40
-            maxLength: 40
+            oneOf:
+              - minLength: 40
+                maxLength: 40
+                pattern: "^[0-9a-f]{40}$"
+              - minLength: 15
+                maxLength: 15
+                pattern: "^TANK_[0-9]{10}$"
         id:
           type: string
           description: ID of the category


### PR DESCRIPTION
Fixes the following regarding tanks:
* Rating subsection in context menu triggering an error toast.
* Add to category triggering an error toast.
* Carousel error when a tank appeared in it.