### PR TITLE
Don't let invalid container width values cause errors

### DIFF
--- a/public/js/mod/reader_options.js
+++ b/public/js/mod/reader_options.js
@@ -42,7 +42,9 @@ function SettingsPanel() {
             let value,
                 type;
 
-            [, value, type] = /^(\d+)(px|%)?$/.exec(raw);
+            const match = /^(\d+)(px|%)?$/.exec(raw);
+            if (!match) return;
+            [, value, type] = match;
             value = value || 1200;
             type = type || "px";
             state.containerWidth.value = `${value}${type}`;


### PR DESCRIPTION
Fixes `Uncaught TypeError: can't access property Symbol.iterator, /^(\d+)(px|%)?$/.exec(...) is null` if you try to enter "fartenpoopen" or something similar as container width.