### PR TITLE
Update integration tests to 8f2fba6cfc5f582e776615359113d9ff37218b3d

### DIFF
--- a/.github/workflows/push-continuous-integration.yml
+++ b/.github/workflows/push-continuous-integration.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   INTEGRATION_TEST_REPOSITORY: ${{ github.event.inputs.integration_test_repository || 'psilabs-dev/aio-lanraragi' }}
-  INTEGRATION_TEST_REF: ${{ github.event.inputs.integration_test_ref || '8f0993203d32045f5f808087065b19d6cd0bef94' }}
+  INTEGRATION_TEST_REF: ${{ github.event.inputs.integration_test_ref || '8f2fba6cfc5f582e776615359113d9ff37218b3d' }}
 
 name: "Continuous Integration \U0001F44C\U0001F440"
 jobs:


### PR DESCRIPTION
- compare: https://github.com/psilabs-dev/aio-lanraragi/compare/8f0993203d32045f5f808087065b19d6cd0bef94...8f2fba6cfc5f582e776615359113d9ff37218b3d
- PRs:
    - https://github.com/psilabs-dev/aio-lanraragi/pull/210

Primarily fix some playwright test methodologies in preparation for upcoming UI changes. Does not introduce new tests, though hardens almost all existing ones in the following ways:

1. error toasts are banned
2. spinners are banned
3. any playwright test that's testing some kind of scope no longer runs API calls through that scope, it will run user actions instead (i.e. try to more faithfully conduct a true UI test)

Additionally, previous integration test cases kept adding Playwright boilerplate code, so I've moved all of that under a context manager, which incidentally also closed off browser/page closure leaks, and forgotten OK assertions.