### PR TITLE
Support Up/Down arrow keys for page navigation in the reader

### DIFF
--- a/public/js/mod/reader_common.js
+++ b/public/js/mod/reader_common.js
@@ -565,6 +565,7 @@ function handleShortcuts(e) {
             spaceScrollProcessInput(e);
             break;
         case 37: // left arrow
+        case 38: // up arrow
             if (e.shiftKey) {
                 changePage("first", true);
             } else {
@@ -572,6 +573,7 @@ function handleShortcuts(e) {
             }
             break;
         case 39: // right arrow
+        case 40: // down arrow
             if (e.shiftKey) {
                 changePage("last", true);
             } else {


### PR DESCRIPTION
Closes #1718

I read LANraragi with a wireless presenter clicker — a small handheld remote with only `Up` / `Down` arrows plus a laser / hyperlink button. These remotes send no `Left` / `Right` keys, so the reader currently ignores the clicker's buttons, forcing me to use a mouse just to flip pages — which defeats the purpose of holding a remote in the first place.

This PR aliases `Up` ≡ `Left` and `Down` ≡ `Right` in `handleShortcuts`, including the `Shift` modifier for first / last page jumps.