### PR TITLE
clear index before removing all members

### DIFF
--- a/lib/LANraragi/Model/Archive.pm
+++ b/lib/LANraragi/Model/Archive.pm
@@ -420,6 +420,8 @@ sub delete_archive ($id) {
     $redis->del($id);
     $redis->quit();
 
+    LANraragi::Utils::Database::update_indexes( $id, $oldtags, "" );
+
     # Remove matching data from the search indexes
     my $redis_search = LANraragi::Model::Config->get_redis_search;
     $redis_search->zrem( "LRR_TITLES", "$oldtitle\0$id" );
@@ -427,8 +429,6 @@ sub delete_archive ($id) {
     $redis_search->srem( "LRR_UNTAGGED",    $id );
     $redis_search->srem( "LRR_TANKGROUPED", $id );
     $redis_search->quit();
-
-    LANraragi::Utils::Database::update_indexes( $id, $oldtags, "" );
 
     if ( -e $filename ) {
         my $status = unlink_path($filename);


### PR DESCRIPTION
Pass integration test https://github.com/psilabs-dev/aio-lanraragi/blob/756d6af4d364c6e758063d8a20fdd0d37f1e665f/integration_tests/tests/simple/test_with_archives.py#L172, ie. deleting archives doesn't remove them from the index. Reason as attached in commit message.