### PR TITLE
Update fontawesome

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.9.80",
             "license": "MIT",
             "dependencies": {
-                "@fortawesome/fontawesome-free": "6.2.1",
+                "@fortawesome/fontawesome-free": "^6.7.2",
                 "@jcubic/tagger": "0.4.2",
                 "@preact/signals": "^2.9.2",
                 "allcollapsible": "1.1.0",
@@ -187,11 +187,9 @@
             }
         },
         "node_modules/@fortawesome/fontawesome-free": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.2.1.tgz",
-            "integrity": "sha512-viouXhegu/TjkvYQoiRZK3aax69dGXxgEjpvZW81wIJdxm5Fnvp3VVIP4VHKqX4SvFw6qpmkILkD4RJWAdrt7A==",
-            "hasInstallScript": true,
-            "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
+            "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
             "engines": {
                 "node": ">=6"
             }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     },
     "homepage": "https://github.com/Difegue/LANraragi#readme",
     "dependencies": {
-        "@fortawesome/fontawesome-free": "6.2.1",
+        "@fortawesome/fontawesome-free": "^6.7.2",
         "@jcubic/tagger": "0.4.2",
         "@preact/signals": "^2.9.2",
         "allcollapsible": "1.1.0",


### PR DESCRIPTION
This fixes a ton of warnings in the console (for firefox) that looks like this:
`downloadable font: Glyph bbox was incorrect (glyph ids 5 9 10 12 13 15 16 33 49 59 60 61 72 76 81 83 84 85 88 91 92 97 101 102 103 104 106 107 109 118 120 121 122 124 134 135 136 137 139 141 143 145 146) (font-family: "Font Awesome 6 Pro" style:normal weight:300 stretch:100 src index:0) source: whatever`