### PR TITLE
OpenAPI has made pinned a number, fix comparisons

### DIFF
--- a/public/js/category.js
+++ b/public/js/category.js
@@ -101,7 +101,7 @@ Category.updateCategoryDetails = function () {
 
     document.getElementById("catname").value = category.name;
     document.getElementById("catsearch").value = category.search;
-    document.getElementById("pinned").checked = category.pinned === "1";
+    document.getElementById("pinned").checked = Number(category.pinned) === 1;
 
     if (category.search === "") {
         // Show tankoubons and archives if static and check the matching IDs

--- a/public/js/mod/index.js
+++ b/public/js/mod/index.js
@@ -1111,7 +1111,7 @@ export function loadCategories() {
 
             for (let i = 0; i < iteration; i++) {
                 const category = data[i];
-                const pinned = category.pinned === "1";
+                const pinned = Number(category.pinned) === 1;
 
                 let catName = (pinned ? "📌" : "") + category.name;
                 catName = LRR.encodeHTML(catName);


### PR DESCRIPTION
Fixed this while working on https://github.com/Difegue/LANraragi/pull/1670. Same issue as https://github.com/Difegue/LANraragi/pull/1560.

`pinned` and co. are now numbers, which means that the evaluation is always false.

```javascript
console.log(1==="1");
```
