### PR TITLE
carousel wait when search is not initialized

### DIFF
--- a/lib/LANraragi/Model/Search.pm
+++ b/lib/LANraragi/Model/Search.pm
@@ -30,7 +30,7 @@ sub do_search ( $filter, $category_id, $start, $sortkey, $sortorder, $newonly, $
     my $redis  = LANraragi::Model::Config->get_redis_search;
     my $logger = get_logger( "Search Engine", "lanraragi" );
 
-    unless ( $redis->exists("LAST_JOB_TIME") && ( $redis->exists("LRR_TANKGROUPED") || !$grouptanks ) ) {
+    unless ( $redis->exists("LAST_JOB_TIME") ) {
         $logger->warn("Search engine is not initialized yet. Please wait a few seconds.");
 
         # TODO - This is the only case where the API returns -1, but it's not really handled well clientside at the moment.

--- a/public/js/mod/index.js
+++ b/public/js/mod/index.js
@@ -11,12 +11,16 @@ import DOMPurify from "dompurify";
 
 export let selectedCategory = "";
 let carouselInitialized = false;
+let carouselGeneration = 0;
 let swiper = {};
 let serverVersion = "";
 let debugMode = false;
 export let pageSize = 100;
 export let isMultiSelectMode = false;
 export let selectedArchives = new Set();
+
+const CAROUSEL_RETRY_DELAY_MS = 1500;
+const CAROUSEL_MAX_RETRIES = 10;
 
 /**
  * Initialize the Archive Index.
@@ -491,24 +495,64 @@ export function updateCarousel(e) {
     }
 
     if (carouselInitialized) {
-        Server.callAPI(endpoint, "GET", null, I18N.CarouselError,
-            (results) => {
-                swiper.virtual.removeAllSlides();
-                const slides = results.data
-                    .map((archive) => LRR.buildThumbnailDiv(archive));
-                swiper.virtual.appendSlide(slides);
-                swiper.virtual.update();
-
-                if (results.data.length === 0) {
-                    $("#carousel-empty").show();
-                }
-
-                $("#carousel-loading").hide();
-                $(".swiper-wrapper").show();
-                $("#reload-carousel").removeClass("fa-spin");
-            },
-        );
+        loadCarousel(endpoint, ++carouselGeneration);
     }
+}
+
+/**
+ * Fetch and render the carousel, retry nonblock while search engine initializes
+ * @param {string} endpoint Search API endpoint for the current carousel type
+ * @param {number} generation token identifying this carousel refresh
+ */
+async function loadCarousel(endpoint, generation) {
+    try {
+        for (let attempt = 0; attempt <= CAROUSEL_MAX_RETRIES; attempt++) {
+            if (attempt > 0) {
+                await new Promise((resolve) => setTimeout(resolve, CAROUSEL_RETRY_DELAY_MS));
+            }
+
+            const response = await fetch(new LRR.ApiURL(endpoint), { method: "GET" });
+
+            // Search engine still initializing: back off and retry
+            if (response.status === 204) { continue; }
+            if (!response.ok) {
+                throw new Error(`${response.status} ${response.statusText}`);
+            }
+
+            const results = await response.json();
+            // Only render if a newer load hasn't superseded this one
+            if (generation !== carouselGeneration) { return; }
+            renderCarousel(results);
+            return;
+        }
+
+        throw new Error(`Search engine not initialized after ${CAROUSEL_MAX_RETRIES * CAROUSEL_RETRY_DELAY_MS}ms`);
+    } catch (error) {
+        if (generation !== carouselGeneration) { return; }
+        LRR.showErrorToast(I18N.CarouselError, error);
+        $("#carousel-loading").hide();
+        $("#reload-carousel").removeClass("fa-spin");
+    }
+}
+
+/**
+ * Render carousel slides from a search API result.
+ * @param {{data: Array}} results Search API response payload.
+ */
+function renderCarousel(results) {
+    swiper.virtual.removeAllSlides();
+    const slides = results.data
+        .map((archive) => LRR.buildThumbnailDiv(archive));
+    swiper.virtual.appendSlide(slides);
+    swiper.virtual.update();
+
+    if (results.data.length === 0) {
+        $("#carousel-empty").show();
+    }
+
+    $("#carousel-loading").hide();
+    $(".swiper-wrapper").show();
+    $("#reload-carousel").removeClass("fa-spin");
 }
 
 // #endregion

--- a/public/js/mod/index.js
+++ b/public/js/mod/index.js
@@ -495,7 +495,8 @@ export function updateCarousel(e) {
     }
 
     if (carouselInitialized) {
-        loadCarousel(endpoint, ++carouselGeneration);
+        carouselGeneration += 1;
+        loadCarousel(endpoint, carouselGeneration);
     }
 }
 

--- a/tests/search.t
+++ b/tests/search.t
@@ -40,6 +40,20 @@ is( $filtered, 13, qq(Empty search(full index)) );
 ( $total, $filtered, @ids ) = LANraragi::Model::Search::do_search( $search, "", 0, 0, 0, 0, 0, 0, 0 );
 is( $filtered, 13, qq(Empty search(tank grouping off)) );
 
+note('testing initialized empty index with tank grouping enabled...');
+{
+    my $redis_search = LANraragi::Model::Config->get_redis_search;
+    $redis_search->del("LRR_TANKGROUPED");
+
+    my ( $empty_total, $empty_filtered, @empty_ids ) =
+      LANraragi::Model::Search::do_search( "", "", 0, 0, 0, 0, 0, 1, 0 );
+    is( $empty_total,    0, 'empty initialized grouped search total is zero' );
+    is( $empty_filtered, 0, 'empty initialized grouped search filtered count is zero' );
+    is_deeply( \@empty_ids, [], 'empty initialized grouped search returns no ids' );
+
+    LANraragi::Model::Stats::build_stat_hashes();
+}
+
 $search = qq(Ghost in the Shell);
 do_test_search();
 is( $ids[0], "4857fd2e7c00db8b0af0337b94055d8445118630", qq(Basic search ($search)) );


### PR DESCRIPTION
carousel errors out through toast when 204 (still initializing) is received. Should wait until backend is ready