### PR TITLE
Eslint should ignore subdirectories in js/vendor

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -79,6 +79,6 @@ const config = {
 
 export default defineConfig([
     importX.flatConfigs.recommended,
-    globalIgnores(["public/js/vendor/*.js", "tests/samples/*"]),
+    globalIgnores(["public/js/vendor/**", "tests/samples/*"]),
     config,
 ]);


### PR DESCRIPTION
Right now it's not a problem, but if #1635 is merged eslint will start linting that which isn't great.