### PR TITLE
Add es-module-shims for legacy importmap support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
                 "clsx": "1.1.1",
                 "datatables.net": "1.11.5",
                 "dompurify": "^3.4.11",
+                "es-module-shims": "^2.8.2",
                 "eslint-plugin-import-x": "^4.17.1",
                 "fscreen": "1.2.0",
                 "geist": "1.0.0",
@@ -1410,6 +1411,12 @@
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
             }
+        },
+        "node_modules/es-module-shims": {
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-2.8.2.tgz",
+            "integrity": "sha512-Re3rc7Fu8zrN2lD6ExQo+9SS1o2hai0DSLuC/m6R09A84DTL6SSKO+/s3JzKN648yxxdjJfuyFLSpsgr5kb0KA==",
+            "license": "MIT"
         },
         "node_modules/esbuild": {
             "version": "0.28.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "clsx": "1.1.1",
         "datatables.net": "1.11.5",
         "dompurify": "^3.4.11",
+        "es-module-shims": "^2.8.2",
         "eslint-plugin-import-x": "^4.17.1",
         "fscreen": "1.2.0",
         "geist": "1.0.0",

--- a/templates/common/importmap.html.tt2
+++ b/templates/common/importmap.html.tt2
@@ -1,3 +1,4 @@
+<script async src="[% c.url_for("/js/vendor/es-module-shims.js") %]" type="text/JAVASCRIPT"></script>
 <script type="importmap">
     {
         "imports": {

--- a/tools/install.pl
+++ b/tools/install.pl
@@ -43,6 +43,7 @@ my @vendor_js = (
     '/@preact/signals/dist/signals.module.js',
     '/@preact/signals/utils/dist/utils.module.js',
     '/@preact/signals-core/dist/signals-core.module.js',
+    '/es-module-shims/dist/es-module-shims.js',
 );
 
 my @vendor_bundle = (


### PR DESCRIPTION
Add [es-module-shims](https://github.com/guybedford/es-module-shims) to provide an import map fallback for legacy browsers on end-of-life devices (e.g., iPad Air 2).