### PR TITLE
Fix changelog visual issues

### DIFF
--- a/public/css/lrr.css
+++ b/public/css/lrr.css
@@ -817,7 +817,7 @@ body.swal2-shown>[aria-hidden="true"] {
 }
 
 #changelog img {
-  max-width: 400px;
+  max-width: min(400px, 100%);
   height: auto;
 }
 

--- a/public/css/lrr.css
+++ b/public/css/lrr.css
@@ -816,7 +816,7 @@ body.swal2-shown>[aria-hidden="true"] {
   text-align: left;
 }
 
-#changelog>*>img {
+#changelog img {
   max-width: 400px;
   height: auto;
 }


### PR DESCRIPTION
1. image is stretched vertically
2. on a phone, the image bleeds through right border

final result (on phone):

<img width="590" height="1278" alt="IMG_1095" src="https://github.com/user-attachments/assets/9df89acc-ab75-47a1-936c-01e8e4a48154" />

(the release notes taking only half the height of the phone is another pre-existing issue)