### PR TITLE
Fix backup encoding and Net::SSLeay on Windows

### DIFF
--- a/lib/LANraragi/Controller/Api/Database.pm
+++ b/lib/LANraragi/Controller/Api/Database.pm
@@ -86,7 +86,7 @@ sub download_backup {
 
     # Depending on the requested format, either serve the file directly or read its contents and return as JSON
     if ( $self->req->param('format') && $self->req->param('format') eq 'json' ) {
-        open my $fh, '<:encoding(UTF-8)', $filepath or die "Cannot read $filepath: $!";
+        open my $fh, '<', $filepath or die "Cannot read $filepath: $!";
         local $/;
         my $json = <$fh>;
         close $fh;

--- a/lib/LANraragi/Utils/Minion.pm
+++ b/lib/LANraragi/Utils/Minion.pm
@@ -572,7 +572,7 @@ sub add_tasks {
                 my $filename = "backup_" . $job->id . ".json";
                 my $filepath = "$tempdir/$filename";
 
-                open my $fh, '>:encoding(UTF-8)', $filepath
+                open my $fh, '>', $filepath
                   or die "Cannot write to $filepath: $!";
                 print $fh $json;
                 close $fh;

--- a/tools/build/windows/install.sh
+++ b/tools/build/windows/install.sh
@@ -26,6 +26,13 @@ sed -i "s/croak 'Minion workers do not support fork emulation'/#croak 'Minion wo
 perl Makefile.PL && mingw32-make install
 cd ../ && rm -rf Minion-11.0
 
+cpanm --notest --installdeps Net::SSLeay@1.96
+curl -L -s https://cpan.metacpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.96.tar.gz | tar -xz
+cd Net-SSLeay-1.96
+sed -i "s/gcc/cc/" Makefile.PL
+PERL_MM_USE_DEFAULT=1 perl Makefile.PL && mingw32-make install
+cd ../ && rm -rf Net-SSLeay-1.96
+
 cpanm --notest ETHER/Net-IDN-Encode-2.501-TRIAL.tar.gz
 
 # Install remaining modules


### PR DESCRIPTION
Fixes backup encoding when it goes through minion by not encoding the resulting file.

There were changes made upstream that makes Perl module compilation use cc/c++ instead of gcc/g++ but SSLeay hardcodes to gcc so it breaks when it tries to find the libs.