### PR TITLE
Context menu for category actions

### DIFF
--- a/locales/template/en.po
+++ b/locales/template/en.po
@@ -1471,6 +1471,33 @@ msgstr "Category deleted!"
 msgid "Error deleting category"
 msgstr "Error deleting category"
 
+msgid "Pin"
+msgstr "Pin"
+
+msgid "Unpin"
+msgstr "Unpin"
+
+msgid "Error updating category pin:"
+msgstr "Error updating category pin:"
+
+msgid "Set as Bookmark"
+msgstr "Set as Bookmark"
+
+msgid "Remove Bookmark"
+msgstr "Remove Bookmark"
+
+msgid "Category pinned!"
+msgstr "Category pinned!"
+
+msgid "Category unpinned!"
+msgstr "Category unpinned!"
+
+msgid "Bookmark category set!"
+msgstr "Bookmark category set!"
+
+msgid "Bookmark category removed!"
+msgstr "Bookmark category removed!"
+
 msgid "Writing a Predicate"
 msgstr "Writing a Predicate"
 

--- a/public/js/category.js
+++ b/public/js/category.js
@@ -101,7 +101,7 @@ Category.updateCategoryDetails = function () {
 
     document.getElementById("catname").value = category.name;
     document.getElementById("catsearch").value = category.search;
-    document.getElementById("pinned").checked = category.pinned === "1";
+    document.getElementById("pinned").checked = Number(category.pinned) === 1;
 
     if (category.search === "") {
         // Show tankoubons and archives if static and check the matching IDs

--- a/public/js/mod/common.js
+++ b/public/js/mod/common.js
@@ -545,6 +545,18 @@ export function showPopUp(c) {
     return Swal.fire(c);
 }
 
+export function showDeleteConfirmPopUp(text) {
+    return showPopUp({
+        text,
+        icon: "warning",
+        showCancelButton: true,
+        focusConfirm: false,
+        confirmButtonText: I18N.ConfirmYes,
+        reverseButtons: true,
+        confirmButtonColor: "#d33",
+    });
+}
+
 /**
  * Fires a HEAD request to get filesize of a given URL.
  * return target img size.

--- a/public/js/mod/index.js
+++ b/public/js/mod/index.js
@@ -19,6 +19,7 @@ let debugMode = false;
 export let pageSize = 100;
 export let isMultiSelectMode = false;
 export let selectedArchives = new Set();
+export const catList = [];
 
 const CAROUSEL_RETRY_DELAY_MS = 1500;
 const CAROUSEL_MAX_RETRIES = 10;
@@ -1076,14 +1077,12 @@ export function toggleCategory(button) {
     const categoryId = button.id;
     if (selectedCategory === categoryId) {
         button.classList.remove("toggled");
-        selectedCategory = "";
+        clearCategoryFilter();
     } else {
         selectedCategory = categoryId;
         button.classList.add("toggled");
+        IndexTable.doSearch();
     }
-
-    // Trigger search
-    IndexTable.doSearch();
 }
 
 /**
@@ -1117,22 +1116,17 @@ export function loadCategories() {
                 catName = LRR.encodeHTML(catName);
 
                 const div = `<div style='display:inline-block'>
-                    <input class='favtag-btn ${((category.id === selectedCategory) ? "toggled" : "")}' 
-                            type='button' id='${category.id}' value='${catName}' 
+                    <input class='favtag-btn category-context-menu ${((category.id === selectedCategory) ? "toggled" : "")}'
+                            type='button' id='${category.id}' value='${catName}'
                             onclick='window.Index.toggleCategory(this)' title='${I18N.CategoryDesc}'/>
                 </div>`;
-
-                // Take this opportunity to update the bookmark
-                if (category.id === localStorage.getItem("bookmarkCategoryId")) {
-                    localStorage.setItem("bookmarkedArchives", JSON.stringify(category.archives));
-                }
 
                 html += div;
             }
 
             // If more than 10 categories, the rest goes into a dropdown
             if (data.length > 10) {
-                html += `<select id="catdropdown" class="favtag-btn">
+                html += `<select id="catdropdown" class="favtag-btn category-context-menu">
                             <option selected disabled>...</option>`;
 
                 for (let i = 10; i < data.length; i++) {
@@ -1147,10 +1141,36 @@ export function loadCategories() {
 
             $("#category-container").html(html);
 
+            catList.length = 0;
+            for (let i = 0; i < data.length; i++) {
+                const category = data[i];
+                catList.push({ name: category.name, id: category.id, pinned: category.pinned, search: category.search });
+            }
+
+            refreshBookmarkedArchives(data);
+
             // Add a listener on dropdown selection
             $("#catdropdown").on("change", () => toggleCategory($("#catdropdown")[0].selectedOptions[0]));
         },
     );
+}
+
+function refreshBookmarkedArchives(categories) {
+    const bookmarkCategoryId = localStorage.getItem("bookmarkCategoryId");
+    if (!bookmarkCategoryId) { return; }
+
+    const bookmarked = categories.find((category) => category.id === bookmarkCategoryId);
+    if (bookmarked) {
+        localStorage.setItem("bookmarkedArchives", JSON.stringify(bookmarked.archives));
+    }
+}
+
+/**
+ * Clear active category filter and redo the search
+ */
+export function clearCategoryFilter() {
+    selectedCategory = "";
+    IndexTable.doSearch();
 }
 
 // #endregion

--- a/public/js/mod/index.js
+++ b/public/js/mod/index.js
@@ -1111,7 +1111,7 @@ export function loadCategories() {
 
             for (let i = 0; i < iteration; i++) {
                 const category = data[i];
-                const pinned = category.pinned === "1";
+                const pinned = Number(category.pinned) === 1;
 
                 let catName = (pinned ? "📌" : "") + category.name;
                 catName = LRR.encodeHTML(catName);

--- a/public/js/mod/index_contextmenu.js
+++ b/public/js/mod/index_contextmenu.js
@@ -9,17 +9,13 @@ import I18N from "i18n";
 
 let pseudoCopyBtn = undefined;
 
+/**
+ * Delete an archive by its ID
+ * @param {*} id The Archive ID
+ */
 function handleDelete(id) {
     const isTank = id.startsWith("TANK_");
-    LRR.showPopUp({
-        text: isTank ? I18N.ConfirmTankoubonDeletion : I18N.ConfirmArchiveDeletion,
-        icon: "warning",
-        showCancelButton: true,
-        focusConfirm: false,
-        confirmButtonText: I18N.ConfirmYes,
-        reverseButtons: true,
-        confirmButtonColor: "#d33",
-    })
+    LRR.showDeleteConfirmPopUp(isTank ? I18N.ConfirmTankoubonDeletion : I18N.ConfirmArchiveDeletion)
         .then((result) => {
             if (result.isConfirmed) {
                 if (isTank) Server.deleteTankoubon(id, () => {
@@ -60,6 +56,66 @@ function handleContextMenu(option, id) {
         case "msm-toggle-archive":
             if (!Index.isMultiSelectMode) Index.toggleMultiSelectMode();
             Index.toggleArchiveSelection(id);
+            break;
+        default:
+            break;
+    }
+}
+
+/**
+ * Handle context menu clicks within the category row.
+ * @param {*} option The clicked option
+ * @param {*} cat The category object from Index.catList ({ name, id, pinned, search })
+ */
+function handleCategoryContextMenu(option, cat) {
+    switch (option) {
+        case "pin": {
+            const newPinned = Number(cat.pinned) === 1 ? "0" : "1";
+            const pinMsg = newPinned === "1" ? I18N.CategoryPinned : I18N.CategoryUnpinned;
+            Server.callAPI(`/api/categories/${cat.id}?pinned=${newPinned}`, "PUT", pinMsg, I18N.CategoryPinError,
+                () => {
+                    Index.loadCategories();
+                },
+            );
+            break;
+        }
+        case "bookmark": {
+            const isBookmark = localStorage.getItem("bookmarkCategoryId") === cat.id;
+            if (isBookmark) {
+                Server.callAPI("/api/categories/bookmark_link", "DELETE", I18N.BookmarkUnlinked, I18N.BookmarkUnlinkError,
+                    () => {
+                        localStorage.removeItem("bookmarkCategoryId");
+                        localStorage.removeItem("bookmarkedArchives");
+                        Index.loadCategories().then(() => IndexTable.doSearch());
+                    },
+                );
+            } else {
+                Server.callAPI(`/api/categories/bookmark_link/${cat.id}`, "PUT", I18N.BookmarkLinked, I18N.BookmarkLinkError,
+                    () => {
+                        localStorage.setItem("bookmarkCategoryId", cat.id);
+                        Index.loadCategories().then(() => IndexTable.doSearch());
+                    },
+                );
+            }
+            break;
+        }
+        case "delete":
+            LRR.showDeleteConfirmPopUp(I18N.CategoryDeleteConfirm).then((result) => {
+                if (result.isConfirmed) {
+                    Server.callAPI(`/api/categories/${cat.id}`, "DELETE", I18N.CategoryDeleted, I18N.CategoryDeleteError,
+                        () => {
+                            if (Index.selectedCategory === cat.id) {
+                                Index.clearCategoryFilter();
+                            }
+                            if (localStorage.getItem("bookmarkCategoryId") === cat.id) {
+                                localStorage.removeItem("bookmarkCategoryId");
+                                localStorage.removeItem("bookmarkedArchives");
+                            }
+                            Index.loadCategories();
+                        },
+                    );
+                }
+            });
             break;
         default:
             break;
@@ -273,4 +329,38 @@ export function initialize(catListData) {
             };
         }
     });
+
+    // Initialize category context menu
+    if (LRR.isUserLogged()) {
+        $.contextMenu({
+            selector: ".category-context-menu",
+            build: ($trigger, _e) => {
+                const catId = $trigger.is("select")
+                    ? $trigger.find(":selected").attr("id")
+                    : $trigger.attr("id");
+
+                const cat = Index.catList.find((c) => c.id === catId);
+                if (!cat) { return false; }
+
+                const isPinned = Number(cat.pinned) === 1;
+
+                const items = {
+                    "pin": { name: isPinned ? I18N.CategoryUnpin : I18N.CategoryPin, icon: "fas fa-thumbtack" },
+                };
+                if (!cat.search) {
+                    const isBookmark = localStorage.getItem("bookmarkCategoryId") === catId;
+                    items["bookmark"] = { name: isBookmark ? I18N.CategoryRemoveBookmark : I18N.CategorySetBookmark, icon: "fas fa-bookmark" };
+                }
+                items["sep1"] = "---------";
+                items["delete"] = { name: I18N.Delete, icon: "fas fa-trash-alt" };
+
+                return {
+                    callback: function (key, _options) {
+                        handleCategoryContextMenu(key, cat);
+                    },
+                    items: items,
+                };
+            }
+        });
+    }
 }

--- a/templates/i18n.html.tt2
+++ b/templates/i18n.html.tt2
@@ -56,6 +56,15 @@ I18N.CategoryPredicateTitle = "[% c.lh("Writing a Predicate") %]";
 I18N.BookmarkLinkError = "[% c.lh("Error linking bookmark button:") %]";
 I18N.BookmarkUnlinkError = "[% c.lh("Error unlinking bookmark button:") %]";
 I18N.GetBookmarkError = "[% c.lh("Error getting bookmark category:") %]";
+I18N.CategoryPin = "[% c.lh("Pin") %]";
+I18N.CategoryUnpin = "[% c.lh("Unpin") %]";
+I18N.CategoryPinError = "[% c.lh("Error updating category pin:") %]";
+I18N.CategorySetBookmark = "[% c.lh("Set as Bookmark") %]";
+I18N.CategoryRemoveBookmark = "[% c.lh("Remove Bookmark") %]";
+I18N.CategoryPinned = "[% c.lh("Category pinned!") %]";
+I18N.CategoryUnpinned = "[% c.lh("Category unpinned!") %]";
+I18N.BookmarkLinked = "[% c.lh("Bookmark category set!") %]";
+I18N.BookmarkUnlinked = "[% c.lh("Bookmark category removed!") %]";
 
 I18N.StatusNew = "[% c.lh("New archive") %]";
 I18N.StatusRead = "[% c.lh("Archive read") %]";


### PR DESCRIPTION
Depends on: https://github.com/Difegue/LANraragi/pull/1698

Adds an admin context menu for category actions with the following options:

- set/unset a static category as bookmark
- pin/unpin a category
- delete a category

Dynamic category:
<img width="533" height="212" alt="Screenshot 2026-07-08 at 3 32 30 PM" src="https://github.com/user-attachments/assets/a9e87a1a-34a8-4f66-a2d5-1d49611bea78" />

Static category:
<img width="789" height="214" alt="Screenshot 2026-07-08 at 3 32 00 PM" src="https://github.com/user-attachments/assets/44098667-bb07-4ef3-8024-c34731459712" />

And refactor/fix the bookmark which previously lived in the 10-capped category presentation (which breaks if we have more than 10 cats), might need a dedicated PR for that