### PR TITLE
Fix partially broken multi-select mode after creating a tankoubon

### DIFF
--- a/public/js/mod/index.js
+++ b/public/js/mod/index.js
@@ -606,6 +606,9 @@ export function exitSelectionCarouselMode() {
     // Hide MSM controls
     $("#msm-carousel-controls").hide();
 
+    // Update msm flag
+    isMultiSelectMode = false;
+
     // Reload normal carousel content
     updateCarousel();
 


### PR DESCRIPTION
After creating a tank, the multi-selection mode were supposed to be closed. However, the flag was still enabled which prevented the slider from fully updating, leaving it in a "partial" multi-select mode