### PR TITLE
Wrap icon circle around DT page number

### DIFF
--- a/public/css/lrr.css
+++ b/public/css/lrr.css
@@ -145,8 +145,10 @@ table thead .sorting_disabled a:after {
 }
 
 .paginate_button {
+  box-sizing: border-box;
   min-width: 2rem;
   width: auto !important;
+  padding: 0 10px;
 }
 
 .ellipsis {

--- a/public/themes/modern.css
+++ b/public/themes/modern.css
@@ -343,13 +343,13 @@ td.itdc {
 
 .paginate_button:hover {
   background-color: #F5F7F7;
-  border-radius: 100%;
+  border-radius: 15px;
 }
 
 .paginate_button.current {
   font-weight: bold;
   background-color: #363940;
-  border-radius: 100%;
+  border-radius: 15px;
 }
 
 .ellipsis {

--- a/public/themes/modern_clear.css
+++ b/public/themes/modern_clear.css
@@ -408,13 +408,13 @@ td.itdc {
 
 .paginate_button:hover {
     background-color: #df696e;
-    border-radius: 100% 100% 100% 100%;
+    border-radius: 15px;
 }
 
 .paginate_button.current {
     font-weight: bold;
     background-color: #566D75;
-    border-radius: 100% 100% 100% 100%;
+    border-radius: 15px;
     color: #E1E7E9;
 }
 

--- a/public/themes/modern_red.css
+++ b/public/themes/modern_red.css
@@ -347,12 +347,12 @@ td.itdc {
 
 .paginate_button:hover {
   background-color: #BE234B;
-  border-radius: 100%;
+  border-radius: 15px;
 }
 
 .paginate_button.current {
   background-color: #E9A53A;
-  border-radius: 100%;
+  border-radius: 15px;
   font-weight: bold;
 }
 


### PR DESCRIPTION
When the DT page is long, it stretches the background circle instead of applying a bevel.

Before:

<img width="343" height="52" alt="Screenshot 2026-08-22 at 1 39 48 PM" src="https://github.com/user-attachments/assets/8205d68b-5a3b-4bb7-81a8-49bacf59068c" />

After:

<img width="330" height="50" alt="Screenshot 2026-08-23 at 11 23 40 AM" src="https://github.com/user-attachments/assets/e104bea8-4c31-4c01-a84c-b669f77a0224" />
