### PR TITLE
add overflow wrap to caption namespace

### DIFF
--- a/public/css/lrr.css
+++ b/public/css/lrr.css
@@ -214,6 +214,7 @@ p#nb {
   font-size: 10pt;
   padding: 3px 0px 7px;
   vertical-align: top;
+  overflow-wrap: anywhere;
 }
 
 .caption-tags {


### PR DESCRIPTION
before

<img width="536" height="100" alt="Screenshot 2026-09-05 at 3 38 43 PM" src="https://github.com/user-attachments/assets/67b77b2a-477e-4471-8c25-799b2cf040be" />

after

<img width="700" height="420" alt="image" src="https://github.com/user-attachments/assets/61c128e4-a5d3-42ed-a886-24b046f5f010" />
