### PR TITLE
Add .lrrignore support for filtering archives

### DIFF
--- a/lib/LANraragi.pm
+++ b/lib/LANraragi.pm
@@ -15,6 +15,7 @@ use Time::HiRes qw(gettimeofday);
 
 use LANraragi::Utils::Generic    qw(start_shinobu start_minion get_version);
 use LANraragi::Utils::Logging    qw(get_logger get_logdir);
+use LANraragi::Utils::Ignore;
 use LANraragi::Utils::Plugins    qw(get_plugins);
 use LANraragi::Utils::TempFolder qw(get_temp);
 use LANraragi::Utils::Routing;
@@ -185,6 +186,9 @@ sub startup {
     # /!\ Enqueuing tasks must be done either before starting the worker, or once the IOLoop is started!
     # Anything else can cause weird database lockups.
     $self->minion->enqueue('build_stat_hashes');
+
+    # Load ignore rules into Redis before starting any workers
+    LANraragi::Utils::Ignore::initialize();
 
     # Start a Minion worker in a subprocess
     start_minion($self);

--- a/lib/LANraragi/Model/Upload.pm
+++ b/lib/LANraragi/Model/Upload.pm
@@ -16,6 +16,7 @@ use File::Find qw(find);
 use LANraragi::Utils::Archive  qw(extract_thumbnail);
 use LANraragi::Utils::Database qw(invalidate_cache compute_id set_title set_summary add_archive_to_redis add_timestamp_tag add_pagecount add_arcsize);
 use LANraragi::Utils::Logging  qw(get_logger);
+use LANraragi::Utils::Ignore   qw(load_ignore_rules is_ignored);
 use LANraragi::Utils::Redis    qw(redis_encode);
 use LANraragi::Utils::Generic  qw(is_archive get_bytelength);
 use LANraragi::Utils::String   qw(trim trim_CRLF trim_url);
@@ -57,6 +58,14 @@ sub handle_incoming_file ( $tempfile, $catid, $tags, $title, $summary ) {
     # Future home of the file
     my $userdir     = LANraragi::Model::Config->get_userdir;
     my $output_file = create_path( $userdir . '/' . $filename );
+
+    # Check ignore rules: reject if the file would be ignored by .lrrignore rules
+    my $ignore_rules = load_ignore_rules();
+    if ( is_ignored( $output_file, $ignore_rules ) ) {
+        $logger->info("$filename matches .lrrignore rules, rejecting upload.");
+        unlink_path $tempfile;
+        return ( 415, "deadbeef", $filename, "This file matches configured ignore rules." );
+    }
 
     #Check if the ID is already in the database, and
     #that the file it references still exists on the filesystem

--- a/lib/LANraragi/Utils/Ignore.pm
+++ b/lib/LANraragi/Utils/Ignore.pm
@@ -1,0 +1,191 @@
+package LANraragi::Utils::Ignore;
+
+use strict;
+use warnings;
+use utf8;
+use feature qw(signatures state);
+no warnings 'experimental::signatures';
+
+use File::Spec;
+use File::Basename qw(dirname basename);
+use Config;
+
+use LANraragi::Utils::Path    qw(open_path find_path create_path);
+use LANraragi::Utils::String  qw(trim);
+use Storable                  qw(nfreeze thaw);
+
+use Exporter 'import';
+our @EXPORT_OK = qw(
+    is_ignored
+    build_ignore_rules
+    initialize
+    load_ignore_rules
+);
+
+use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );
+
+# Called at server startup to scan .lrrignore files and store rules in Redis.
+sub initialize {
+    my $redis = LANraragi::Model::Config->get_redis_config;
+    my $rules = build_ignore_rules( LANraragi::Model::Config->get_userdir );
+    $redis->set( "LRR_IGNORE_RULES", nfreeze($rules) );
+    $redis->quit();
+}
+
+# Load cached ignore rules from Redis.
+# Rules are immutable at runtime; they only change when the server restarts.
+sub load_ignore_rules {
+    state $cached = do {
+        my $redis = LANraragi::Model::Config->get_redis_config;
+        my $data  = $redis->get("LRR_IGNORE_RULES");
+        $redis->quit();
+        return undef unless $data;
+
+        # compile regexp
+        my $rules = thaw($data);
+        for my $patterns (values %{ $rules->{entries} }) {
+            for my $p (@$patterns) {
+                $p->{regex} = qr{$p->{regex}};
+            }
+        }
+        return $rules;
+    };
+    return $cached;
+}
+
+# Scan the content directory for .lrrignore files and build rule entries.
+sub build_ignore_rules ($content_dir) {
+    $content_dir =~ s{\\}{/}g unless IS_UNIX;
+    my $rules = {
+        content_dir => $content_dir,
+        entries     => {},
+    };
+
+    my @lrrignore_dirs;
+    find_path(
+        sub {
+            my $f = create_path($_);
+            return if -d $f;
+            return unless basename($f) eq '.lrrignore';
+            push @lrrignore_dirs, dirname($f);
+        },
+        $content_dir
+    );
+
+    for my $dir (@lrrignore_dirs) {
+        load_ignore_file( $dir, $rules->{entries} );
+    }
+
+    return $rules;
+}
+
+# Rules data structure:
+# $rules = {
+#     content_dir => $path,                      # Root content directory for scanning
+#     entries     => {                           # Hash map: dir -> patterns
+#         $path => [                             # Parsed patterns from a single .lrrignore file
+#             {
+#                 pattern  => "*.tmp",           # Original pattern string
+#                 regex    => qr/.../i,          # Compiled regex for matching
+#                 negation => 0|1,               # 1 = ! re-include, 0 = ignore
+#             },
+#             ...
+#         ],
+#         ...
+#     },
+# }
+#
+sub is_ignored ($file, $rules) {
+    return 0 unless $rules;
+
+    my $entries = $rules->{entries};
+    return 0 unless $entries && keys %$entries;
+
+    return 0 unless is_subpath($file, $rules->{content_dir});
+
+    my $d = dirname($file);
+    while (1) {
+        if ( my $patterns = $entries->{$d} ) {
+            my $rel = File::Spec->abs2rel( $file, $d );
+            $rel =~ s{\\}{/}g unless IS_UNIX;
+            utf8::decode($rel);
+            my $result;
+            for my $rule ( @$patterns ) {
+                next unless $rel =~ $rule->{regex};
+                $result = $rule->{negation} ? 0 : 1;
+            }
+            return $result if defined $result;
+        }
+        last if $d eq $rules->{content_dir};
+        $d = dirname($d);
+    }
+    return 0;
+}
+
+sub load_ignore_file ($dir, $entries) {
+    my $ignore = File::Spec->catfile( $dir, ".lrrignore" );
+    return unless -f $ignore;
+    my @parsed = parse_ignore_file($ignore);
+    return unless @parsed;
+    $entries->{$dir} = \@parsed;
+}
+
+sub parse_ignore_file ($path) {
+    my @patterns;
+
+    open_path( my $fh, '<:encoding(UTF-8)', $path ) or return @patterns;
+    my @lines = <$fh>;
+    close($fh);
+
+    for my $line (@lines) {
+        $line = trim($line);
+        next if $line eq '';
+        next if $line =~ /^#/;
+
+        my $negation = 0;
+        if ( $line =~ s/^!// ) { $negation = 1; }
+
+        my $regex = glob_to_regex($line);
+        next unless defined $regex;
+
+        push @patterns, {
+            pattern  => $line,
+            regex    => $regex,
+            negation => $negation,
+        };
+    }
+
+    return @patterns;
+}
+
+sub glob_to_regex ($pattern_str) {
+
+    my $match_dir = 0;
+    if ( $pattern_str =~ s{/$}{} ) { $match_dir = 1; }
+
+    my $anchored = 0;
+    if ( $pattern_str =~ s{^\.?/}{} ) { $anchored = 1; }
+
+    return () if $pattern_str eq '';
+
+    $pattern_str = join '[^/]*', map {
+        quotemeta($_ =~ s/\\(.)/$1/gr);
+    } split(/(?<!\\)\*/, $pattern_str, -1);
+
+    if (!$anchored) {
+        $pattern_str = '(?:.+/)?' . $pattern_str;
+    }
+    if ( $match_dir ) {
+        $pattern_str .= '/.*';
+    }
+
+    return ( '(?i)^' . $pattern_str . '$' );
+}
+
+sub is_subpath ($path, $parent) {
+    $parent =~ s{/+$}{};
+    return 0 if $path eq $parent;
+    return index( $path, $parent . '/' ) == 0;
+}
+  
+1;

--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -36,6 +36,8 @@ use LANraragi::Utils::Logging    qw(get_logger);
 use LANraragi::Utils::Generic    qw(is_archive exec_with_lock_pure);
 use LANraragi::Utils::Redis      qw(redis_encode);
 use LANraragi::Utils::Path       qw(create_path open_path find_path get_archive_path);
+use LANraragi::Utils::Ignore     qw(is_ignored load_ignore_rules);
+use LANraragi::Model::Archive;
 
 use LANraragi::Model::Config;
 use LANraragi::Model::Plugins;
@@ -133,11 +135,18 @@ sub update_filemap {
     my $dirname = LANraragi::Model::Config->get_userdir;
     my @files;
 
+    my $ignore_rules = load_ignore_rules();
+
     # Get all files in content directory and subdirectories.
     find_path(
         sub {
             $_ = create_path($_);
             return if -d $_;    #Directories are excluded on the spot
+
+            if ( is_ignored( $_, $ignore_rules ) ) {
+                return;
+            }
+
             return unless is_archive($_);
             push @files, $_;    #Push files to array
         },
@@ -151,17 +160,32 @@ sub update_filemap {
     my %fshash      = map { $_ => 1 } @files;
 
     my @newfiles     = grep { !$filemaphash{$_} } @files;
-    my @deletedfiles = grep { !$fshash{$_} } @filemapfiles;
+    my @deletedfiles = grep { !$fshash{$_} } @filemapfiles;  # contains both deleted and ignored files.
 
     $logger->info( "Found " . scalar @newfiles . " new files." );
-    $logger->info( scalar @deletedfiles . " files were found on the filemap but not on the filesystem." );
+    $logger->info( scalar @deletedfiles . " stale entries to remove from filemap." );
 
-    # Delete old files from filemap
+    # Delete old files from filemap and cleanup ignored archives
+    my $redis_arc = LANraragi::Model::Config->get_redis;
     foreach my $deletedfile (@deletedfiles) {
         $logger->debug("Removing $deletedfile from filemap.");
+        if ( -e $deletedfile ) {
+            my $id = $redis->hget( "LRR_FILEMAP", $deletedfile );
+            if ($id) {
+                my ($acquired) = exec_with_lock_pure(
+                    [ "archive-write:$id" ],
+                    sub { $redis_arc->hset( $id, "file", "" ); },
+                    undef, 60
+                );
+                unless ($acquired) {
+                    $logger->warn("Could not acquire lock for $id, skipping file field clear.");
+                }
+            }
+        }
         $redis->hdel( "LRR_FILEMAP", $deletedfile ) || $logger->warn("Couldn't delete previous filemap data.");
     }
 
+    $redis_arc->quit();
     $redis->quit();
 
     eval {
@@ -328,6 +352,12 @@ sub new_file_callback ($name) {
 
     $logger->debug("New file detected: $name");
     unless ( -d $name ) {
+
+        my $ignore_rules = load_ignore_rules();
+        if ( is_ignored( $name, $ignore_rules ) ) {
+            $logger->debug("$name matches .lrrignore rules, skipping.");
+            return;
+        }
 
         my $redis = LANraragi::Model::Config->get_redis_config;
         eval { add_to_filemap( $redis, $name ); };

--- a/tests/LANraragi/Utils/Ignore.t
+++ b/tests/LANraragi/Utils/Ignore.t
@@ -1,0 +1,291 @@
+use strict;
+use warnings;
+use utf8;
+
+use Test::More;
+binmode Test::More->builder->output, ':encoding(UTF-8)';
+binmode Test::More->builder->failure_output, ':encoding(UTF-8)';
+use File::Temp qw(tempdir);
+use File::Spec;
+use File::Path qw(make_path);
+use LANraragi::Utils::Path qw(open_path_or_die);
+
+use constant IS_UNIX => ( $^O ne 'MSWin32' );
+
+BEGIN {
+    use_ok('LANraragi::Utils::Ignore');
+}
+
+sub make_rules {
+    my ($dir, @lines) = @_;
+    my $file = File::Spec->catfile($dir, ".lrrignore");
+    open_path_or_die( my $fh, '>:encoding(UTF-8)', $file );
+    print $fh join("\n", @lines);
+    close($fh);
+}
+
+# ============ *.tmp pattern (no slash) ============
+{
+    my $tmp = tempdir(CLEANUP => 1);
+    make_path( File::Spec->catdir($tmp, "sub") );
+    make_rules($tmp, "*.tmp");
+
+    my $r = LANraragi::Utils::Ignore::build_ignore_rules($tmp);
+    ok( LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, "foo.tmp"), $r ),       "*.tmp matches foo.tmp" );
+    ok( LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, "sub", "bar.tmp"), $r ), "*.tmp matches sub/bar.tmp" );
+    ok( !LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, "foo.cbz"), $r ),       "*.tmp does NOT match foo.cbz" );
+    ok( !LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, "foo.tmp.cbz"), $r ),   "*.tmp does NOT match foo.tmp.cbz" );
+}
+
+# ============ Directory pattern with trailing / ============
+{
+    my $tmp = tempdir(CLEANUP => 1);
+    make_path( File::Spec->catdir($tmp, "private") );
+    make_rules($tmp, "private/");
+
+    my $r = LANraragi::Utils::Ignore::build_ignore_rules($tmp);
+    ok( LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, "private", "secret.cbz"), $r ),
+        "private/* matches private/secret.cbz" );
+    ok( !LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, "not_private.cbz"), $r ),
+        "private/* does NOT match not_private.cbz" );
+}
+
+# ============ Path boundary (a should not match ab, a/ should not match a) ============
+{
+    my $tmp = tempdir(CLEANUP => 1);
+    make_rules($tmp, "file");
+
+    my $r = LANraragi::Utils::Ignore::build_ignore_rules($tmp);
+    ok( LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, "file"), $r ),
+        "file matches file" );
+    ok( !LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, "file1"), $r ),
+        "file does NOT match file1" );
+
+    # dir/ → dir/*
+    make_rules($tmp, "dir/");
+    my $r2 = LANraragi::Utils::Ignore::build_ignore_rules($tmp);
+    ok( !LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, "dir"), $r2 ),
+        "dir/ does NOT match file dir" );
+}
+
+# ============ Escape: \*, \!, \# ============
+{
+    my $tmp = tempdir(CLEANUP => 1);
+
+    make_rules($tmp, 'star\*lit.tmp');
+    my $r = LANraragi::Utils::Ignore::build_ignore_rules($tmp);
+    ok( LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, 'star*lit.tmp'), $r ),
+        '\* matches literal *' );
+    ok( !LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, 'starlit.tmp'), $r ),
+        '\* does NOT match starlit' );
+
+    make_rules($tmp, '\!bang.tmp');
+    my $r2 = LANraragi::Utils::Ignore::build_ignore_rules($tmp);
+    ok( LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, '!bang.tmp'), $r2 ),
+        '\! matches literal ! at line start' );
+
+    make_rules($tmp, '\#tag.tmp');
+    my $r3 = LANraragi::Utils::Ignore::build_ignore_rules($tmp);
+    ok( LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, '#tag.tmp'), $r3 ),
+        '\# matches literal # at line start' );
+}
+
+# ============ Anchored pattern with leading / ============
+{
+    my $tmp = tempdir(CLEANUP => 1);
+    make_path( File::Spec->catdir($tmp, "sub") );
+    make_rules($tmp, "/root.cbz");
+
+    my $r = LANraragi::Utils::Ignore::build_ignore_rules($tmp);
+    ok( LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, "root.cbz"), $r ),
+        "/root.cbz matches root-level file" );
+    ok( !LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, "sub", "root.cbz"), $r ),
+        "/root.cbz does NOT match sub/root.cbz" );
+}
+
+# ============ Negation (!) — last matching rule wins ============
+{
+    my $tmp = tempdir(CLEANUP => 1);
+    make_rules($tmp, "*.tmp", "!important.tmp");
+
+    my $r = LANraragi::Utils::Ignore::build_ignore_rules($tmp);
+    ok( LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, "foo.tmp"), $r ),       "*.tmp matches foo.tmp" );
+    ok( !LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, "important.tmp"), $r ), "!important.tmp re-includes" );
+}
+
+# ============ Nested .lrrignore (child overrides parent) ============
+{
+    my $tmp = tempdir(CLEANUP => 1);
+    my $sub = File::Spec->catdir($tmp, "sub");
+    make_path($sub);
+    make_rules($tmp, "*.tmp");
+    make_rules($sub, "!keep.tmp");
+
+    # build_ignore_rules from a file in sub loads both parent and child rules
+    my $r = LANraragi::Utils::Ignore::build_ignore_rules($tmp);
+    ok( LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, "x.tmp"), $r ),
+        "root *.tmp works on root file" );
+    ok( LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, "sub", "drop.tmp"), $r ),
+        "root *.tmp applies in subdir" );
+    ok( !LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, "sub", "keep.tmp"), $r ),
+        "sub/keep.tmp re-included by child !keep.tmp" );
+}
+
+# ============ CJK paths ============
+{
+    my $tmp = tempdir(CLEANUP => 1);
+
+    # Chinese
+    my $cn = File::Spec->catdir($tmp, "漫画");
+    make_path($cn);
+    make_rules($tmp, "漫画/vol1.rar");
+    my $r = LANraragi::Utils::Ignore::build_ignore_rules($tmp);
+    ok( LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($cn, "vol1.rar"), $r ),
+        "CJK: 漫画/vol1.rar matched by 漫画/vol1.rar" );
+    ok( !LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($cn, "vol1.zip"), $r ),
+        "CJK: 漫画/vol1.zip not matched" );
+
+    # Japanese
+    my $jp = File::Spec->catdir($tmp, "同人誌");
+    make_path($jp);
+    make_rules($tmp, "同人誌/C97.cbz");
+    my $r2 = LANraragi::Utils::Ignore::build_ignore_rules($tmp);
+    ok( LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($jp, "C97.cbz"), $r2 ),
+        "CJK: 同人誌/C97.cbz matched by 同人誌/C97.cbz" );
+
+    # Korean
+    my $kr = File::Spec->catdir($tmp, "웹툰");
+    make_path($kr);
+    make_rules($tmp, "웹툰/ch01.zip");
+    my $r3 = LANraragi::Utils::Ignore::build_ignore_rules($tmp);
+    ok( LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($kr, "ch01.zip"), $r3 ),
+        "CJK: 웹툰/ch01.zip matched by 웹툰/ch01.zip" );
+
+    # CJK filename pattern
+    make_rules($tmp, "漫画1.cbz");
+    my $r4 = LANraragi::Utils::Ignore::build_ignore_rules($tmp);
+    ok( LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, "漫画1.cbz"), $r4 ),
+        "CJK: 漫画1.cbz matched by 漫画1.cbz" );
+    ok( !LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, "漫画2.cbz"), $r4 ),
+        "CJK: 漫画2.cbz not matched by 漫画1.cbz" );
+
+    # CJK directory .lrrignore (nested override)
+    my $sp_cn = "特别";
+    utf8::encode($sp_cn) unless IS_UNIX;
+    my $sp = File::Spec->catdir($tmp, $sp_cn);
+    make_path($sp);
+    make_rules($tmp, "过滤.tmp");
+    make_rules($sp, "!保留.tmp");
+    my $r5 = LANraragi::Utils::Ignore::build_ignore_rules($tmp);
+    ok( LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($sp, "过滤.tmp"), $r5 ),
+        "CJK: 过滤.tmp ignored by root 过滤.tmp" );
+    ok( !LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($sp, "保留.tmp"), $r5 ),
+        "CJK: 保留.tmp re-included by child !保留.tmp" );
+}
+
+# ============ Comments and empty lines ============
+{
+    my $tmp = tempdir(CLEANUP => 1);
+    make_rules($tmp, "# comment", "", "*.cbz", "   # comment with spaces");
+
+    my $r = LANraragi::Utils::Ignore::build_ignore_rules($tmp);
+    ok( LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, "test.cbz"), $r ), "comment lines are skipped, *.cbz works" );
+}
+
+# ============ Special characters in filenames ============
+# Verify that is_ignored / find_path / abs2rel handle unusual characters gracefully.
+{
+    my $tmp = tempdir(CLEANUP => 1);
+
+    my $sub = File::Spec->catdir($tmp, "sub");
+    make_path($sub);
+    make_rules($tmp,
+        'space .tmp',
+        'paren(1).tmp',
+        'bracket[1].tmp',
+        'curly{1}.tmp',
+        'dollar$.tmp',
+        'semi;.tmp',
+        'pipe|.tmp',
+        'caret^.tmp',
+        'plus+.tmp',
+        'hash#.tmp',
+        'amp&.tmp',
+        'tilde~.tmp',
+        'at@.tmp',
+        'backtick` .tmp',
+        'single\'quote.tmp',
+        'double"quote.tmp',
+        '.leading dot.cbz',
+        "emoj\x{1F4D6}.tmp",
+        'sub/nested space.tmp',
+        'sub/exclaim!.tmp',
+    );
+
+    my @specials = (
+        'space .tmp',
+        'paren(1).tmp',
+        'bracket[1].tmp',
+        'curly{1}.tmp',
+        'dollar$.tmp',
+        'semi;.tmp',
+        'pipe|.tmp',
+        'caret^.tmp',
+        'plus+.tmp',
+        'hash#.tmp',
+        'amp&.tmp',
+        'tilde~.tmp',
+        'at@.tmp',
+        'backtick` .tmp',
+        'single\'quote.tmp',
+        'double"quote.tmp',
+        '.leading dot.cbz',
+        "emoj\x{1F4D6}.tmp",
+        'sub/nested space.tmp',
+        'sub/exclaim!.tmp',
+    );
+
+    for my $name (@specials) {
+        open( my $fh, '>', File::Spec->catfile( $tmp, $name ) );
+        close($fh);
+    }
+
+    my $r = LANraragi::Utils::Ignore::build_ignore_rules($tmp);
+
+    for my $name (@specials) {
+        my $file = File::Spec->catfile( $tmp, $name );
+        my $rel  = File::Spec->abs2rel( $file, $tmp );
+        my $expected = 1;
+        ok( LANraragi::Utils::Ignore::is_ignored( $file, $r ) == $expected,
+            "special chars: $rel => " . ( $expected ? "ignored" : "scanned" ) );
+    }
+}
+
+# ============ No .lrrignore file ============
+{
+    my $tmp = tempdir(CLEANUP => 1);
+    my $r = LANraragi::Utils::Ignore::build_ignore_rules($tmp);
+    ok( !LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, "foo.cbz"), $r ), "no ignore file -> nothing ignored" );
+}
+
+# ============ Specific file path ============
+{
+    my $tmp = tempdir(CLEANUP => 1);
+    make_path( File::Spec->catdir($tmp, "backup") );
+    make_rules($tmp, "backup/old.cbz");
+
+    my $r = LANraragi::Utils::Ignore::build_ignore_rules($tmp);
+    ok( LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, "backup", "old.cbz"), $r ), "backup/old.cbz matches specific file" );
+    ok( !LANraragi::Utils::Ignore::is_ignored( File::Spec->catfile($tmp, "backup", "new.cbz"), $r ), "backup/old.cbz does NOT match other files" );
+}
+
+# ============ Empty .lrrignore ============
+{
+    my $tmp = tempdir(CLEANUP => 1);
+    make_rules($tmp, "", "# only comments", "   ");
+
+    my $r = LANraragi::Utils::Ignore::build_ignore_rules($tmp);
+    is( scalar keys %{ $r->{entries} }, 0, "empty .lrrignore produces empty entries" );
+}
+
+done_testing();


### PR DESCRIPTION
This PR add `.lrrignore` support with plexignore based syntax, triggered during Shinobu scanning and when new files are added.

See https://github.com/Difegue/LANraragi/discussions/1120

### syntax

Based on the [Plex `.plexignore`](https://support.plex.tv/articles/201381883-special-keyword-file-folder-exclusion/) spec, extended with some useful features from gitignore:

| Syntax | Description |
|--------|-------------|
| `*` | glob wildcard, matches any character except `/` |
| `#` | comment (line start only; `\#` escapes to literal `#`) |
| `!` | negation, overrides parent directory rules (`\!` escapes to literal `!`) |
| Leading `/` | anchors the pattern to the `.lrrignore` file's directory |
| Trailing `/` | matches all contents of the directory |
| `\*` | literal `*` |
| `\` | for any other `\X`, the backslash is silently dropped (`\X` → `X`) |

Rules are resolved relative to the `.lrrignore` file's own directory, with nested rules overriding parent ones.


### interface

`Ignore.pm` exports four methods:

- `is_ignored($file, $rules)`: walks parent directories via `dirname` and matches against compiled regex rules
- `build_ignore_rules($content_dir)`: scans the directory tree for `.lrrignore` files and builds a rule set
- `initialize()`: called at server startup, builds rules and stores them in Redis as `LRR_IGNORE_RULES`
- `load_ignore_rules()`: loads the frozen rule set from Redis with `state $cached`

### windows compatibility

The project's existing cross-platform filesystem APIs don't quite cover some of the path operations this feature needs. I'm not familiar with Windows, so I can't say for sure it'll work there. The tests pass under MSYS2. And that is all I can guaranteen.

### unit test

Added tests covering the various ignore syntax rules.