### PR TITLE
Bump Karen and don't install Wix

### DIFF
--- a/.github/workflows/push-continous-delivery.yml
+++ b/.github/workflows/push-continous-delivery.yml
@@ -91,7 +91,6 @@ jobs:
     - name: Build MSI Installer
       run: |
         choco uninstall wixtoolset
-        choco install wixtoolset --version 3.14.0 --allow-downgrade --force
         ./tools/build/windows/build-installer.ps1
     - name: Upload Installer
       uses: actions/upload-artifact@v7

--- a/.github/workflows/release-delivery.yml
+++ b/.github/workflows/release-delivery.yml
@@ -37,7 +37,6 @@ jobs:
     - name: Build MSI Installer
       run: |
         choco uninstall wixtoolset
-        choco install wixtoolset --version 3.14.0 --allow-downgrade --force
         ./tools/build/windows/build-installer.ps1
     - name: Upload Installer
       uses: actions/upload-artifact@v7

--- a/tools/build/windows/build-installer.ps1
+++ b/tools/build/windows/build-installer.ps1
@@ -1,5 +1,7 @@
 # --- LRR Windows build script V2 ---
 
+$ErrorActionPreference = "Stop"
+
 echo "🎌 Building up LRR Windows Package 🎌"
 echo "Inferring version from package.json..."
 


### PR DESCRIPTION
It should now use the Wix tools provided by the nuget. Also make the build script fail if something goes wrong.