### PR TITLE
Metrics-related bug fixes

### DIFF
--- a/lib/LANraragi.pm
+++ b/lib/LANraragi.pm
@@ -257,6 +257,23 @@ sub startup {
             LANraragi::Model::Metrics::flush_request_metrics_to_redis();
         });
 
+        # Worker exit-related cleanups
+        $self->hook(
+            before_server_start => sub {
+                my ( $server, $app ) = @_;
+                return unless $server->isa('Mojo::Server::Prefork');
+
+                # https://docs.mojolicious.org/Mojo/Server/Prefork#reap
+                # if a worker process exists, clean up its metrics.
+                $server->on(
+                    reap => sub {
+                        my ( $prefork, $pid ) = @_;
+                        LANraragi::Model::Metrics::cleanup_worker_gauges_on_exit($pid);
+                    }
+                );
+            }
+        );
+
         $self->LRR_LOGGER->info("Metrics collection is enabled.");
 
     }

--- a/lib/LANraragi.pm
+++ b/lib/LANraragi.pm
@@ -257,18 +257,22 @@ sub startup {
             LANraragi::Model::Metrics::flush_request_metrics_to_redis();
         });
 
-        # Worker exit-related cleanups
+        # Manage Mojo worker lifecycles
         $self->hook(
             before_server_start => sub {
                 my ( $server, $app ) = @_;
-                return unless $server->isa('Mojo::Server::Prefork');
 
-                # https://docs.mojolicious.org/Mojo/Server/Prefork#reap
-                # if a worker process exists, clean up its metrics.
+                # track all active workers.
+                $server->on(
+                    spawn => sub {
+                        my ( $prefork, $pid ) = @_;
+                        LANraragi::Model::Metrics::register_worker($pid);
+                    }
+                );
                 $server->on(
                     reap => sub {
                         my ( $prefork, $pid ) = @_;
-                        LANraragi::Model::Metrics::cleanup_worker_gauges_on_exit($pid);
+                        LANraragi::Model::Metrics::unregister_worker($pid);
                     }
                 );
             }

--- a/lib/LANraragi/Controller/Api/Shinobu.pm
+++ b/lib/LANraragi/Controller/Api/Shinobu.pm
@@ -5,6 +5,7 @@ use Config;
 
 use LANraragi::Utils::Generic qw(start_shinobu render_api_response);
 use LANraragi::Utils::TempFolder qw(get_temp);
+use LANraragi::Model::Metrics;
 
 use constant IS_UNIX => ( $Config{osname} ne 'MSWin32' );
 
@@ -109,6 +110,10 @@ sub stop_shinobu {
         chomp(my $pid = <$fh>);
         close($fh);
         kill HUP => $pid;
+    }
+
+    if ( $self->LRR_CONF->enable_metrics ) {
+        LANraragi::Model::Metrics::unregister_shinobu();
     }
 
     render_api_response( $self, "shinobu_stop" );

--- a/lib/LANraragi/Model/Metrics.pm
+++ b/lib/LANraragi/Model/Metrics.pm
@@ -281,6 +281,7 @@ sub collect_request_metrics {
     my $controller      = shift;
     my $start_time      = $controller->stash('metrics.start_time');
     return unless $start_time;
+    return unless $controller->match->endpoint;
 
     my $duration        = tv_interval($start_time);
     my $method          = $controller->req->method;

--- a/lib/LANraragi/Model/Metrics.pm
+++ b/lib/LANraragi/Model/Metrics.pm
@@ -374,6 +374,29 @@ sub collect_process_metrics {
     }
 }
 
+sub cleanup_worker_gauges_on_exit {
+    my $pid = shift;
+
+    my $metrics_redis = LANraragi::Model::Config->get_redis_metrics;
+    my $logger        = get_logger( "Metrics", "lanraragi" );
+    my $error;
+    eval {
+        foreach my $process_type (qw(http minion shinobu)) {
+            $metrics_redis->hdel(
+                "metrics:$process_type:$pid",
+                qw(virtual_memory_bytes resident_memory_bytes open_fds max_fds start_time_seconds)
+            );
+        }
+        $logger->debug("Cleaned up gauges of exited process $pid.");
+    };
+    $error = $@;
+    $metrics_redis->quit();
+
+    if ($error) {
+        $logger->error("Failed to clean up gauges of exited process $pid: $error");
+    }
+}
+
 # Clean up all existing metrics data on startup
 sub cleanup_metrics {
 

--- a/lib/LANraragi/Model/Metrics.pm
+++ b/lib/LANraragi/Model/Metrics.pm
@@ -461,19 +461,40 @@ sub unregister_worker {
     my $error;
     eval {
         $redis->hdel("metrics:active_workers", $pid);
-        foreach my $process_type (qw(http minion shinobu)) {
-            $redis->hdel(
-                "metrics:$process_type:$pid",
-                qw(virtual_memory_bytes resident_memory_bytes open_fds max_fds start_time_seconds)
-            );
-        }
-        $logger->debug("Cleaned up gauges of exited process $pid.");
+        $redis->hdel(
+            "metrics:http:$pid",
+            qw(virtual_memory_bytes resident_memory_bytes open_fds max_fds start_time_seconds)
+        );
+        $logger->debug("Cleaned up gauges of exited worker $pid.");
     };
     $error = $@;
     $redis->quit();
 
     if ($error) {
         $logger->error("Failed to clean up gauges of exited process $pid: $error");
+    }
+}
+
+# Unregister shinobu and clean up gauge metrics.
+sub unregister_shinobu {
+
+    my $metrics_redis = LANraragi::Model::Config->get_redis_metrics;
+    my $logger        = get_logger( "Metrics", "lanraragi" );
+    my $error;
+    eval {
+        foreach my $key ( $metrics_redis->keys("metrics:shinobu:*") ) {
+            $metrics_redis->hdel(
+                $key,
+                qw(virtual_memory_bytes resident_memory_bytes open_fds max_fds start_time_seconds)
+            );
+        }
+        $logger->debug("Cleaned up shinobu gauges.");
+    };
+    $error = $@;
+    $metrics_redis->quit();
+
+    if ($error) {
+        $logger->error("Failed to clean up shinobu gauges: $error");
     }
 }
 

--- a/lib/LANraragi/Model/Metrics.pm
+++ b/lib/LANraragi/Model/Metrics.pm
@@ -41,14 +41,13 @@ sub get_prometheus_api_metrics {
     my @output;
     my @metric_keys = $metrics_redis->keys("metrics:worker:*");
     my %aggregated_api_metrics;
-    my %active_workers;
+    my $worker_count = $metrics_redis->hlen("metrics:active_workers");
 
     foreach my $key ( @metric_keys ) {
 
         # Parse key: metrics:worker:{PID}:{endpoint_encoded}_{method}
         if ( $key =~ /^metrics:worker:(\d+):(.+)_([A-Z]+)$/ ) {
             my ($worker_pid, $endpoint_encoded, $method) = ($1, $2, $3);
-            $active_workers{$worker_pid} = 1;
 
             next unless $endpoint_encoded && $method;
 
@@ -103,7 +102,6 @@ sub get_prometheus_api_metrics {
     }
 
     # API worker count metric
-    my $worker_count = scalar keys %active_workers;
     push @output, "# TYPE lanraragi_active_workers gauge";
     push @output, "# HELP lanraragi_active_workers Number of active LANraragi workers";
     push @output, "lanraragi_active_workers $worker_count";
@@ -374,29 +372,6 @@ sub collect_process_metrics {
     }
 }
 
-sub cleanup_worker_gauges_on_exit {
-    my $pid = shift;
-
-    my $metrics_redis = LANraragi::Model::Config->get_redis_metrics;
-    my $logger        = get_logger( "Metrics", "lanraragi" );
-    my $error;
-    eval {
-        foreach my $process_type (qw(http minion shinobu)) {
-            $metrics_redis->hdel(
-                "metrics:$process_type:$pid",
-                qw(virtual_memory_bytes resident_memory_bytes open_fds max_fds start_time_seconds)
-            );
-        }
-        $logger->debug("Cleaned up gauges of exited process $pid.");
-    };
-    $error = $@;
-    $metrics_redis->quit();
-
-    if ($error) {
-        $logger->error("Failed to clean up gauges of exited process $pid: $error");
-    }
-}
-
 # Clean up all existing metrics data on startup
 sub cleanup_metrics {
 
@@ -415,6 +390,7 @@ sub cleanup_metrics {
             my $count = scalar(@all_keys);
             $logger->info("Cleaned up $count metrics keys.");
         }
+        $metrics_redis->del("metrics:active_workers");
     };
     my $error = $@;
     $metrics_redis->quit();
@@ -455,6 +431,49 @@ sub flush_request_metrics_to_redis {
     %REQUEST_METRICS_CACHE        = ();
     $REQUEST_METRICS_UPDATE_COUNT = 0;
     $REQUEST_METRICS_LAST_FLUSH   = $now;
+}
+
+# Register worker in the active workers registry
+sub register_worker {
+    my $pid = shift;
+
+    my $redis   = LANraragi::Model::Config->get_redis_metrics;
+    my $logger  = get_logger( "Metrics", "lanraragi" );
+    my $error;
+    eval {
+        $redis->hset("metrics:active_workers", $pid, 1);
+    };
+    $error = $@;
+    $redis->quit();
+
+    if ($error) {
+        $logger->error("Failed to register worker process $pid: $error");
+    }
+}
+
+# Unregister worker from the active workers registry and clean up its gauge metrics.
+sub unregister_worker {
+    my $pid = shift;
+
+    my $redis   = LANraragi::Model::Config->get_redis_metrics;
+    my $logger  = get_logger( "Metrics", "lanraragi" );
+    my $error;
+    eval {
+        $redis->hdel("metrics:active_workers", $pid);
+        foreach my $process_type (qw(http minion shinobu)) {
+            $redis->hdel(
+                "metrics:$process_type:$pid",
+                qw(virtual_memory_bytes resident_memory_bytes open_fds max_fds start_time_seconds)
+            );
+        }
+        $logger->debug("Cleaned up gauges of exited process $pid.");
+    };
+    $error = $@;
+    $redis->quit();
+
+    if ($error) {
+        $logger->error("Failed to clean up gauges of exited process $pid: $error");
+    }
 }
 
 1;

--- a/lib/LANraragi/Utils/Metrics.pm
+++ b/lib/LANraragi/Utils/Metrics.pm
@@ -20,6 +20,7 @@ sub extract_endpoint {
     # Archive endpoints
     $path =~ s{/api/archives/[a-f0-9]{40}(/|$)}{/api/archives/:id$1}g;
     $path =~ s{/api/archives/:id/progress/\d+}{/api/archives/:id/progress/:page};
+    $path =~ s{/api/archives/:id/stamps/\d+$}{/api/archives/:id/stamps/:index};
 
     # Category endpoints
     $path =~ s{/api/categories/bookmark_link/[^/]+(/|$)}{/api/categories/bookmark_link/:id$1}g;
@@ -33,9 +34,16 @@ sub extract_endpoint {
         }
     }ge;
 
-    # Tankoubon endpoints  
+    # Tankoubon endpoints
     $path =~ s{/api/tankoubons/[^/]+/[a-f0-9]{40}(/|$)}{/api/tankoubons/:id/:archive$1}g;
     $path =~ s{/api/tankoubons/[^/]+(/|$)}{/api/tankoubons/:id$1}g;
+    $path =~ s{/api/tankoubons/:id/progress/\d+$}{/api/tankoubons/:id/progress/:page};
+
+    # Stamp endpoints
+    $path =~ s{/api/stamps/[^/]+(/|$)}{/api/stamps/:id$1}g;
+
+    # Database endpoints
+    $path =~ s{/api/database/backup/\d+$}{/api/database/backup/:jobid};
 
     # Minion endpoints
     $path =~ s{/api/minion/([^/]+)/queue(/|$)}{/api/minion/:jobname/queue$2}g;

--- a/lib/Shinobu.pm
+++ b/lib/Shinobu.pm
@@ -76,6 +76,10 @@ sub initialize_from_new_process {
     my $userdir = LANraragi::Model::Config->get_userdir;
     my $metrics_enabled = LANraragi::Model::Config->enable_metrics;
 
+    if ($metrics_enabled) {
+        LANraragi::Model::Metrics::unregister_shinobu();
+    }
+
     $logger->info("Shinobu File Watcher started.");
     $logger->info("Content folder is $userdir.");
 


### PR DESCRIPTION
Problem 1: The metrics leak that can span a couple months (resulting in a reported 100gb memory on grafana in a machine with only 96gb ram) is traced back to worker stats not being cleaned up on exit.

E.g.:
- worker X, Y reported memory usage of 1mb, total memory usage 2mb
- worker X dies, but 1mb usage still lives in redis. total memory usage is still 2mb (even though actual usage is just Y)
- rinse and repeat with hundreds of dying workers, you get a load of ghost ram usage

Any gauge metric reported by an exited worker poisons the actual metrics cache, because complete cleanup happens only on LRR start (which there is a reason why cleanup doesn't happen during LRR runtime).

> Consider why non-gauge metrics do not need to be cleaned up when a worker exits though.

Problem 2: Redis stores the metrics of dead workers, and the way we *count* total active workers is which PIDs are in the metrics cache. What that actually counts is all workers, dead or alive.

These two issues are addressed by an architectural tweak:

- worker metrics are now an explicit lifecycle problem, when mojo reaps children processes, their corresponding PID is used to clean up gauge metrics.
- mojo lifecycle also includes active worker registration and unregistration.

Additionally, the endpoints recorded by metrics are 3-months out of date, so this is updated (maybe Utils/Metrics.pm might do some parse-and-build of openapi.yaml so that we can dynamically handle this problem...).

In draft: todo pending on any non-mojo process that still needs lifecycle management.